### PR TITLE
Added Fedora library extensions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,8 @@
 
 # Compiled Dynamic libraries
 *.so
+*.so.debug
+*.debug
 
 # Compiled Static libraries
 *.lai


### PR DESCRIPTION
Compiling in Fedora produces `.debug` and `.so.debug` files in the /bin directory. This commit adds such files to .gitignore so that they are not tracked.