### PR TITLE
Add the normal (non-log) x-scale display for spectrum.

### DIFF
--- a/applications/mne_x/plugins/noise/FormFiles/noiseestimatesetup.ui
+++ b/applications/mne_x/plugins/noise/FormFiles/noiseestimatesetup.ui
@@ -95,6 +95,29 @@
           <item row="0" column="1">
            <widget class="QSpinBox" name="m_qSpinDataLen"/>
           </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="m_cb_logscale">
+            <property name="text">
+             <string>Log scale</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
          </layout>
         </item>
         <item row="0" column="1">

--- a/applications/mne_x/plugins/noise/FormFiles/noiseestimatesetupwidget.cpp
+++ b/applications/mne_x/plugins/noise/FormFiles/noiseestimatesetupwidget.cpp
@@ -73,6 +73,8 @@ NoiseEstimateSetupWidget::NoiseEstimateSetupWidget(NoiseEstimate* toolbox, QWidg
 
     connect(ui.m_qComboBoxnFFT, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &NoiseEstimateSetupWidget::chgnFFT);
     connect(ui.m_qSpinDataLen, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &NoiseEstimateSetupWidget::chgDataLen);
+    connect(ui.m_cb_logscale, static_cast<void (QCheckBox::*)(bool)>(&QCheckBox::clicked), this, &NoiseEstimateSetupWidget::chgXAxisType);
+
 }
 
 
@@ -105,6 +107,13 @@ void NoiseEstimateSetupWidget::init()
 
     //set up the data length for spectrum calculation
     ui.m_qSpinDataLen->setValue(6);
+
+    //set up the default x-scale type of spectrum
+    if ( m_pNoiseEstimate->m_x_scale_type == 0)
+        ui.m_cb_logscale->setChecked(false);
+    else
+        ui.m_cb_logscale->setChecked(true);
+
 }
 
 
@@ -112,13 +121,30 @@ void NoiseEstimateSetupWidget::init()
 
 void NoiseEstimateSetupWidget::chgnFFT(int idx)
 {
-//    qDebug() << "ui.m_qComboBoxnFFT->itemData(idx).toInt();" << ui.m_qComboBoxnFFT->itemText(idx).toInt();
+    //qDebug() << "ui.m_qComboBoxnFFT->itemData(idx).toInt();" << ui.m_qComboBoxnFFT->itemText(idx).toInt();
     m_pNoiseEstimate->m_iFFTlength = ui.m_qComboBoxnFFT->itemText(idx).toInt();
 }
 
+//*************************************************************************************************************
+
 void NoiseEstimateSetupWidget::chgDataLen(int idx)
 {
-//    qDebug() << "ui.m_qComboBoxnFFT->itemData(idx).toInt();" << ui.m_qComboBoxnFFT->itemText(idx).toInt();
     m_pNoiseEstimate->m_DataLen = idx;
+    //qDebug() << "m_pNoiseEstimate->m_DataLen" <<m_pNoiseEstimate->m_DataLen;
+}
+
+//*************************************************************************************************************
+
+void NoiseEstimateSetupWidget::chgXAxisType()
+{
+
+    //qDebug()<<"Check state1";
+    bool checkstatus = ui.m_cb_logscale->isChecked();
+    if ( checkstatus)
+        m_pNoiseEstimate->m_x_scale_type = 1;
+    else
+        m_pNoiseEstimate->m_x_scale_type = 0;
+
+    qDebug() << "setup widget scale type" << m_pNoiseEstimate->m_x_scale_type ;
 }
 

--- a/applications/mne_x/plugins/noise/FormFiles/noiseestimatesetupwidget.h
+++ b/applications/mne_x/plugins/noise/FormFiles/noiseestimatesetupwidget.h
@@ -115,6 +115,7 @@ public:
     void init();
     void chgnFFT(int idx);
     void chgDataLen(int idx);
+    void chgXAxisType();
 
 private slots:
 

--- a/applications/mne_x/plugins/noise/noiseestimate.h
+++ b/applications/mne_x/plugins/noise/noiseestimate.h
@@ -202,9 +202,10 @@ private:
     bool m_bIsRunning;      /**< If source lab is running */
     bool m_bProcessData;    /**< If data should be received for processing */
 
-    double m_Fs;         /** < sample rate */
-    qint32 m_iFFTlength; /**< number of bins for FFT */
-    float m_DataLen;   /**< the length of data used for spectrum calculation */
+    double m_Fs;            /**< sample rate */
+    qint32 m_iFFTlength;    /**< number of bins for FFT */
+    float m_DataLen;        /**< the length of data used for spectrum calculation */
+    qint8 m_x_scale_type;   /**< Type of x-axis scale: normal (0) or log (1) */
 
     QMutex mutex;       /**< mutex for spectrum */
 

--- a/applications/mne_x_libs/xDisp/frequencyspectrumwidget.cpp
+++ b/applications/mne_x_libs/xDisp/frequencyspectrumwidget.cpp
@@ -214,11 +214,14 @@ void FrequencySpectrumWidget::init()
         m_pFSModel = new FrequencySpectrumModel(this);
 
         m_pFSModel->setInfo(m_pFS->getFiffInfo());
+        m_pFSModel->setScaleType(m_pFS->getScaleType()); /*Added by Limin; 10/19/2014 for passing the scale type to the model*/
 
         if(m_pFSDelegate)
             delete m_pFSDelegate;
 //        m_pFSDelegate = new FrequencySpectrumDelegate(this);
         m_pFSDelegate = new FrequencySpectrumDelegate(m_pTableView,this);
+        m_pFSDelegate->setScaleType(m_pFS->getScaleType()); /*Added by Limin; 10/19/2014 for passing the scale type to the delegate*/
+
 
         connect(m_pTableView, &QTableView::doubleClicked, m_pFSModel, &FrequencySpectrumModel::toggleFreeze);
 

--- a/applications/mne_x_libs/xDisp/helpers/frequencyspectrumdelegate.h
+++ b/applications/mne_x_libs/xDisp/helpers/frequencyspectrumdelegate.h
@@ -89,6 +89,14 @@ public:
 
     //=========================================================================================================
     /**
+    * Set scale type.
+    *
+    * @param [in] ScaleType.
+    */
+    void setScaleType(qint8 ScaleType);
+
+    //=========================================================================================================
+    /**
     * Use the painter and style option to render the item specified by the item index.
     *
     * (sizeHint() must be implemented also)
@@ -156,13 +164,6 @@ private:
     */
     void createGridTick(const QModelIndex &index, const QStyleOptionViewItem &option,  QPainter *painter) const;
 
-    //=========================================================================================================
-    /**
-    * Is called when mouse is moved.
-    * Function is getting the current mouse position for measurement of the real-time curve and to zoom in or out.
-    *
-    * @param [in] mouseEvent pointer to MouseEvent.
-    */
 
     // Scaling
     float m_fMaxValue;     /**< Maximum value of the data to plot  */
@@ -176,6 +177,9 @@ private:
     int m_mousey;            /**< the mouse y pos */
     QRect m_visRect;         /**< visual rect of row of tableview */
     float m_x_rate;          /**< the rate of the cursor position in the raw visual rect */
+
+
+    qint8 m_iScaleType;      /**< scale type */
 
 
 

--- a/applications/mne_x_libs/xDisp/helpers/frequencyspectrummodel.cpp
+++ b/applications/mne_x_libs/xDisp/helpers/frequencyspectrummodel.cpp
@@ -2,13 +2,14 @@
 /**
 * @file     frequencyspectrummodel.cpp
 * @author   Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+*           Limin Sun <liminsun@nmr.mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     May, 2014
 *
 * @section  LICENSE
 *
-* Copyright (C) 2014, Christoph Dinh and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2014, Christoph Dinh, Limin Sun and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -61,6 +62,7 @@ FrequencySpectrumModel::FrequencySpectrumModel(QObject *parent)
 , m_bInitialized(false)
 , m_iLowerFrqIdx(0)
 , m_iUpperFrqIdx(0)
+, m_iScaleType(0)
 {
 }
 
@@ -191,6 +193,12 @@ void FrequencySpectrumModel::setInfo(FiffInfo::SPtr &info)
 }
 
 
+//*************************************************************************************************************
+
+void FrequencySpectrumModel::setScaleType(qint8 ScaleType)
+{
+    m_iScaleType = ScaleType;
+}
 
 //*************************************************************************************************************
 
@@ -207,7 +215,11 @@ void FrequencySpectrumModel::addData(const MatrixXd &data)
         double currFreq = 0;
         for(qint32 i = 0; i < m_dataCurrent.cols(); ++i)
         {
-            m_vecFreqScale[i] = log10(currFreq+k);
+            if (m_iScaleType) //log
+                m_vecFreqScale[i] = log10(currFreq+k);
+            else // normal
+                m_vecFreqScale[i] = currFreq;
+
             currFreq += freqRes;
         }
 

--- a/applications/mne_x_libs/xDisp/helpers/frequencyspectrummodel.h
+++ b/applications/mne_x_libs/xDisp/helpers/frequencyspectrummodel.h
@@ -152,6 +152,14 @@ public:
 
     //=========================================================================================================
     /**
+    * Sets Scale type
+    *
+    * @param [in] ScaleType       The corresponding scale type
+    */
+    void setScaleType(qint8 ScaleType);
+
+    //=========================================================================================================
+    /**
     * Adds the frequency estimation
     *
     * @param[in] data   the frequency estimation
@@ -285,6 +293,8 @@ private:
 
     qint32 m_iLowerFrqIdx;  /**< Upper frequency plotting boundary */
     qint32 m_iUpperFrqIdx;  /**< Lower frequency plotting boundary */
+
+    qint8 m_iScaleType;
 
 };
 

--- a/applications/mne_x_libs/xMeas/frequencyspectrum.cpp
+++ b/applications/mne_x_libs/xMeas/frequencyspectrum.cpp
@@ -2,13 +2,14 @@
 /**
 * @file     frequencyspectrum.cpp
 * @author   Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+*           Limin Sun <liminsun@nmr.mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     July, 2014
 *
 * @section  LICENSE
 *
-* Copyright (C) 2014, Christoph Dinh and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2014, Christoph Dinh, Limin Sun and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -85,6 +86,14 @@ void FrequencySpectrum::initFromFiffInfo(FiffInfo::SPtr &p_pFiffInfo)
     m_pFiffInfo = p_pFiffInfo;
 
     m_bIsInit = true;
+}
+
+//*************************************************************************************************************
+
+void FrequencySpectrum::initScaleType(qint8 ScaleType)
+{
+    m_xScaleType = ScaleType;
+
 }
 
 

--- a/applications/mne_x_libs/xMeas/frequencyspectrum.h
+++ b/applications/mne_x_libs/xMeas/frequencyspectrum.h
@@ -2,13 +2,14 @@
 /**
 * @file     frequencyspectrum.h
 * @author   Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+*           Limin Sun <liminsun@nmr.mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     February, 2013
 *
 * @section  LICENSE
 *
-* Copyright (C) 2013, Christoph Dinh and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2013, Christoph Dinh, Limin Sun and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -112,6 +113,14 @@ public:
 
     //=========================================================================================================
     /**
+    * Init Scale Type
+    *
+    * @param[in] ScaleType     Scale type to init from
+    */
+    void initScaleType(qint8 ScaleType);
+
+    //=========================================================================================================
+    /**
     * Returns whether channel info is initialized
     *
     * @return true whether the channel info is available.
@@ -125,6 +134,14 @@ public:
     * @return the reference to the orig FiffInfo.
     */
     inline FiffInfo::SPtr& getFiffInfo();
+
+    //=========================================================================================================
+    /**
+    * Returns the scale type.
+    *
+    * @return the scale type.
+    */
+    inline qint8 getScaleType();
 
     //=========================================================================================================
     /**
@@ -158,6 +175,10 @@ private:
 
     bool m_bIsInit;             /**< If channel info is initialized.*/
     bool m_bContainsValues;     /**< If values are stored.*/
+
+    /* Begin : Added by Limin, 10/19/14  for passing scaletype parameter from noisee stimate to spectrum model*/
+    qint8 m_xScaleType;         /**< The scale type of x axis: 0-normal; 1-log.  */
+    /* End */
 };
 
 
@@ -180,6 +201,12 @@ inline FiffInfo::SPtr& FrequencySpectrum::getFiffInfo()
     return m_pFiffInfo;
 }
 
+//*************************************************************************************************************
+
+inline qint8 FrequencySpectrum::getScaleType()
+{
+    return m_xScaleType;
+}
 
 //*************************************************************************************************************
 


### PR DESCRIPTION
With this new function, we can have two the spectrum display mode: normal-scale (0) and log-scale (1).
Default display mode is normal.

Christoph, I found our current version (put fiff simulator plugin and noise estimator plugin) is not stable. Maybe we should debug them together when you have time.  
