### PR TITLE
[LIB-138] Fix transparency in Disp3D & [LIB-189] make frame graph work with OpenGL < 3.3

### DIFF
--- a/libraries/disp3D/engine/model/3dhelpers/geometrymultiplier.cpp
+++ b/libraries/disp3D/engine/model/3dhelpers/geometrymultiplier.cpp
@@ -117,7 +117,16 @@ void GeometryMultiplier::setTransforms(const QVector<QMatrix4x4> &tInstanceTansf
         return;
     }
 
-    m_pTransformBuffer->setData(buildTransformBuffer(tInstanceTansform));
+    //Update buffer content
+    const QByteArray &transformBufferData = buildTransformBuffer(tInstanceTansform);
+    if(transformBufferData.size() != m_pTransformBuffer->data().size())
+    {
+        m_pTransformBuffer->setData(transformBufferData);
+    }
+    else
+    {
+        m_pTransformBuffer->updateData(0, transformBufferData);
+    }
     m_pTransformAttribute->setBuffer(m_pTransformBuffer);
 
     updateInstanceCount(tInstanceTansform.size());
@@ -134,8 +143,26 @@ void GeometryMultiplier::setColors(const QVector<QColor> &tInstanceColors)
         return;
     }
 
-    m_pColorBuffer->setData(buildColorBuffer(tInstanceColors));
-    m_pColorAttribute->setBuffer(m_pColorBuffer);
+    //Update buffer content
+    const QByteArray &colorBufferData = buildColorBuffer(tInstanceColors);
+    if(colorBufferData.size() != m_pColorBuffer->data().size())
+    {
+        m_pColorBuffer->setData(colorBufferData);
+    }
+    else
+    {
+        m_pColorBuffer->updateData(0, colorBufferData);
+    }
+
+    if(tInstanceColors.size() > 1)
+    {
+        m_pColorAttribute->setDivisor(1);
+    }
+    else
+    {
+        //enable 1 color for x transforms
+        m_pColorAttribute->setDivisor(0);
+    }
 
     updateInstanceCount(tInstanceColors.size());
 }
@@ -152,14 +179,16 @@ void GeometryMultiplier::init()
     m_pTransformAttribute->setVertexSize(16);
     m_pTransformAttribute->setDivisor(1);
     m_pTransformAttribute->setByteOffset(0);
-
+    m_pTransformAttribute->setBuffer(m_pTransformBuffer);
     //Set color attribute parameters
     m_pColorAttribute->setName(QStringLiteral("instanceColor"));
     m_pColorAttribute->setAttributeType(QAttribute::VertexAttribute);
     m_pColorAttribute->setVertexBaseType(QAttribute::Float);
     m_pColorAttribute->setVertexSize(3);
-    m_pColorAttribute->setDivisor(1);
+    //Set divisor 0 to enable empty color buffer
+    m_pColorAttribute->setDivisor(0);
     m_pColorAttribute->setByteOffset(0);
+    m_pColorAttribute->setBuffer(m_pColorBuffer);
 
     //Set default instance color
     QVector<QColor> tempColors;

--- a/libraries/disp3D/engine/model/items/common/abstractmeshtreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/common/abstractmeshtreeitem.cpp
@@ -77,7 +77,7 @@ using namespace Eigen;
 AbstractMeshTreeItem::AbstractMeshTreeItem(QEntity* p3DEntityParent, int iType, const QString& text)
 : Abstract3DTreeItem(p3DEntityParent, iType, text)
 , m_pMaterial(new PerVertexPhongAlphaMaterial)
-, m_pTessMaterial(new PerVertexTessPhongAlphaMaterial(true))
+, m_pTessMaterial(new PerVertexTessPhongAlphaMaterial)
 , m_pNormalMaterial(new ShowNormalsMaterial())
 , m_pCustomMesh(new CustomMesh())
 {

--- a/libraries/disp3D/engine/model/items/common/abstractmeshtreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/common/abstractmeshtreeitem.cpp
@@ -76,7 +76,7 @@ using namespace Eigen;
 
 AbstractMeshTreeItem::AbstractMeshTreeItem(QEntity* p3DEntityParent, int iType, const QString& text)
 : Abstract3DTreeItem(p3DEntityParent, iType, text)
-, m_pMaterial(new PerVertexPhongAlphaMaterial(true))
+, m_pMaterial(new PerVertexPhongAlphaMaterial)
 , m_pTessMaterial(new PerVertexTessPhongAlphaMaterial(true))
 , m_pNormalMaterial(new ShowNormalsMaterial())
 , m_pCustomMesh(new CustomMesh())

--- a/libraries/disp3D/engine/model/items/digitizer/digitizertreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/digitizer/digitizertreeitem.cpp
@@ -116,7 +116,7 @@ void DigitizerTreeItem::addData(const QList<FIFFLIB::FiffDigPoint>& tDigitizer, 
         pSourceSphereEntity->addComponent(pTransform);
 
         //Add material
-        GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial(true);
+        GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial;
         pMaterial->setAmbient(tSphereColor);
         pSourceSphereEntity->addComponent(pMaterial);
     }

--- a/libraries/disp3D/engine/model/items/freesurfer/fssurfacetreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/freesurfer/fssurfacetreeitem.cpp
@@ -92,6 +92,11 @@ void FsSurfaceTreeItem::initItem()
 {
     this->setToolTip("Brain hemisphere surface item");
 
+    //Use SortPolicy in frame graph
+    this->removeComponent(m_pMaterial);
+    m_pMaterial = new PerVertexPhongAlphaMaterial(true, true);
+    this->addComponent(m_pMaterial);
+
     //Add surface meta information as item children
     QList<QStandardItem*> list;
     QVariant data;

--- a/libraries/disp3D/engine/model/items/freesurfer/fssurfacetreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/freesurfer/fssurfacetreeitem.cpp
@@ -94,7 +94,7 @@ void FsSurfaceTreeItem::initItem()
 
     //Use SortPolicy in frame graph
     this->removeComponent(m_pMaterial);
-    m_pMaterial = new PerVertexPhongAlphaMaterial(true, true);
+    m_pMaterial = new PerVertexPhongAlphaMaterial(true);
     this->addComponent(m_pMaterial);
 
     //Add surface meta information as item children

--- a/libraries/disp3D/engine/model/items/network/networktreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/network/networktreeitem.cpp
@@ -225,7 +225,7 @@ void NetworkTreeItem::plotNetwork(const Network& tNetworkData, const QVector3D& 
         pSourceSphereEntity->addComponent(pSphereMesh);
 
         //Add material
-        GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial(true);
+        GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial;
         pMaterial->setAmbient(Qt::blue);
         pMaterial->setAlpha(1.0f);
         pSourceSphereEntity->addComponent(pMaterial);

--- a/libraries/disp3D/engine/model/items/sensordata/gpuinterpolationitem.cpp
+++ b/libraries/disp3D/engine/model/items/sensordata/gpuinterpolationitem.cpp
@@ -87,7 +87,7 @@ using namespace Qt3DCore;
 GpuInterpolationItem::GpuInterpolationItem(Qt3DCore::QEntity *p3DEntityParent, int iType, const QString &text)
     : Abstract3DTreeItem(p3DEntityParent, iType, text)
     , m_bIsDataInit(false)
-    , m_pMaterial(new GpuInterpolationMaterial(true))
+    , m_pMaterial(new GpuInterpolationMaterial)
 {
     initItem();
 }

--- a/libraries/disp3D/engine/model/items/sensorspace/sensorpositiontreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/sensorspace/sensorpositiontreeitem.cpp
@@ -181,7 +181,7 @@ void SensorPositionTreeItem::plotSensors(const QList<FIFFLIB::FiffChInfo>& lChIn
     pSensorEntity->addComponent(pMesh);
 
     //Add material
-    GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial(true);
+    GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial;
 
     QColor colDefault(100,100,100);
     pMaterial->setAmbient(colDefault);

--- a/libraries/disp3D/engine/model/items/sensorspace/sensorsurfacetreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/sensorspace/sensorsurfacetreeitem.cpp
@@ -95,7 +95,7 @@ void SensorSurfaceTreeItem::initItem()
     this->removeComponent(m_pTessMaterial);
     this->removeComponent(m_pNormalMaterial);
 
-    PerVertexPhongAlphaMaterial* pBemMaterial = new PerVertexPhongAlphaMaterial(true);
+    PerVertexPhongAlphaMaterial* pBemMaterial = new PerVertexPhongAlphaMaterial();
     this->addComponent(pBemMaterial);
 }
 

--- a/libraries/disp3D/engine/model/items/sourceactivity/ecddatatreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/sourceactivity/ecddatatreeitem.cpp
@@ -188,7 +188,7 @@ void EcdDataTreeItem::plotDipoles(const ECDSet& tECDSet)
     dipoleEntity->addComponent(pDipolMesh);
 
     //Add material
-    GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial(true);
+    GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial;
     pMaterial->setAmbient(QColor(0,0,0));
     pMaterial->setAlpha(1.0f);
     dipoleEntity->addComponent(pMaterial);

--- a/libraries/disp3D/engine/model/items/sourcespace/sourcespacetreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/sourcespace/sourcespacetreeitem.cpp
@@ -180,7 +180,7 @@ void SourceSpaceTreeItem::plotSources(const MNEHemisphere& tHemisphere)
     pSourceSphereEntity->addComponent(pSphereMesh);
 
     //Add material
-    GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial(true);
+    GeometryMultiplierMaterial* pMaterial = new GeometryMultiplierMaterial;
     QColor defaultColor(255,0,0);
     pMaterial->setAmbient(defaultColor);
 

--- a/libraries/disp3D/engine/model/materials/geometrymultipliermaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/geometrymultipliermaterial.cpp
@@ -189,7 +189,7 @@ void GeometryMultiplierMaterial::init()
 
     this->setEffect(m_pVertexEffect);
 
-    connect(m_pAlphaParameter, &QParameter::valueChanged,
+    connect(m_pAlphaParameter.data(), &QParameter::valueChanged,
             this, &GeometryMultiplierMaterial::onAlphaChanged);
 
     //Init filter keys

--- a/libraries/disp3D/engine/model/materials/geometrymultipliermaterial.h
+++ b/libraries/disp3D/engine/model/materials/geometrymultipliermaterial.h
@@ -72,9 +72,6 @@ namespace Qt3DRender {
     class QFilterKey;
     class QTechnique;
     class QRenderPass;
-    class QNoDepthMask;
-    class QBlendEquationArguments;
-    class QBlendEquation;
 }
 
 namespace Qtcore {
@@ -112,10 +109,9 @@ public:
     /**
     * Default constructor.
     *
-    * @param[in] bUseAlpha      Whether to use alpha/transparency.
     * @param[in] parent         The parent of this class.
     */
-    explicit GeometryMultiplierMaterial(bool bUseAlpha = false, Qt3DCore::QNode *parent = 0);
+    explicit GeometryMultiplierMaterial(Qt3DCore::QNode *parent = 0);
 
 
     //=========================================================================================================
@@ -167,6 +163,15 @@ private:
     */
     void init();
 
+    //=========================================================================================================
+    /**
+    * This function gets called whenever the alpha value is changed.
+    * It handles the change between opaque and transparent depending on the new alpha.
+    *
+    * @param[in] fAlpha         The new alpha value.
+    */
+    void onAlphaChanged(const QVariant &fAlpha);
+
     QPointer<Qt3DRender::QEffect>           m_pVertexEffect;
 
     QPointer<Qt3DRender::QParameter>        m_pAmbientColor;
@@ -187,13 +192,6 @@ private:
     QPointer<Qt3DRender::QTechnique>        m_pVertexES2Technique;
     QPointer<Qt3DRender::QRenderPass>       m_pVertexES2RenderPass;
     QPointer<Qt3DRender::QShaderProgram>    m_pVertexES2Shader;
-
-    QPointer<Qt3DRender::QNoDepthMask>                  m_pNoDepthMask;
-    QPointer<Qt3DRender::QBlendEquationArguments>       m_pBlendState;
-    QPointer<Qt3DRender::QBlendEquation>                m_pBlendEquation;
-
-    bool        m_bUseAlpha;
-
 };
 
 

--- a/libraries/disp3D/engine/model/materials/gpuinterpolationmaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/gpuinterpolationmaterial.cpp
@@ -310,7 +310,7 @@ void GpuInterpolationMaterial::init()
     //Add to material
     this->setEffect(m_pEffect);
 
-    connect(m_pAlphaParameter, &QParameter::valueChanged,
+    connect(m_pAlphaParameter.data(), &QParameter::valueChanged,
             this, &GpuInterpolationMaterial::onAlphaChanged);
 
     //Init draw filter key

--- a/libraries/disp3D/engine/model/materials/gpuinterpolationmaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/gpuinterpolationmaterial.cpp
@@ -331,7 +331,7 @@ void GpuInterpolationMaterial::onAlphaChanged(const QVariant &fAlpha)
         {
             m_pDrawFilterKey->setValue(QStringLiteral("forward"));
         }
-        else if(tempAlpha < 1.0f)
+        else
         {
             m_pDrawFilterKey->setValue(QStringLiteral("forwardTransparent"));
         }

--- a/libraries/disp3D/engine/model/materials/gpuinterpolationmaterial.h
+++ b/libraries/disp3D/engine/model/materials/gpuinterpolationmaterial.h
@@ -84,10 +84,6 @@ namespace Qt3DRender {
         class QFilterKey;
         class QTechnique;
         class QBuffer;
-        class QCullFace;
-        class QNoDepthMask;
-        class QBlendEquationArguments;
-        class QBlendEquation;
 }
 
 
@@ -124,10 +120,9 @@ public:
     /**
     * Default constructor.
     *
-    * @param[in] bUseAlpha      Whether to use alpha/transparency.
     * @param[in] parent         The parent of this class.
     */
-    explicit GpuInterpolationMaterial(bool bUseAlpha = false, Qt3DCore::QNode *parent = 0);
+    explicit GpuInterpolationMaterial(Qt3DCore::QNode *parent = 0);
 
     //=========================================================================================================
     /**
@@ -200,6 +195,15 @@ private:
 
     //=========================================================================================================
     /**
+    * This function gets called whenever the alpha value is changed.
+    * It handles the change between opaque and transparent depending on the new alpha.
+    *
+    * @param[in] fAlpha         The new alpha value.
+    */
+    void onAlphaChanged(const QVariant &fAlpha);
+
+    //=========================================================================================================
+    /**
      * Build the content of the weight matrix buffer.
      *
      * @param tInterpolationMatrix      The weight matrix.
@@ -258,13 +262,6 @@ private:
 
     //Colormap type
     QPointer<Qt3DRender::QParameter>                    m_pColormapParameter;       /**< This parameter stores the colormap type. */
-
-    QPointer<Qt3DRender::QCullFace>                     m_pCullFace;                /**< This render state activates face culling. */
-
-    //Alpha states
-    QPointer<Qt3DRender::QNoDepthMask>                  m_pNoDepthMask;             /**< This render state disables depth write. */
-    QPointer<Qt3DRender::QBlendEquationArguments>       m_pBlendState;              /**< This render state specifes how blend values are handled. */
-    QPointer<Qt3DRender::QBlendEquation>                m_pBlendEquation;           /**< This render state specifies the blend equation. */
 };
 
 

--- a/libraries/disp3D/engine/model/materials/gpuinterpolationmaterial.h
+++ b/libraries/disp3D/engine/model/materials/gpuinterpolationmaterial.h
@@ -220,8 +220,6 @@ private:
      */
     QByteArray buildZeroBuffer(const uint tSize);
 
-    bool                                                m_bUseAlpha;                /**< Declares if the rendered object is transparent. */
-
     QPointer<Qt3DRender::QEffect>                       m_pEffect;                  /**< The effect of this material. */
 
     //Phongalpha parameter

--- a/libraries/disp3D/engine/model/materials/networkmaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/networkmaterial.cpp
@@ -173,7 +173,7 @@ void NetworkMaterial::onAlphaChanged(const QVariant &fAlpha)
         {
             m_pFilterKey->setValue(QStringLiteral("forward"));
         }
-        else if(tempAlpha < 1.0f)
+        else
         {
             m_pFilterKey->setValue(QStringLiteral("forwardTransparent"));
         }

--- a/libraries/disp3D/engine/model/materials/networkmaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/networkmaterial.cpp
@@ -152,7 +152,7 @@ void NetworkMaterial::init()
 
     this->setEffect(m_pVertexEffect);
 
-    connect(m_pAlphaParameter, &QParameter::valueChanged,
+    connect(m_pAlphaParameter.data(), &QParameter::valueChanged,
             this, &NetworkMaterial::onAlphaChanged);
 
     //Init filter keys

--- a/libraries/disp3D/engine/model/materials/networkmaterial.h
+++ b/libraries/disp3D/engine/model/materials/networkmaterial.h
@@ -73,9 +73,6 @@ namespace Qt3DRender {
     class QFilterKey;
     class QTechnique;
     class QRenderPass;
-    class QNoDepthMask;
-    class QBlendEquationArguments;
-    class QBlendEquation;
     class QGraphicsApiFilter;
 }
 
@@ -143,6 +140,15 @@ private:
     */
     void init();
 
+    //=========================================================================================================
+    /**
+    * This function gets called whenever the alpha value is changed.
+    * It handles the change between opaque and transparent depending on the new alpha.
+    *
+    * @param[in] fAlpha         The new alpha value.
+    */
+    void onAlphaChanged(const QVariant &fAlpha);
+
     QPointer<Qt3DRender::QEffect>           m_pVertexEffect;
 
     QPointer<Qt3DRender::QParameter>        m_pDiffuseParameter;
@@ -165,10 +171,6 @@ private:
     QPointer<Qt3DRender::QTechnique>        m_pVertexES2Technique;
     QPointer<Qt3DRender::QRenderPass>       m_pVertexES2RenderPass;
     QPointer<Qt3DRender::QShaderProgram>    m_pVertexES2Shader;
-
-    QPointer<Qt3DRender::QNoDepthMask>                  m_pNoDepthMask;
-    QPointer<Qt3DRender::QBlendEquationArguments>       m_pBlendState;
-    QPointer<Qt3DRender::QBlendEquation>                m_pBlendEquation;
 };
 
 } // namespace DISP3DLIB

--- a/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.cpp
@@ -53,10 +53,6 @@
 #include <Qt3DRender/qparameter.h>
 #include <Qt3DRender/qrenderpass.h>
 #include <QFilterKey>
-#include <Qt3DRender/qdepthtest.h>
-#include <Qt3DRender/qblendequation.h>
-#include <Qt3DRender/qblendequationarguments.h>
-#include <Qt3DRender/qnodepthmask.h>
 #include <Qt3DRender/qgraphicsapifilter.h>
 
 #include <QUrl>
@@ -78,7 +74,7 @@ using namespace Qt3DRender;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-PerVertexPhongAlphaMaterial::PerVertexPhongAlphaMaterial(bool bUseAlpha, bool bUseSortPolicy, QNode *parent)
+PerVertexPhongAlphaMaterial::PerVertexPhongAlphaMaterial(bool bUseSortPolicy, QNode *parent)
 : QMaterial(parent)
 , m_pVertexEffect(new QEffect())
 , m_pDiffuseParameter(new QParameter(QStringLiteral("kd"), QColor::fromRgbF(0.7f, 0.7f, 0.7f, 1.0f)))
@@ -94,10 +90,6 @@ PerVertexPhongAlphaMaterial::PerVertexPhongAlphaMaterial(bool bUseAlpha, bool bU
 , m_pVertexES2RenderPass(new QRenderPass())
 , m_pVertexES2Shader(new QShaderProgram())
 , m_pFilterKey(new QFilterKey)
-, m_pNoDepthMask(new QNoDepthMask())
-, m_pBlendState(new QBlendEquationArguments())
-, m_pBlendEquation(new QBlendEquation())
-, m_bUseAlpha(bUseAlpha)
 , m_bUseSortPolicy(bUseSortPolicy)
 {
     this->init();
@@ -142,36 +134,6 @@ void PerVertexPhongAlphaMaterial::init()
     m_pVertexES2Technique->graphicsApiFilter()->setMinorVersion(0);
     m_pVertexES2Technique->graphicsApiFilter()->setProfile(QGraphicsApiFilter::NoProfile);
 
-    //If wanted setup transparency - TODO: Fix transparency problem and remove this
-    if(m_bUseAlpha) {
-        m_pBlendState->setSourceRgb(QBlendEquationArguments::SourceAlpha);
-        m_pBlendState->setDestinationRgb(QBlendEquationArguments::OneMinusSourceAlpha);
-        m_pBlendEquation->setBlendFunction(QBlendEquation::Add);
-
-        m_pVertexGL3RenderPass->addRenderState(m_pBlendEquation);
-        m_pVertexGL2RenderPass->addRenderState(m_pBlendEquation);
-        m_pVertexES2RenderPass->addRenderState(m_pBlendEquation);
-
-        m_pVertexGL3RenderPass->addRenderState(m_pNoDepthMask);
-        m_pVertexGL2RenderPass->addRenderState(m_pNoDepthMask);
-        m_pVertexES2RenderPass->addRenderState(m_pNoDepthMask);
-
-        m_pVertexGL3RenderPass->addRenderState(m_pBlendState);
-        m_pVertexGL2RenderPass->addRenderState(m_pBlendState);
-        m_pVertexES2RenderPass->addRenderState(m_pBlendState);
-    }
-
-    m_pFilterKey->setName(QStringLiteral("renderingStyle"));
-
-    if(m_bUseSortPolicy)
-    {
-        m_pFilterKey->setValue(QStringLiteral("forwardSorted"));
-    }
-    else
-    {
-        m_pFilterKey->setValue(QStringLiteral("forward"));
-    }
-
     m_pVertexGL3Technique->addFilterKey(m_pFilterKey);
     m_pVertexGL2Technique->addFilterKey(m_pFilterKey);
     m_pVertexES2Technique->addFilterKey(m_pFilterKey);
@@ -190,6 +152,13 @@ void PerVertexPhongAlphaMaterial::init()
     m_pVertexEffect->addParameter(m_pAlphaParameter);
 
     this->setEffect(m_pVertexEffect);
+
+    connect(m_pAlphaParameter, &QParameter::valueChanged,
+            this, &PerVertexPhongAlphaMaterial::onAlphaChanged);
+
+    //Init filter keys
+    m_pFilterKey->setName(QStringLiteral("renderingStyle"));
+    onAlphaChanged(m_pAlphaParameter->value());
 }
 
 
@@ -208,3 +177,32 @@ void PerVertexPhongAlphaMaterial::setAlpha(float alpha)
     m_pAlphaParameter->setValue(alpha);
 }
 
+
+//*************************************************************************************************************
+
+void PerVertexPhongAlphaMaterial::onAlphaChanged(const QVariant &fAlpha)
+{
+    if(fAlpha.canConvert<float>())
+    {
+        float tempAlpha = fAlpha.toFloat();
+
+        if(tempAlpha == 1.0f)
+        {
+            m_pFilterKey->setValue(QStringLiteral("forward"));
+        }
+        else if(tempAlpha < 1.0f)
+        {
+            if(m_bUseSortPolicy)
+            {
+                m_pFilterKey->setValue(QStringLiteral("forwardSorted"));
+            }
+            else
+            {
+                m_pFilterKey->setValue(QStringLiteral("forwardTransparent"));
+            }
+        }
+    }
+}
+
+
+//*************************************************************************************************************

--- a/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.cpp
@@ -78,7 +78,7 @@ using namespace Qt3DRender;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-PerVertexPhongAlphaMaterial::PerVertexPhongAlphaMaterial(bool bUseAlpha, QNode *parent)
+PerVertexPhongAlphaMaterial::PerVertexPhongAlphaMaterial(bool bUseAlpha, bool bUseSortPolicy, QNode *parent)
 : QMaterial(parent)
 , m_pVertexEffect(new QEffect())
 , m_pDiffuseParameter(new QParameter(QStringLiteral("kd"), QColor::fromRgbF(0.7f, 0.7f, 0.7f, 1.0f)))
@@ -98,6 +98,7 @@ PerVertexPhongAlphaMaterial::PerVertexPhongAlphaMaterial(bool bUseAlpha, QNode *
 , m_pBlendState(new QBlendEquationArguments())
 , m_pBlendEquation(new QBlendEquation())
 , m_bUseAlpha(bUseAlpha)
+, m_bUseSortPolicy(bUseSortPolicy)
 {
     this->init();
 }
@@ -161,7 +162,15 @@ void PerVertexPhongAlphaMaterial::init()
     }
 
     m_pFilterKey->setName(QStringLiteral("renderingStyle"));
-    m_pFilterKey->setValue(QStringLiteral("forward"));
+
+    if(m_bUseSortPolicy)
+    {
+        m_pFilterKey->setValue(QStringLiteral("forwardSorted"));
+    }
+    else
+    {
+        m_pFilterKey->setValue(QStringLiteral("forward"));
+    }
 
     m_pVertexGL3Technique->addFilterKey(m_pFilterKey);
     m_pVertexGL2Technique->addFilterKey(m_pFilterKey);

--- a/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.cpp
@@ -153,7 +153,7 @@ void PerVertexPhongAlphaMaterial::init()
 
     this->setEffect(m_pVertexEffect);
 
-    connect(m_pAlphaParameter, &QParameter::valueChanged,
+    connect(m_pAlphaParameter.data(), &QParameter::valueChanged,
             this, &PerVertexPhongAlphaMaterial::onAlphaChanged);
 
     //Init filter keys

--- a/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.h
+++ b/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.h
@@ -110,10 +110,11 @@ public:
     /**
     * Default constructor.
     *
-    * @param[in] bUseAlpha      Whether to use alpha/transparency.
-    * @param[in] parent         The parent of this class.
+    * @param[in] bUseAlpha          Whether to use alpha/transparency.
+    * @param[in] bUseSortPolicy     Whether to use the sort policy in the framegraph.
+    * @param[in] parent             The parent of this class.
     */
-    explicit PerVertexPhongAlphaMaterial(bool bUseAlpha = false, Qt3DCore::QNode *parent = 0);
+    explicit PerVertexPhongAlphaMaterial(bool bUseAlpha = false, bool bUseSortPolicy = false, Qt3DCore::QNode *parent = 0);
 
     //=========================================================================================================
     /**
@@ -168,6 +169,7 @@ private:
     QPointer<Qt3DRender::QBlendEquation>                m_pBlendEquation;
 
     bool        m_bUseAlpha;
+    bool        m_bUseSortPolicy;
 };
 
 } // namespace DISP3DLIB

--- a/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.h
+++ b/libraries/disp3D/engine/model/materials/pervertexphongalphamaterial.h
@@ -73,9 +73,6 @@ namespace Qt3DRender {
     class QFilterKey;
     class QTechnique;
     class QRenderPass;
-    class QNoDepthMask;
-    class QBlendEquationArguments;
-    class QBlendEquation;
     class QGraphicsApiFilter;
 }
 
@@ -110,11 +107,10 @@ public:
     /**
     * Default constructor.
     *
-    * @param[in] bUseAlpha          Whether to use alpha/transparency.
     * @param[in] bUseSortPolicy     Whether to use the sort policy in the framegraph.
     * @param[in] parent             The parent of this class.
     */
-    explicit PerVertexPhongAlphaMaterial(bool bUseAlpha = false, bool bUseSortPolicy = false, Qt3DCore::QNode *parent = 0);
+    explicit PerVertexPhongAlphaMaterial(bool bUseSortPolicy = false, Qt3DCore::QNode *parent = 0);
 
     //=========================================================================================================
     /**
@@ -145,6 +141,15 @@ private:
     */
     void init();
 
+    //=========================================================================================================
+    /**
+    * This function gets called whenever the alpha value is changed.
+    * It handles the change between opaque and transparent depending on the new alpha.
+    *
+    * @param[in] fAlpha         The new alpha value.
+    */
+    void onAlphaChanged(const QVariant &fAlpha);
+
     QPointer<Qt3DRender::QEffect>           m_pVertexEffect;
 
     QPointer<Qt3DRender::QParameter>        m_pDiffuseParameter;
@@ -164,11 +169,6 @@ private:
     QPointer<Qt3DRender::QRenderPass>       m_pVertexES2RenderPass;
     QPointer<Qt3DRender::QShaderProgram>    m_pVertexES2Shader;
 
-    QPointer<Qt3DRender::QNoDepthMask>                  m_pNoDepthMask;
-    QPointer<Qt3DRender::QBlendEquationArguments>       m_pBlendState;
-    QPointer<Qt3DRender::QBlendEquation>                m_pBlendEquation;
-
-    bool        m_bUseAlpha;
     bool        m_bUseSortPolicy;
 };
 

--- a/libraries/disp3D/engine/model/materials/pervertextessphongalphamaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/pervertextessphongalphamaterial.cpp
@@ -140,7 +140,7 @@ void PerVertexTessPhongAlphaMaterial::init()
 
     this->setEffect(m_pVertexEffect);
 
-    connect(m_pAlphaParameter, &QParameter::valueChanged,
+    connect(m_pAlphaParameter.data(), &QParameter::valueChanged,
             this, &PerVertexTessPhongAlphaMaterial::onAlphaChanged);
 
     //Init draw filter key

--- a/libraries/disp3D/engine/model/materials/pervertextessphongalphamaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/pervertextessphongalphamaterial.cpp
@@ -78,7 +78,7 @@ using namespace Qt3DRender;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-PerVertexTessPhongAlphaMaterial::PerVertexTessPhongAlphaMaterial(bool bUseAlpha, QNode *parent)
+PerVertexTessPhongAlphaMaterial::PerVertexTessPhongAlphaMaterial(QNode *parent)
 : QMaterial(parent)
 , m_pVertexEffect(new QEffect())
 , m_pDiffuseParameter(new QParameter(QStringLiteral("kd"), QColor::fromRgbF(0.7f, 0.7f, 0.7f, 1.0f)))
@@ -92,10 +92,6 @@ PerVertexTessPhongAlphaMaterial::PerVertexTessPhongAlphaMaterial(bool bUseAlpha,
 , m_pVertexGL4RenderPass(new QRenderPass())
 , m_pVertexGL4Shader(new QShaderProgram())
 , m_pFilterKey(new QFilterKey)
-, m_pNoDepthMask(new QNoDepthMask())
-, m_pBlendState(new QBlendEquationArguments())
-, m_pBlendEquation(new QBlendEquation())
-, m_bUseAlpha(bUseAlpha)
 {
     this->init();
 }
@@ -128,19 +124,6 @@ void PerVertexTessPhongAlphaMaterial::init()
     m_pVertexGL4Technique->graphicsApiFilter()->setMinorVersion(0);
     m_pVertexGL4Technique->graphicsApiFilter()->setProfile(QGraphicsApiFilter::CoreProfile);
 
-    //If wanted setup transparency
-    if(m_bUseAlpha) {
-        m_pBlendState->setSourceRgb(QBlendEquationArguments::SourceAlpha);
-        m_pBlendState->setDestinationRgb(QBlendEquationArguments::OneMinusSourceAlpha);
-        m_pBlendEquation->setBlendFunction(QBlendEquation::Add);
-
-        m_pVertexGL4RenderPass->addRenderState(m_pBlendEquation);
-        m_pVertexGL4RenderPass->addRenderState(m_pNoDepthMask);
-        m_pVertexGL4RenderPass->addRenderState(m_pBlendState);
-    }
-
-    m_pFilterKey->setName(QStringLiteral("renderingStyle"));
-    m_pFilterKey->setValue(QStringLiteral("forward"));
     m_pVertexGL4Technique->addFilterKey(m_pFilterKey);
 
     m_pVertexGL4Technique->addRenderPass(m_pVertexGL4RenderPass);
@@ -156,6 +139,33 @@ void PerVertexTessPhongAlphaMaterial::init()
     m_pVertexEffect->addParameter(m_pTriangleScaleParameter);
 
     this->setEffect(m_pVertexEffect);
+
+    connect(m_pAlphaParameter, &QParameter::valueChanged,
+            this, &PerVertexTessPhongAlphaMaterial::onAlphaChanged);
+
+    //Init draw filter key
+    m_pFilterKey->setName(QStringLiteral("renderingStyle"));
+    onAlphaChanged(m_pAlphaParameter->value());
+}
+
+
+//*************************************************************************************************************
+
+void PerVertexTessPhongAlphaMaterial::onAlphaChanged(const QVariant &fAlpha)
+{
+    if(fAlpha.canConvert<float>())
+    {
+        float tempAlpha = fAlpha.toFloat();
+
+        if(tempAlpha == 1.0f)
+        {
+            m_pFilterKey->setValue(QStringLiteral("forward"));
+        }
+        else
+        {
+            m_pFilterKey->setValue(QStringLiteral("forwardTransparent"));
+        }
+    }
 }
 
 

--- a/libraries/disp3D/engine/model/materials/pervertextessphongalphamaterial.h
+++ b/libraries/disp3D/engine/model/materials/pervertextessphongalphamaterial.h
@@ -73,9 +73,6 @@ namespace Qt3DRender {
     class QFilterKey;
     class QTechnique;
     class QRenderPass;
-    class QNoDepthMask;
-    class QBlendEquationArguments;
-    class QBlendEquation;
     class QGraphicsApiFilter;
 }
 
@@ -110,10 +107,9 @@ public:
     /**
     * Default constructor.
     *
-    * @param[in] bUseAlpha      Whether to use alpha/transparency.
     * @param[in] parent         The parent of this class.
     */
-    explicit PerVertexTessPhongAlphaMaterial(bool bUseAlpha = false, Qt3DCore::QNode *parent = 0);
+    explicit PerVertexTessPhongAlphaMaterial(Qt3DCore::QNode *parent = 0);
 
     //=========================================================================================================
     /**
@@ -144,6 +140,15 @@ private:
     */
     void init();
 
+    //=========================================================================================================
+    /**
+    * This function gets called whenever the alpha value is changed.
+    * It handles the change between opaque and transparent depending on the new alpha.
+    *
+    * @param[in] fAlpha         The new alpha value.
+    */
+    void onAlphaChanged(const QVariant &fAlpha);
+
     QPointer<Qt3DRender::QEffect>                   m_pVertexEffect;
 
     QPointer<Qt3DRender::QParameter>                m_pDiffuseParameter;
@@ -159,12 +164,6 @@ private:
     QPointer<Qt3DRender::QTechnique>                m_pVertexGL4Technique;
     QPointer<Qt3DRender::QRenderPass>               m_pVertexGL4RenderPass;
     QPointer<Qt3DRender::QShaderProgram>            m_pVertexGL4Shader;
-
-    QPointer<Qt3DRender::QNoDepthMask>              m_pNoDepthMask;
-    QPointer<Qt3DRender::QBlendEquationArguments>   m_pBlendState;
-    QPointer<Qt3DRender::QBlendEquation>            m_pBlendEquation;
-
-    bool        m_bUseAlpha;
 };
 
 } // namespace DISP3DLIB

--- a/libraries/disp3D/engine/model/materials/shownormalsmaterial.cpp
+++ b/libraries/disp3D/engine/model/materials/shownormalsmaterial.cpp
@@ -53,10 +53,6 @@
 #include <Qt3DRender/qparameter.h>
 #include <Qt3DRender/qrenderpass.h>
 #include <QFilterKey>
-#include <Qt3DRender/qdepthtest.h>
-#include <Qt3DRender/qblendequation.h>
-#include <Qt3DRender/qblendequationarguments.h>
-#include <Qt3DRender/qnodepthmask.h>
 #include <Qt3DRender/qgraphicsapifilter.h>
 
 #include <QUrl>
@@ -85,9 +81,6 @@ ShowNormalsMaterial::ShowNormalsMaterial(QNode *parent)
 , m_pVertexGL3RenderPass(new QRenderPass())
 , m_pVertexGL3Shader(new QShaderProgram())
 , m_pFilterKey(new QFilterKey)
-, m_pNoDepthMask(new QNoDepthMask())
-, m_pBlendState(new QBlendEquationArguments())
-, m_pBlendEquation(new QBlendEquation())
 {
     this->init();
 }
@@ -110,15 +103,6 @@ void ShowNormalsMaterial::init()
     m_pVertexGL3Shader->setFragmentShaderCode(QShaderProgram::loadSource(QUrl(QStringLiteral("qrc:/engine/model/materials/shaders/gl3/shownormals.frag"))));
     m_pVertexGL3RenderPass->setShaderProgram(m_pVertexGL3Shader);
 
-    //Setup transparency
-    m_pBlendState->setSourceRgb(QBlendEquationArguments::SourceAlpha);
-    m_pBlendState->setDestinationRgb(QBlendEquationArguments::OneMinusSourceAlpha);
-    m_pBlendEquation->setBlendFunction(QBlendEquation::Add);
-
-    m_pVertexGL3RenderPass->addRenderState(m_pBlendEquation);
-    m_pVertexGL3RenderPass->addRenderState(m_pNoDepthMask);
-    m_pVertexGL3RenderPass->addRenderState(m_pBlendState);
-
     //Set OpenGL version - This material can only be used with opengl 4.0 or higher since it is using geometry shaders
     m_pVertexGL3Technique->graphicsApiFilter()->setApi(QGraphicsApiFilter::OpenGL);
     m_pVertexGL3Technique->graphicsApiFilter()->setMajorVersion(3);
@@ -126,7 +110,7 @@ void ShowNormalsMaterial::init()
     m_pVertexGL3Technique->graphicsApiFilter()->setProfile(QGraphicsApiFilter::CoreProfile);
 
     m_pFilterKey->setName(QStringLiteral("renderingStyle"));
-    m_pFilterKey->setValue(QStringLiteral("forward"));
+    m_pFilterKey->setValue(QStringLiteral("forwardTransparent"));
     m_pVertexGL3Technique->addFilterKey(m_pFilterKey);
 
     m_pVertexGL3Technique->addRenderPass(m_pVertexGL3RenderPass);

--- a/libraries/disp3D/engine/model/materials/shownormalsmaterial.h
+++ b/libraries/disp3D/engine/model/materials/shownormalsmaterial.h
@@ -73,9 +73,6 @@ namespace Qt3DRender {
     class QFilterKey;
     class QTechnique;
     class QRenderPass;
-    class QNoDepthMask;
-    class QBlendEquationArguments;
-    class QBlendEquation;
     class QGraphicsApiFilter;
 }
 
@@ -134,10 +131,6 @@ private:
     QPointer<Qt3DRender::QTechnique>                m_pVertexGL3Technique;
     QPointer<Qt3DRender::QRenderPass>               m_pVertexGL3RenderPass;
     QPointer<Qt3DRender::QShaderProgram>            m_pVertexGL3Shader;
-
-    QPointer<Qt3DRender::QNoDepthMask>              m_pNoDepthMask;
-    QPointer<Qt3DRender::QBlendEquationArguments>   m_pBlendState;
-    QPointer<Qt3DRender::QBlendEquation>            m_pBlendEquation;
 };
 
 } // namespace DISP3DLIB

--- a/libraries/disp3D/engine/view/customframegraph.cpp
+++ b/libraries/disp3D/engine/view/customframegraph.cpp
@@ -94,10 +94,12 @@ CustomFrameGraph::CustomFrameGraph(Qt3DCore::QNode *parent)
     , m_pDispatchCompute(new QDispatchCompute(m_pSurfaceSelector))
     , m_pComputeFilter(new QTechniqueFilter(m_pDispatchCompute))
     , m_pCameraSelector(new QCameraSelector(m_pSurfaceSelector))
-    , m_pForwardFilter(new QTechniqueFilter(m_pCameraSelector))
-    , m_pSortPolicy(new QSortPolicy(m_pForwardFilter))
-    , m_pMemoryBarrier(new QMemoryBarrier(m_pSortPolicy))
+    , m_pMemoryBarrier(new QMemoryBarrier(m_pCameraSelector))
+    , m_pForwardFilter(new QTechniqueFilter(m_pMemoryBarrier))
+    , m_pForwardSortedFilter(new QTechniqueFilter(m_pMemoryBarrier))
+    , m_pSortPolicy(new QSortPolicy(m_pForwardSortedFilter))
     , m_pForwardKey(new QFilterKey)
+    , m_pForwardSortedKey(new QFilterKey)
     , m_pComputeKey(new QFilterKey)
 {
     init();
@@ -165,12 +167,16 @@ void CustomFrameGraph::init()
     m_pForwardKey->setName(QStringLiteral("renderingStyle"));
     m_pForwardKey->setValue(QStringLiteral("forward"));
 
+    m_pForwardSortedKey->setName(QStringLiteral("renderingStyle"));
+    m_pForwardSortedKey->setValue(QStringLiteral("forwardSorted"));
+
     //Add Matches
     m_pComputeFilter->addMatch(m_pComputeKey);
     m_pForwardFilter->addMatch(m_pForwardKey);
+    m_pForwardSortedFilter->addMatch(m_pForwardSortedKey);
 
     //Set draw policy
-    QVector<QSortPolicy::SortType> sortTypes = {Qt3DRender::QSortPolicy::BackToFront};
+    QVector<QSortPolicy::SortType> sortTypes = {QSortPolicy::StateChangeCost, QSortPolicy::BackToFront};
     m_pSortPolicy->setSortTypes(sortTypes);
 
     //Set Memory Barrier it ensures the finishing of the compute shader run before drawing the scene.

--- a/libraries/disp3D/engine/view/customframegraph.cpp
+++ b/libraries/disp3D/engine/view/customframegraph.cpp
@@ -57,6 +57,7 @@
 #include <Qt3DRender/QMemoryBarrier>
 #include <Qt3DRender/QFilterKey>
 #include <Qt3DRender/QCamera>
+#include <Qt3DRender/QSortPolicy>
 
 
 //*************************************************************************************************************
@@ -94,7 +95,8 @@ CustomFrameGraph::CustomFrameGraph(Qt3DCore::QNode *parent)
     , m_pComputeFilter(new QTechniqueFilter(m_pDispatchCompute))
     , m_pCameraSelector(new QCameraSelector(m_pSurfaceSelector))
     , m_pForwardFilter(new QTechniqueFilter(m_pCameraSelector))
-    , m_pMemoryBarrier(new QMemoryBarrier(m_pForwardFilter))
+    , m_pSortPolicy(new QSortPolicy(m_pForwardFilter))
+    , m_pMemoryBarrier(new QMemoryBarrier(m_pSortPolicy))
     , m_pForwardKey(new QFilterKey)
     , m_pComputeKey(new QFilterKey)
 {
@@ -113,6 +115,7 @@ CustomFrameGraph::~CustomFrameGraph()
     m_pComputeFilter->deleteLater();
     m_pCameraSelector->deleteLater();
     m_pForwardFilter->deleteLater();
+    m_pSortPolicy->deleteLater();
     m_pMemoryBarrier->deleteLater();
     m_pForwardKey->deleteLater();
     m_pComputeKey->deleteLater();
@@ -165,6 +168,10 @@ void CustomFrameGraph::init()
     //Add Matches
     m_pComputeFilter->addMatch(m_pComputeKey);
     m_pForwardFilter->addMatch(m_pForwardKey);
+
+    //Set draw policy
+    QVector<QSortPolicy::SortType> sortTypes = {Qt3DRender::QSortPolicy::BackToFront};
+    m_pSortPolicy->setSortTypes(sortTypes);
 
     //Set Memory Barrier it ensures the finishing of the compute shader run before drawing the scene.
     m_pMemoryBarrier->setWaitOperations(QMemoryBarrier::VertexAttributeArray);

--- a/libraries/disp3D/engine/view/customframegraph.cpp
+++ b/libraries/disp3D/engine/view/customframegraph.cpp
@@ -58,6 +58,13 @@
 #include <Qt3DRender/QFilterKey>
 #include <Qt3DRender/QCamera>
 #include <Qt3DRender/QSortPolicy>
+#include <Qt3DRender/QRenderStateSet>
+#include <Qt3DRender/QDepthTest>
+#include <Qt3DRender/QNoDepthMask>
+#include <Qt3DRender/QBlendEquation>
+#include <Qt3DRender/QBlendEquationArguments>
+#include <Qt3DRender/QCullFace>
+#include <QSurfaceFormat>
 
 
 //*************************************************************************************************************
@@ -86,22 +93,27 @@ using namespace Qt3DRender;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-CustomFrameGraph::CustomFrameGraph(Qt3DCore::QNode *parent)
+CustomFrameGraph::CustomFrameGraph(const QSurfaceFormat &tSurfaceFormat, Qt3DCore::QNode *parent)
     : QViewport(parent)
-    , m_pSurfaceSelector(new QRenderSurfaceSelector(this))
-    , m_pClearBuffers(new QClearBuffers(m_pSurfaceSelector))
-    , m_pNoDraw(new QNoDraw(m_pClearBuffers))
-    , m_pDispatchCompute(new QDispatchCompute(m_pSurfaceSelector))
-    , m_pComputeFilter(new QTechniqueFilter(m_pDispatchCompute))
-    , m_pCameraSelector(new QCameraSelector(m_pSurfaceSelector))
-    , m_pMemoryBarrier(new QMemoryBarrier(m_pCameraSelector))
-    , m_pForwardFilter(new QTechniqueFilter(m_pMemoryBarrier))
-    , m_pForwardSortedFilter(new QTechniqueFilter(m_pMemoryBarrier))
-    , m_pSortPolicy(new QSortPolicy(m_pForwardSortedFilter))
+    , m_pForwardTranspKey(new QFilterKey)
     , m_pForwardKey(new QFilterKey)
     , m_pForwardSortedKey(new QFilterKey)
     , m_pComputeKey(new QFilterKey)
+    , m_pDepthTest(new QDepthTest)
+    , m_pCullFace(new QCullFace)
+    , m_pBlendEquation(new QBlendEquation)
+    , m_pBlendArguments(new QBlendEquationArguments)
+    , m_pNoDepthMask( new QNoDepthMask)
+    , m_bUseOpenGl4_3(false)
 {
+    //Test for OpenGL version 4.3
+    if((tSurfaceFormat.majorVersion() == 4
+            && tSurfaceFormat.minorVersion() >= 3
+            || tSurfaceFormat.majorVersion() > 4))
+    {
+        m_bUseOpenGl4_3 = true;
+    }
+
     init();
 }
 
@@ -121,6 +133,17 @@ CustomFrameGraph::~CustomFrameGraph()
     m_pMemoryBarrier->deleteLater();
     m_pForwardKey->deleteLater();
     m_pComputeKey->deleteLater();
+    m_pForwardState->deleteLater();
+    m_pTransparentState->deleteLater();
+    m_pForwardSortedFilter->deleteLater();
+    m_pForwardSortedKey->deleteLater();
+    m_pForwardTranspFilter->deleteLater();
+    m_pForwardTranspKey->deleteLater();
+    m_pDepthTest->deleteLater();
+    m_pCullFace->deleteLater();
+    m_pBlendEquation->deleteLater();
+    m_pBlendArguments->deleteLater();
+    m_pNoDepthMask->deleteLater();
 }
 
 
@@ -154,15 +177,64 @@ void CustomFrameGraph::setClearColor(const QColor &tColor)
 
 void CustomFrameGraph::init()
 {
+    //Build the frame graph
+    m_pSurfaceSelector = new QRenderSurfaceSelector(this);
+    //Clear buffer branch
+    m_pClearBuffers = new QClearBuffers(m_pSurfaceSelector);
+    m_pNoDraw = new QNoDraw(m_pClearBuffers);
+    //Compute branch
+    m_pDispatchCompute = new QDispatchCompute(m_pSurfaceSelector);
+    m_pComputeFilter = new QTechniqueFilter(m_pDispatchCompute);
+    // Forward render branch
+    m_pCameraSelector = new QCameraSelector(m_pSurfaceSelector);
+
+    if(m_bUseOpenGl4_3)
+    {
+        m_pMemoryBarrier = new QMemoryBarrier(m_pCameraSelector);
+        m_pForwardState = new QRenderStateSet(m_pMemoryBarrier);
+    }
+    else
+    {
+        //don't use memory barrier
+        m_pForwardState = new QRenderStateSet(m_pCameraSelector);
+    }
+
+    m_pForwardFilter = new QTechniqueFilter(m_pForwardState);
+    //Transparent forward render branch
+    m_pTransparentState = new QRenderStateSet(m_pForwardState);
+    m_pForwardTranspFilter = new QTechniqueFilter(m_pTransparentState);
+    //Transparent sorted forward render branch
+    m_pForwardSortedFilter = new QTechniqueFilter(m_pTransparentState);
+    m_pSortPolicy = new QSortPolicy(m_pForwardSortedFilter);
+
+    //Init frame graph nodes
     this->setNormalizedRect(QRectF(0.0f, 0.0f, 1.0f, 1.0f));
 
     //Set ClearBuffer
     m_pClearBuffers->setBuffers(QClearBuffers::ColorDepthBuffer);
     m_pClearBuffers->setClearColor(Qt::black);
 
+    //Set depth test
+    m_pDepthTest->setDepthFunction(QDepthTest::Less);
+    m_pForwardState->addRenderState(m_pDepthTest);
+    m_pCullFace->setMode(QCullFace::Back);
+    m_pForwardState->addRenderState(m_pCullFace);
+
+
+    //Set Transparent states
+    m_pBlendArguments->setSourceRgb(QBlendEquationArguments::SourceAlpha);
+    m_pBlendArguments->setDestinationRgb(QBlendEquationArguments::OneMinusSourceAlpha);
+    m_pBlendEquation->setBlendFunction(QBlendEquation::Add);
+    m_pTransparentState->addRenderState(m_pBlendArguments);
+    m_pTransparentState->addRenderState(m_pBlendEquation);
+    m_pTransparentState->addRenderState(m_pNoDepthMask);
+
     //Set filter keys these need to match with the material.
     m_pComputeKey->setName(QStringLiteral("renderingStyle"));
     m_pComputeKey->setValue(QStringLiteral("compute"));
+
+    m_pForwardTranspKey->setName(QStringLiteral("renderingStyle"));
+    m_pForwardTranspKey->setValue(QStringLiteral("forwardTransparent"));
 
     m_pForwardKey->setName(QStringLiteral("renderingStyle"));
     m_pForwardKey->setValue(QStringLiteral("forward"));
@@ -174,6 +246,7 @@ void CustomFrameGraph::init()
     m_pComputeFilter->addMatch(m_pComputeKey);
     m_pForwardFilter->addMatch(m_pForwardKey);
     m_pForwardSortedFilter->addMatch(m_pForwardSortedKey);
+    m_pForwardTranspFilter->addMatch(m_pForwardTranspKey);
 
     //Set draw policy
     QVector<QSortPolicy::SortType> sortTypes = {QSortPolicy::StateChangeCost, QSortPolicy::BackToFront};

--- a/libraries/disp3D/engine/view/customframegraph.h
+++ b/libraries/disp3D/engine/view/customframegraph.h
@@ -77,6 +77,7 @@ namespace Qt3DRender {
         class QFilterKey;
         class QMemoryBarrier;
         class QCamera;
+        class QSortPolicy;
 }
 
 
@@ -156,27 +157,28 @@ private:
      */
     void init();
 
-    QPointer<Qt3DRender::QRenderSurfaceSelector> m_pSurfaceSelector;    /**< Frame graph node that declares the render surface. */
+    QPointer<Qt3DRender::QRenderSurfaceSelector>    m_pSurfaceSelector;     /**< Frame graph node that declares the render surface. */
 
-    QPointer<Qt3DRender::QClearBuffers> m_pClearBuffers;                /**< Frame graph node that clears buffers in the branch. */
+    QPointer<Qt3DRender::QClearBuffers>             m_pClearBuffers;        /**< Frame graph node that clears buffers in the branch. */
 
-    QPointer<Qt3DRender::QNoDraw> m_pNoDraw;                            /**< Frame graph node that prevents rendering in the branch. */
+    QPointer<Qt3DRender::QNoDraw>                   m_pNoDraw;              /**< Frame graph node that prevents rendering in the branch. */
 
-    QPointer<Qt3DRender::QDispatchCompute> m_pDispatchCompute;          /**< Frame graph node that issues work to the compute shader. */
+    QPointer<Qt3DRender::QDispatchCompute>          m_pDispatchCompute;     /**< Frame graph node that issues work to the compute shader. */
 
-    QPointer<Qt3DRender::QTechniqueFilter> m_pComputeFilter;            /**< Frame graph node selects the compute technique. */
+    QPointer<Qt3DRender::QTechniqueFilter>          m_pComputeFilter;       /**< Frame graph node selects the compute technique. */
 
-    QPointer<Qt3DRender::QCameraSelector> m_pCameraSelector;            /**< Frame graph node that selects the camera. */
+    QPointer<Qt3DRender::QCameraSelector>           m_pCameraSelector;      /**< Frame graph node that selects the camera. */
 
-    QPointer<Qt3DRender::QTechniqueFilter> m_pForwardFilter;            /**< Frame graph node that selects the forward rendering technique. */
+    QPointer<Qt3DRender::QTechniqueFilter>          m_pForwardFilter;       /**< Frame graph node that selects the forward rendering technique. */
 
-    QPointer<Qt3DRender::QMemoryBarrier> m_pMemoryBarrier;              /**< Frame graph node that emplaces a memory barrier to synchronize computing and rendering. */
+    QPointer<Qt3DRender::QSortPolicy>               m_pSortPolicy;          /**< Frame graph node that defines the drawing order. */
 
-    QPointer<Qt3DRender::QFilterKey> m_pForwardKey;                     /**< Filter key for the compute filter. */
+    QPointer<Qt3DRender::QMemoryBarrier>            m_pMemoryBarrier;       /**< Frame graph node that emplaces a memory barrier to synchronize computing and rendering. */
 
-    QPointer<Qt3DRender::QFilterKey> m_pComputeKey;                     /**< Filter key for the forward rendering filter. */
+    QPointer<Qt3DRender::QFilterKey>                m_pForwardKey;          /**< Filter key for the compute filter. */
+
+    QPointer<Qt3DRender::QFilterKey>                m_pComputeKey;          /**< Filter key for the forward rendering filter. */
 };
-
 
 //*************************************************************************************************************
 //=============================================================================================================

--- a/libraries/disp3D/engine/view/customframegraph.h
+++ b/libraries/disp3D/engine/view/customframegraph.h
@@ -169,13 +169,17 @@ private:
 
     QPointer<Qt3DRender::QCameraSelector>           m_pCameraSelector;      /**< Frame graph node that selects the camera. */
 
+    QPointer<Qt3DRender::QMemoryBarrier>            m_pMemoryBarrier;       /**< Frame graph node that emplaces a memory barrier to synchronize computing and rendering. */
+
     QPointer<Qt3DRender::QTechniqueFilter>          m_pForwardFilter;       /**< Frame graph node that selects the forward rendering technique. */
+
+    QPointer<Qt3DRender::QTechniqueFilter>          m_pForwardSortedFilter; /**< Frame graph node that selects the forward sorted rendering technique. */
 
     QPointer<Qt3DRender::QSortPolicy>               m_pSortPolicy;          /**< Frame graph node that defines the drawing order. */
 
-    QPointer<Qt3DRender::QMemoryBarrier>            m_pMemoryBarrier;       /**< Frame graph node that emplaces a memory barrier to synchronize computing and rendering. */
+    QPointer<Qt3DRender::QFilterKey>                m_pForwardKey;          /**< Filter key for the forward filter. */
 
-    QPointer<Qt3DRender::QFilterKey>                m_pForwardKey;          /**< Filter key for the compute filter. */
+    QPointer<Qt3DRender::QFilterKey>                m_pForwardSortedKey;    /**< Filter key for the sorted forward filter. */
 
     QPointer<Qt3DRender::QFilterKey>                m_pComputeKey;          /**< Filter key for the forward rendering filter. */
 };

--- a/libraries/disp3D/engine/view/customframegraph.h
+++ b/libraries/disp3D/engine/view/customframegraph.h
@@ -78,7 +78,15 @@ namespace Qt3DRender {
         class QMemoryBarrier;
         class QCamera;
         class QSortPolicy;
+        class QRenderStateSet;
+        class QDepthTest;
+        class QNoDepthMask;
+        class QBlendEquationArguments;
+        class QBlendEquation;
+        class QCullFace;
 }
+
+class QSurfaceFormat;
 
 
 //*************************************************************************************************************
@@ -112,8 +120,11 @@ public:
     //=========================================================================================================
     /**
     * Constructs a CustomFrameGraph object.
+    *
+    * @param[in] tSurfaceFormat         Surface format for OpenGL version detection.
+    * @param[in] parent                 Pointer to parent node.
     */
-    explicit CustomFrameGraph(Qt3DCore::QNode *parent = 0);
+    explicit CustomFrameGraph(const QSurfaceFormat &tSurfaceFormat, Qt3DCore::QNode *parent = 0);
 
     //=========================================================================================================
     /**
@@ -171,17 +182,37 @@ private:
 
     QPointer<Qt3DRender::QMemoryBarrier>            m_pMemoryBarrier;       /**< Frame graph node that emplaces a memory barrier to synchronize computing and rendering. */
 
-    QPointer<Qt3DRender::QTechniqueFilter>          m_pForwardFilter;       /**< Frame graph node that selects the forward rendering technique. */
+    QPointer<Qt3DRender::QRenderStateSet>           m_pForwardState;        /**< Frame graph node that holds the depth test render state. */
+
+    QPointer<Qt3DRender::QTechniqueFilter>          m_pForwardTranspFilter; /**< Frame graph node that selects the forward rendering technique for transparent objects. */
+
+    QPointer<Qt3DRender::QRenderStateSet>           m_pTransparentState;    /**< Frame graph node that holds the render states for transparency. */
+
+    QPointer<Qt3DRender::QTechniqueFilter>          m_pForwardFilter;       /**< Frame graph node that selects the forward rendering technique for opaque objects. */
 
     QPointer<Qt3DRender::QTechniqueFilter>          m_pForwardSortedFilter; /**< Frame graph node that selects the forward sorted rendering technique. */
 
     QPointer<Qt3DRender::QSortPolicy>               m_pSortPolicy;          /**< Frame graph node that defines the drawing order. */
 
+    QPointer<Qt3DRender::QFilterKey>                m_pForwardTranspKey;    /**< Filter key for the transparent forward filter. */
+
     QPointer<Qt3DRender::QFilterKey>                m_pForwardKey;          /**< Filter key for the forward filter. */
 
     QPointer<Qt3DRender::QFilterKey>                m_pForwardSortedKey;    /**< Filter key for the sorted forward filter. */
 
-    QPointer<Qt3DRender::QFilterKey>                m_pComputeKey;          /**< Filter key for the forward rendering filter. */
+    QPointer<Qt3DRender::QFilterKey>                m_pComputeKey;          /**< Filter key for the compute filter. */
+
+    QPointer<Qt3DRender::QDepthTest>                m_pDepthTest;           /**< Depth test render state. */
+
+    QPointer<Qt3DRender::QCullFace>                 m_pCullFace;            /**< Render state for face culling. */
+
+    QPointer<Qt3DRender::QBlendEquation>            m_pBlendEquation;       /**< Blend equation render state. */
+
+    QPointer<Qt3DRender::QBlendEquationArguments>   m_pBlendArguments;      /**< Blend equation arguments render state. */
+
+    QPointer<Qt3DRender::QNoDepthMask>              m_pNoDepthMask;         /**< Render state for disableling writing to depth buffer. */
+
+    bool                                            m_bUseOpenGl4_3;        /**< OpenGL version 4.3 status flag. */
 };
 
 //*************************************************************************************************************

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -93,7 +93,6 @@ View3D::View3D()
 , m_p3DObjectsEntity(new Qt3DCore::QEntity(m_pRootEntity))
 , m_pLightEntity(new Qt3DCore::QEntity(m_pRootEntity))
 , m_pCameraEntity(this->camera())
-, m_pFrameGraph(new CustomFrameGraph)
 , m_bRotationMode(false)
 , m_bCameraTransMode(false)
 , m_bModelRotationMode(true)
@@ -103,6 +102,8 @@ View3D::View3D()
 , m_vecViewRotationOld(QVector3D(-90.0,130.0,0.0))
 , m_pCameraTransform(new Qt3DCore::QTransform())
 {
+    m_pFrameGraph = new CustomFrameGraph(this->format());
+
     init();
 }
 


### PR DESCRIPTION
I extended the frame graph to render transparent and opaque objects correctly.
All render states used for transparency are now defined in the frame graph and were deleted form the materials.
The PerVertexPhongAlphaMaterial also has an option to sort the objects using it before rendering.
