### PR TITLE
[WIP] Don't display console on releaes builds

### DIFF
--- a/applications/mne_scan/mne_scan/mne_scan.pro
+++ b/applications/mne_scan/mne_scan/mne_scan.pro
@@ -47,9 +47,8 @@ TARGET = mne_scan
 
 CONFIG(debug, debug|release) {
     TARGET = $$join(TARGET,,,d)
+    CONFIG += console
 }
-
-CONFIG += console #DEBUG
 
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {


### PR DESCRIPTION
The console is extremely helpful for debugging during development, but we've decided to hide it on release builds of MNE Scan. If you find this change helpful, you're welcome to adopt it into the official repository. If not, you can just close this pull request.