### PR TITLE
Uncommented important error message

### DIFF
--- a/MNE/generics/circularmatrixbuffer.h
+++ b/MNE/generics/circularmatrixbuffer.h
@@ -251,8 +251,10 @@ inline void CircularMatrixBuffer<_Tp>::push(const Matrix<_Tp, Dynamic, Dynamic>*
                 m_pBuffer[mapIndex(m_iCurrentWriteIndex)] = pMatrix->data()[i];
             m_pUsedElements->release(t_size);
         }
-    //    else
-    //        printf("Error: Matrix not appended to CircularMatrixBuffer - wrong dimensions\n");
+
+        else {
+            printf("Error: Matrix not appended to CircularMatrixBuffer - wrong dimensions\n");
+        }
     }
 }
 


### PR DESCRIPTION
I noticed this extremely helpful error was commented out. Without this print statement, `push` fails silently, and it can take a long time for a developer new to the mne-cpp ecosystem to dig down far enough to find the problem.

Is there a reason it was commented out in the first place?