### PR TITLE
ENH: plugin activate / deactivate

### DIFF
--- a/applications/mne_x/mne_x/src/FormFiles/mainwindow.cpp
+++ b/applications/mne_x/mne_x/src/FormFiles/mainwindow.cpp
@@ -567,6 +567,12 @@ void MainWindow::CentralWidgetShowPlugin()//int iCurrentPluginNum, const QTreeWi
                 setCentralWidget(m_pRunWidget);
         }
     }
+    else
+    {
+        if(m_pRunWidget)
+            delete m_pRunWidget;
+        m_pRunWidget = NULL;
+    }
 
     Subject::notifyEnabled = true; //like Mutex.unlock
 }
@@ -617,7 +623,7 @@ void MainWindow::startMeasurement()
         return;
     }
 
-
+    m_pPluginDockWidget->setTogglingEnabled(false);
     uiSetupRunningState(true);
     startTimer(m_iTimeoutMSec);
     CentralWidgetShowPlugin();
@@ -639,6 +645,7 @@ void MainWindow::stopMeasurement()
 
     qDebug() << "set stopped UI";
 
+    m_pPluginDockWidget->setTogglingEnabled(true);
     uiSetupRunningState(false);
     stopTimer();
     CentralWidgetShowPlugin();

--- a/applications/mne_x/mne_x/src/FormFiles/plugindockwidget.h
+++ b/applications/mne_x/mne_x/src/FormFiles/plugindockwidget.h
@@ -151,7 +151,15 @@ public:
     * @param [in] n index of plugin which's status should be changed.
     * @param [in] status to which plugin should be changed.
     */
-    void activateItem(int n, bool& status);
+    void activateItem(int n, bool status);
+
+     //=========================================================================================================
+    /**
+    * Set whether setting plugins active/inactive (toggling) is allowed.
+    *
+    * @param [in] if true toggling is enabled.
+    */
+    void setTogglingEnabled(bool enabled);
 
 signals:
     //=========================================================================================================
@@ -194,6 +202,14 @@ private slots:
     * @param [in] selectedItem whether program is running.
     */
     void itemSelected(QTreeWidgetItem* selectedItem);    /**< creates all actions for user interface of MainWindow class. */
+
+     //=========================================================================================================
+    /**
+    * Handles activating/deactivating of a plugin.
+    *
+    * @param [in] item which was toggled.
+    */
+    void itemToggled(QTreeWidgetItem* item);
 };
 
 

--- a/applications/mne_x_libs/mne_x/Management/pluginmanager.cpp
+++ b/applications/mne_x_libs/mne_x/Management/pluginmanager.cpp
@@ -111,6 +111,9 @@ void PluginManager::loadPlugins(const QString& dir)
         {
             qDebug() << "try to load Plugin " << fileName;
 
+            // plugins are always disabled when they are first loaded
+            qobject_cast<IPlugin*>(pPlugin)->setStatus(false);
+
             s_vecPlugins.push_back(qobject_cast<IPlugin*>(pPlugin));
 
             Type module_type = qobject_cast<IPlugin*>(pPlugin)->getType();


### PR DESCRIPTION
Some enhancements and fixes:
- Use a checkbox to enable/disable plugins. The method using right-click was not intuitive to me.
- Plugins are now always disabled when they are first loaded
- Update GUI immediately when enabling/disabling a plugin
- Fix a segfault that occurred when selecting inactive and active plugins while the measurement is running
- Prevent user from enabling/disabling plugins during the measurement
