### PR TITLE
[LIB-176] Gpu Interpolation Improvements

### DIFF
--- a/libraries/disp3D/engine/model/3dhelpers/geometrymultiplier.cpp
+++ b/libraries/disp3D/engine/model/3dhelpers/geometrymultiplier.cpp
@@ -118,16 +118,7 @@ void GeometryMultiplier::setTransforms(const QVector<QMatrix4x4> &tInstanceTansf
     }
 
     //Update buffer content
-    const QByteArray &transformBufferData = buildTransformBuffer(tInstanceTansform);
-    if(transformBufferData.size() != m_pTransformBuffer->data().size())
-    {
-        m_pTransformBuffer->setData(transformBufferData);
-    }
-    else
-    {
-        m_pTransformBuffer->updateData(0, transformBufferData);
-    }
-    m_pTransformAttribute->setBuffer(m_pTransformBuffer);
+    m_pTransformBuffer->setData(buildTransformBuffer(tInstanceTansform));
 
     updateInstanceCount(tInstanceTansform.size());
 }
@@ -144,15 +135,7 @@ void GeometryMultiplier::setColors(const QVector<QColor> &tInstanceColors)
     }
 
     //Update buffer content
-    const QByteArray &colorBufferData = buildColorBuffer(tInstanceColors);
-    if(colorBufferData.size() != m_pColorBuffer->data().size())
-    {
-        m_pColorBuffer->setData(colorBufferData);
-    }
-    else
-    {
-        m_pColorBuffer->updateData(0, colorBufferData);
-    }
+    m_pColorBuffer->setData(buildColorBuffer(tInstanceColors));
 
     if(tInstanceColors.size() > 1)
     {

--- a/libraries/disp3D/engine/model/items/common/gpuinterpolationitem.cpp
+++ b/libraries/disp3D/engine/model/items/common/gpuinterpolationitem.cpp
@@ -142,16 +142,6 @@ void GpuInterpolationItem::initData(const MatrixX3f &matVertices,
     m_pSignalDataBuffer->setData(buildZeroBuffer(1));
     this->setMaterialParameter(QVariant::fromValue(m_pSignalDataBuffer.data()), QStringLiteral("InputVec"));
 
-    //Create and add compute shader
-    QPointer<Qt3DRender::QComputeCommand> pComputeCommand = new QComputeCommand();
-    this->addComponent(pComputeCommand);
-
-    const uint iInterpolationMatRows = matVertices.rows();
-    const uint iWorkGroupsSize = static_cast<uint>(std::ceil(std::sqrt(iInterpolationMatRows)));
-    pComputeCommand->setWorkGroupX(iWorkGroupsSize);
-    pComputeCommand->setWorkGroupY(iWorkGroupsSize);
-    pComputeCommand->setWorkGroupZ(1);
-
     //Set custom mesh data
     //generate mesh base color
     MatrixX3f matVertColor = createVertColor(matVertices.rows(), QColor(0,0,0));
@@ -189,6 +179,16 @@ void GpuInterpolationItem::setInterpolationMatrix(QSharedPointer<Eigen::SparseMa
 
         m_pInterpolationMatBuffer->setData(interpolationBufferData);
         m_pOutputColorBuffer->setData(buildZeroBuffer(4 * pMatInterpolationMatrix->rows()));
+
+        //Set work group size
+        if(!m_pComputeCommand) {
+            m_pComputeCommand = new QComputeCommand();
+            this->addComponent(m_pComputeCommand);
+        }
+        const uint iWorkGroupsSize = static_cast<uint>(std::ceil(std::sqrt(pMatInterpolationMatrix->rows())));
+        m_pComputeCommand->setWorkGroupX(iWorkGroupsSize);
+        m_pComputeCommand->setWorkGroupY(iWorkGroupsSize);
+        m_pComputeCommand->setWorkGroupZ(1);
 
         //qDebug() << "4 * pMatInterpolationMatrix->rows()"<<4 * pMatInterpolationMatrix->rows();
         //qDebug() << "pMatInterpolationMatrix->rows()*pMatInterpolationMatrix->cols()"<<pMatInterpolationMatrix->rows()*pMatInterpolationMatrix->cols();

--- a/libraries/disp3D/engine/model/items/common/gpuinterpolationitem.cpp
+++ b/libraries/disp3D/engine/model/items/common/gpuinterpolationitem.cpp
@@ -171,13 +171,12 @@ void GpuInterpolationItem::setInterpolationMatrix(QSharedPointer<Eigen::SparseMa
     QByteArray interpolationBufferData = buildInterpolationMatrixBuffer(pMatInterpolationMatrix);
 
     //Init and set interpolation buffer
-    if(m_pInterpolationMatBuffer->data().size() != pMatInterpolationMatrix->rows()*pMatInterpolationMatrix->cols()*sizeof(float)) {
+    if(m_pInterpolationMatBuffer->data().size() != interpolationBufferData.size()) {
 
         //Set Rows and Cols
         this->setMaterialParameter(QVariant::fromValue(pMatInterpolationMatrix->cols()), QStringLiteral("cols"));
         this->setMaterialParameter(QVariant::fromValue(pMatInterpolationMatrix->rows()), QStringLiteral("rows"));
 
-        m_pInterpolationMatBuffer->setData(interpolationBufferData);
         m_pOutputColorBuffer->setData(buildZeroBuffer(4 * pMatInterpolationMatrix->rows()));
         m_pSignalDataBuffer->setData(buildZeroBuffer(pMatInterpolationMatrix->cols()));
 
@@ -193,8 +192,10 @@ void GpuInterpolationItem::setInterpolationMatrix(QSharedPointer<Eigen::SparseMa
 
         //qDebug() << "4 * pMatInterpolationMatrix->rows()"<<4 * pMatInterpolationMatrix->rows();
         //qDebug() << "pMatInterpolationMatrix->rows()*pMatInterpolationMatrix->cols()"<<pMatInterpolationMatrix->rows()*pMatInterpolationMatrix->cols();
-    } else {
-        m_pInterpolationMatBuffer->updateData(0, interpolationBufferData);
+    }
+
+    m_pInterpolationMatBuffer->setData(interpolationBufferData);
+
 //        QByteArray updateData;
 //        updateData.resize(pMatInterpolationMatrix->cols() * sizeof(float));
 //        float *rawVertexArray = reinterpret_cast<float *>(updateData.data());
@@ -214,7 +215,6 @@ void GpuInterpolationItem::setInterpolationMatrix(QSharedPointer<Eigen::SparseMa
 //            m_pInterpolationMatBuffer->updateData(pos, updateData);
 //            pos += pMatInterpolationMatrix->cols() * sizeof(float); //stride
 //        }
-    }
 
     qDebug("GpuInterpolationItem::setInterpolationMatrix - finished");
 }

--- a/libraries/disp3D/engine/model/items/common/gpuinterpolationitem.cpp
+++ b/libraries/disp3D/engine/model/items/common/gpuinterpolationitem.cpp
@@ -179,6 +179,7 @@ void GpuInterpolationItem::setInterpolationMatrix(QSharedPointer<Eigen::SparseMa
 
         m_pInterpolationMatBuffer->setData(interpolationBufferData);
         m_pOutputColorBuffer->setData(buildZeroBuffer(4 * pMatInterpolationMatrix->rows()));
+        m_pSignalDataBuffer->setData(buildZeroBuffer(pMatInterpolationMatrix->cols()));
 
         //Set work group size
         if(!m_pComputeCommand) {
@@ -239,13 +240,7 @@ void GpuInterpolationItem::addNewRtData(const VectorXf &tSignalVec)
         rawVertexArray[i] = static_cast<float>(tSignalVec[i]);
     }
 
-    //Init and set signal data buffer
-    if(m_pSignalDataBuffer->data().size() != bufferData.size()) {
-        m_pSignalDataBuffer->setData(bufferData);
-        this->setMaterialParameter(QVariant::fromValue(m_pSignalDataBuffer.data()), QStringLiteral("InputVec"));
-    } else {
-        m_pSignalDataBuffer->updateData(0, bufferData);
-    }
+    m_pSignalDataBuffer->setData(bufferData);
 }
 
 
@@ -299,7 +294,7 @@ QByteArray GpuInterpolationItem::buildInterpolationMatrixBuffer(QSharedPointer<E
     unsigned int iCtr = 0;
     for(uint i = 0; i < iRows; ++i) {
         for(uint j = 0; j < iCols; ++j) {
-            rawVertexArray[iCtr] = pMatInterpolationMatrix->coeff(i, j);
+            rawVertexArray[iCtr] = static_cast<float>(pMatInterpolationMatrix->coeff(i, j));
             iCtr++;
         }
     }

--- a/libraries/disp3D/engine/model/items/common/gpuinterpolationitem.h
+++ b/libraries/disp3D/engine/model/items/common/gpuinterpolationitem.h
@@ -195,6 +195,7 @@ protected:
     QPointer<GpuInterpolationMaterial>      m_pGPUMaterial;                 /**< Compute material used for the process. */
 
     QPointer<CustomMesh>                    m_pCustomMesh;                  /**< The actual mesh information (vertices, normals, colors). */
+    QPointer<Qt3DRender::QComputeCommand>   m_pComputeCommand;              /**< The compute command defines the work group size for the compute shader code execution . */
 
     QPointer<Qt3DRender::QBuffer>           m_pInterpolationMatBuffer;      /**< The QBuffer/GLBuffer holding the interpolation matrix data. */
     QPointer<Qt3DRender::QBuffer>           m_pOutputColorBuffer;           /**< The QBuffer/GLBuffer holding the output color (interpolated) data. */


### PR DESCRIPTION
# Gpu Interpolation Improvements

Made some small changes to the Gpu interpolation and geometry multiplier:
- Replaced QBuffer::updateData with setData. This was suggested here: https://bugreports.qt.io/browse/QTBUG-50720
- Fixed the bug "No shader program found" when running Disp3D in debug mode
- Moved the compute command and work group size definition to the right position.
