### PR TITLE
Changed = to == inside if statement

### DIFF
--- a/applications/mne_scan/plugins/epidetect/epidetect.cpp
+++ b/applications/mne_scan/plugins/epidetect/epidetect.cpp
@@ -344,7 +344,7 @@ void Epidetect::run()
         VectorXd newP2PVal = calculator.getP2P();
         VectorXd newKurtosisVal = calculator.getKurtosis();
 
-        if (counter = m_iFuzzyEnStep*m_iListLength-1)
+        if (counter == m_iFuzzyEnStep*m_iListLength-1)
         {
             FuzzyEnHistoryValues.col(0) = fuzzyEnHistory.rowwise().minCoeff();
             FuzzyEnHistoryValues.col(1) = fuzzyEnHistory.rowwise().mean();


### PR DESCRIPTION
There is an `if` statement in `epidetect.cpp` on line 347 that appears to be missing an `=`. I believe it is meant to be checking the value of `counter`, but instead it is overwriting it.