### PR TITLE
ENH: Acceleration for sim

### DIFF
--- a/applications/mne_rt_server/connectors/FiffSimulator/fiffproducer.cpp
+++ b/applications/mne_rt_server/connectors/FiffSimulator/fiffproducer.cpp
@@ -193,6 +193,7 @@ void FiffProducer::run()
             first += quantum;
         }
 
+        // call blocks until there is free space in the buffer
         m_pFiffSimulator->m_pRawMatrixBuffer->push(&tmp);
     }
 

--- a/applications/mne_rt_server/connectors/FiffSimulator/fiffsimulator.h
+++ b/applications/mne_rt_server/connectors/FiffSimulator/fiffsimulator.h
@@ -154,6 +154,22 @@ private:
 
     //=========================================================================================================
     /**
+    * Sets the acceleration factor
+    *
+    * @param[in] p_command  The acceleration factor command.
+    */
+    void comAccel(Command p_command);
+
+    //=========================================================================================================
+    /**
+    * Returns the acceleration factor
+    *
+    * @param[in] p_command  The acceleration factor command.
+    */
+    void comGetAccel(Command p_command);
+
+    //=========================================================================================================
+    /**
     * Sets the fiff simulation file
     *
     * @param[in] p_command  The fiff simulation file command.
@@ -176,6 +192,8 @@ private:
     FiffRawData     m_RawInfo;              /**< Holds the fiff raw measurement information. */
     QString         m_sResourceDataPath;    /**< Holds the path to the Fiff resource simulation file directory.*/
     quint32         m_uiBufferSampleSize;   /**< Sample size of the buffer */
+    float           m_AccelerationFactor;   /**< Acceleration factor to simulate different sampling rates. */
+    float           m_TrueSamplingRate;     /**< The true sampling rate of the fif file. */
 
     RawMatrixBuffer* m_pRawMatrixBuffer;    /**< The Circular Raw Matrix Buffer. */
 

--- a/applications/mne_rt_server/connectors/FiffSimulator/fiffsimulator.json
+++ b/applications/mne_rt_server/connectors/FiffSimulator/fiffsimulator.json
@@ -16,6 +16,20 @@
             "description": "Returns the current buffer size of the FiffStreamClient raw data buffer.",
             "parameters": {}
         },
+        "accel": {
+            "description": "Sets the acceleration factor to simulate different sampling rates.",
+            "parameters": {
+                "factor": {
+                    "description": "acceleration factor",
+                    "type": "float"
+                }
+            }
+        },
+        "getaccel": {
+            "description": "Returns the acceleration factor.",
+            "parameters": {}
+        },
+
         "simfile": {
             "description": "The fiff file which should be used as simulation file.",
             "parameters": {


### PR DESCRIPTION
Allows simulating higher (or lower) sampling rates using an acceleration factor. Note that it simply reads the fif file faster and doesn't do any sampling rate conversion. This is mostly useful for testing the network throughput and processing in MNE-X.

Also, there is currently no way to set the acceleration in MNE-X. We need to figure out a way to have a RT-server plugin specific configuration dialog (will also be needed for BabyMEG2 etc.).
