### PR TITLE
Fixed issue of absolute path. 

### DIFF
--- a/mne_rt_server/connectors/FiffSimulator/fiffsimulator.cpp
+++ b/mne_rt_server/connectors/FiffSimulator/fiffsimulator.cpp
@@ -41,6 +41,7 @@
 
 #include "fiffsimulator.h"
 #include "fiffproducer.h"
+#include <stdlib.h>
 
 
 //*************************************************************************************************************
@@ -88,7 +89,7 @@ using namespace MNELIB;
 
 FiffSimulator::FiffSimulator()
 : m_pFiffProducer(new FiffProducer(this))
-, m_sResourceDataPath("../../mne-cpp/bin/MNE-sample-data/MEG/sample/sample_audvis_raw.fif")
+, m_sResourceDataPath(QString("%1/bin/MNE-sample-data/MEG/sample/sample_audvis_raw.fif").arg(getenv("MNE_CPP")))
 , m_bIsRunning(false)
 , m_uiBufferSampleSize(1000)
 , m_pRawMatrixBuffer(NULL)


### PR DESCRIPTION
Now the simulation can be done from anywhere without being necessarily in the mne-cpp/bin directory. Only thing is that MNE_CPP environment variable must be set. Not totally sure if this works in Windows too. 
