### PR TITLE
Update .gitignore to ignore new test binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,10 @@
 /bin/test_fiff_rwrd
 /bin/test_forward_solution
 /bin/test_forward_solutiond
+/bin/test_fiff_digitizer
+/bin/test_geometryinfo
+/bin/test_interpolation
+/bin/test_mne_msh_display_surface_set
 
 # Other files
 /bin/MNE-sample-data/MEG


### PR DESCRIPTION
The .gitignore file was missing entries for some of the newer test binaries. This pull requests adds them.