### PR TITLE
Added missing library includes that prevented proper linking

### DIFF
--- a/applications/mne_analyze/mne_analyze/mne_analyze.pro
+++ b/applications/mne_analyze/mne_analyze/mne_analyze.pro
@@ -65,14 +65,14 @@ CONFIG(debug, debug|release) {
             -lMNE$${MNE_LIB_VERSION}Fsd \
             -lMNE$${MNE_LIB_VERSION}Fiffd \
             -lMNE$${MNE_LIB_VERSION}Mned \
+            -lMNE$${MNE_LIB_VERSION}GeometryInfod \
+            -lMNE$${MNE_LIB_VERSION}Interpolationd \
             -lMNE$${MNE_LIB_VERSION}Fwdd \
             -lMNE$${MNE_LIB_VERSION}Inversed \
             -lMNE$${MNE_LIB_VERSION}Connectivityd \
             -lMNE$${MNE_LIB_VERSION}Dispd \
             -lMNE$${MNE_LIB_VERSION}DispChartsd \
             -lMNE$${MNE_LIB_VERSION}Disp3Dd \
-            -lMNE$${MNE_LIB_VERSION}GeometryInfod \
-            -lMNE$${MNE_LIB_VERSION}Interpolationd \
             -lanSharedd
 }
 else {
@@ -81,14 +81,14 @@ else {
             -lMNE$${MNE_LIB_VERSION}Fs \
             -lMNE$${MNE_LIB_VERSION}Fiff \
             -lMNE$${MNE_LIB_VERSION}Mne \
+            -lMNE$${MNE_LIB_VERSION}GeometryInfo \
+            -lMNE$${MNE_LIB_VERSION}Interpolation \
             -lMNE$${MNE_LIB_VERSION}Fwd \
             -lMNE$${MNE_LIB_VERSION}Inverse \
             -lMNE$${MNE_LIB_VERSION}Connectivity \
             -lMNE$${MNE_LIB_VERSION}Disp \
             -lMNE$${MNE_LIB_VERSION}DispCharts \
             -lMNE$${MNE_LIB_VERSION}Disp3D \
-            -lMNE$${MNE_LIB_VERSION}GeometryInfo \
-            -lMNE$${MNE_LIB_VERSION}Interpolation \
             -lanShared
 }
 

--- a/applications/mne_analyze/mne_analyze/mne_analyze.pro
+++ b/applications/mne_analyze/mne_analyze/mne_analyze.pro
@@ -71,6 +71,8 @@ CONFIG(debug, debug|release) {
             -lMNE$${MNE_LIB_VERSION}Dispd \
             -lMNE$${MNE_LIB_VERSION}DispChartsd \
             -lMNE$${MNE_LIB_VERSION}Disp3Dd \
+            -lMNE$${MNE_LIB_VERSION}GeometryInfod \
+            -lMNE$${MNE_LIB_VERSION}Interpolationd \
             -lanSharedd
 }
 else {
@@ -85,6 +87,8 @@ else {
             -lMNE$${MNE_LIB_VERSION}Disp \
             -lMNE$${MNE_LIB_VERSION}DispCharts \
             -lMNE$${MNE_LIB_VERSION}Disp3D \
+            -lMNE$${MNE_LIB_VERSION}GeometryInfo \
+            -lMNE$${MNE_LIB_VERSION}Interpolation \
             -lanShared
 }
 

--- a/examples/ex_histogram/ex_histogram.pro
+++ b/examples/ex_histogram/ex_histogram.pro
@@ -58,6 +58,8 @@ CONFIG(debug, debug|release) {
             -lMNE$${MNE_LIB_VERSION}Fsd \
             -lMNE$${MNE_LIB_VERSION}Fiffd \
             -lMNE$${MNE_LIB_VERSION}Mned \
+            -lMNE$${MNE_LIB_VERSION}GeometryInfod \
+            -lMNE$${MNE_LIB_VERSION}Interpolationd \
             -lMNE$${MNE_LIB_VERSION}Fwdd \
             -lMNE$${MNE_LIB_VERSION}Inversed \
             -lMNE$${MNE_LIB_VERSION}Connectivityd \
@@ -71,6 +73,8 @@ else {
             -lMNE$${MNE_LIB_VERSION}Fs \
             -lMNE$${MNE_LIB_VERSION}Fiff \
             -lMNE$${MNE_LIB_VERSION}Mne \
+            -lMNE$${MNE_LIB_VERSION}GeometryInfo \
+            -lMNE$${MNE_LIB_VERSION}Interpolation \
             -lMNE$${MNE_LIB_VERSION}Fwd \
             -lMNE$${MNE_LIB_VERSION}Inverse \
             -lMNE$${MNE_LIB_VERSION}Connectivity \


### PR DESCRIPTION
MNE Analyze and the histogram example were missing linker directives for the GeometryInfo and Interpolation libraries. Even without these, they still compile with the MSVC compiler under windows, the clang compiler under mac, and recent versions of gcc under ubuntu. However,  they need to be added for older versions of gcc distributed in RHEL derivatives like centOS.