### PR TITLE
Introduce intermediate data for connectivity calculation

### DIFF
--- a/applications/mne_scan/libs/scDisp/realtimeconnectivityestimatewidget.cpp
+++ b/applications/mne_scan/libs/scDisp/realtimeconnectivityestimatewidget.cpp
@@ -129,7 +129,24 @@ void RealTimeConnectivityEstimateWidget::getData()
         if(!m_pRtItem) {
             //qDebug()<<"RealTimeConnectivityEstimateWidget::getData - Creating m_pRtItem";
             m_pRtItem = m_pNetworkView->addData(*(m_pRTCE->getValue().data()));
-            init();
+
+            if(m_pRTCE->getSurfSet() && m_pRTCE->getAnnotSet()) {
+                QList<FsSurfaceTreeItem*> lSurfaces = m_pNetworkView->getTreeModel()->addSurfaceSet("sample",
+                                                                                                    "MRI",
+                                                                                                    *(m_pRTCE->getSurfSet().data()),
+                                                                                                    *(m_pRTCE->getAnnotSet().data()));
+
+                for(int i = 0; i < lSurfaces.size(); i++) {
+                    lSurfaces.at(i)->setAlpha(0.3f);
+                }
+            }
+
+            if(m_pRTCE->getSensorSurface() && m_pRTCE->getFiffInfo()) {
+                m_pNetworkView->getTreeModel()->addMegSensorInfo("sample",
+                                                                 "Sensors",
+                                                                 m_pRTCE->getFiffInfo()->chs,
+                                                                 *(m_pRTCE->getSensorSurface()));
+            }
         } else {
             //qDebug()<<"RealTimeConnectivityEstimateWidget::getData - Working with m_pRtItem";
             m_pRtItem->addData(*(m_pRTCE->getValue().data()));
@@ -142,23 +159,7 @@ void RealTimeConnectivityEstimateWidget::getData()
 
 void RealTimeConnectivityEstimateWidget::init()
 {
-    if(m_pRTCE->getSurfSet() && m_pRTCE->getAnnotSet()) {
-        QList<FsSurfaceTreeItem*> lSurfaces = m_pNetworkView->getTreeModel()->addSurfaceSet("sample",
-                                                                                            "MRI",
-                                                                                            *(m_pRTCE->getSurfSet().data()),
-                                                                                            *(m_pRTCE->getAnnotSet().data()));
 
-        for(int i = 0; i < lSurfaces.size(); i++) {
-            lSurfaces.at(i)->setAlpha(0.3f);
-        }
-    }
-
-    if(m_pRTCE->getSensorSurface() && m_pRTCE->getFiffInfo()) {
-        m_pNetworkView->getTreeModel()->addMegSensorInfo("sample",
-                                                         "Sensors",
-                                                         m_pRTCE->getFiffInfo()->chs,
-                                                         *(m_pRTCE->getSensorSurface()));
-    }
 
 }
 

--- a/applications/mne_scan/plugins/babymeg/babymeg.cpp
+++ b/applications/mne_scan/plugins/babymeg/babymeg.cpp
@@ -854,7 +854,7 @@ void BabyMEG::createDigTrig(MatrixXf& data)
     QMap<int,QList<QPair<int,double> > > qMapDetectedTrigger = DetectTrigger::detectTriggerFlanksGrad(data.cast<double>(),
                                                                                                       m_lTriggerChannelIndices,
                                                                                                       0,
-                                                                                                      3.0,
+                                                                                                      1.0,
                                                                                                       false,
                                                                                                       "Rising",
                                                                                                       400);

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
@@ -557,14 +557,14 @@ void NeuronalConnectivity::run()
         {
             //QMutexLocker locker(&m_mutex);
             //Do connectivity estimation here
-            Network connectivityResult = m_pCircularNetworkBuffer->pop();
+            m_currentConnectivityResult = m_pCircularNetworkBuffer->pop();
 
             //Send the data to the connected plugins and the online display
-            if(!connectivityResult.isEmpty()) {
+            if(!m_currentConnectivityResult.isEmpty()) {
                 //qDebug()<<"NeuronalConnectivity::run - Total time"<<m_timer.elapsed();
-                connectivityResult.setFrequencyBins(m_iFreqBandLow, m_iFreqBandHigh);
-                connectivityResult.normalize();
-                m_pRTCEOutput->data()->setValue(connectivityResult);
+                m_currentConnectivityResult.setFrequencyBins(m_iFreqBandLow, m_iFreqBandHigh);
+                m_currentConnectivityResult.normalize();
+                m_pRTCEOutput->data()->setValue(m_currentConnectivityResult);
             }
         }
 
@@ -628,6 +628,13 @@ void NeuronalConnectivity::onFrequencyBandChanged(int iFreqLow, int iFreqHigh)
     // Convert to frequency bins
     m_iFreqBandLow = iFreqLow * dScaleFactor;
     m_iFreqBandHigh = iFreqHigh * dScaleFactor;
+
+    //QMutexLocker locker(&m_mutex);
+    if(!m_currentConnectivityResult.isEmpty()) {
+        m_currentConnectivityResult.setFrequencyBins(m_iFreqBandLow, m_iFreqBandHigh);
+        m_currentConnectivityResult.normalize();
+        m_pCircularNetworkBuffer->push(m_currentConnectivityResult);
+    }
 
     //qDebug() << "NeuronalConnectivity::onFrequencyBandChanged - m_iFreqBandLow" << m_iFreqBandLow;
     //qDebug() << "NeuronalConnectivity::onFrequencyBandChanged - m_iFreqBandHigh" << m_iFreqBandHigh;

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
@@ -166,7 +166,8 @@ void NeuronalConnectivity::init()
     m_pCircularNetworkBuffer = QSharedPointer<CircularBuffer<CONNECTIVITYLIB::Network> >(new CircularBuffer<CONNECTIVITYLIB::Network>(10));
 
     //Init connectivity settings
-    m_connectivitySettings.m_sConnectivityMethods = QStringList() << "COH";
+    m_sConnectivityMethods = QStringList() << "COR";
+    m_connectivitySettings.m_sConnectivityMethods = m_sConnectivityMethods;
     m_connectivitySettings.m_sWindowType = "Hanning";
 }
 
@@ -578,6 +579,7 @@ void NeuronalConnectivity::onNewConnectivityResultAvailable(const Network& conne
 {
     //QMutexLocker locker(&m_mutex);
     m_connectivitySettings = connectivitySettings;
+    m_connectivitySettings.m_sConnectivityMethods = m_sConnectivityMethods;
     m_pCircularNetworkBuffer->push(connectivityResult);
 }
 
@@ -587,7 +589,7 @@ void NeuronalConnectivity::onNewConnectivityResultAvailable(const Network& conne
 void NeuronalConnectivity::onMetricChanged(const QString& sMetric)
 {
     m_pRtConnectivity->restart();
-    m_connectivitySettings.m_sConnectivityMethods = QStringList() << sMetric;
+    m_sConnectivityMethods = QStringList() << sMetric;
 }
 
 

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
@@ -590,6 +590,10 @@ void NeuronalConnectivity::onNewConnectivityResultAvailable(const Network& conne
 
 void NeuronalConnectivity::onMetricChanged(const QString& sMetric)
 {
+    if(m_sConnectivityMethods.contains(sMetric)) {
+        return;
+    }
+
     m_pRtConnectivity->restart();
     m_sConnectivityMethods = QStringList() << sMetric;
 }

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
@@ -524,6 +524,9 @@ void NeuronalConnectivity::generateNodeVertices()
         bPick = false;
     }
 
+    // Set sampling frequency so that the spectrum resolution is updated
+    m_connectivitySettings.setSamplingFrequency(m_pFiffInfo->sfreq);
+
     //Set node 3D positions to connectivity settings
     m_connectivitySettings.setNodePositions(m_matNodeVertComb);
     m_connectivitySettings.clearAllData();

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
@@ -167,8 +167,8 @@ void NeuronalConnectivity::init()
 
     //Init connectivity settings
     m_sConnectivityMethods = QStringList() << "COR";
-    m_connectivitySettings.m_sConnectivityMethods = m_sConnectivityMethods;
-    m_connectivitySettings.m_sWindowType = "Hanning";
+    m_connectivitySettings.setConnectivityMethods(m_sConnectivityMethods);
+    m_connectivitySettings.setWindowType("Hanning");
 }
 
 
@@ -278,7 +278,7 @@ void NeuronalConnectivity::updateSource(SCMEASLIB::Measurement::SPtr pMeasuremen
             m_matNodeVertComb << m_matNodeVertLeft, m_matNodeVertRight;
 
             //Set node 3D positions to connectivity settings
-            m_connectivitySettings.m_matNodePositions = m_matNodeVertComb;            
+            m_connectivitySettings.setNodePositions(m_matNodeVertComb);
         }
 
         for(qint32 i = 0; i < pRTSE->getValue().size(); ++i) {
@@ -286,8 +286,8 @@ void NeuronalConnectivity::updateSource(SCMEASLIB::Measurement::SPtr pMeasuremen
 
             // Check row and colum integrity and restart if necessary
             if(m_connectivitySettings.size() != 0) {
-                if(m_iBlockSize != m_connectivitySettings.m_dataList.first().matData.cols()) {
-                    m_connectivitySettings.clearData();
+                if(m_iBlockSize != m_connectivitySettings.at(0).matData.cols()) {
+                    m_connectivitySettings.clearAllData();
                     m_pRtConnectivity->restart();
                 }
             }
@@ -343,7 +343,6 @@ void NeuronalConnectivity::updateRTMSA(SCMEASLIB::Measurement::SPtr pMeasurement
             }
 
             MatrixXd data;
-            QList<MatrixXd> epochDataList;
 
             for(qint32 i = 0; i < pRTMSA->getMultiSampleArray().size(); ++i) {
                 const MatrixXd& t_mat = pRTMSA->getMultiSampleArray()[i];
@@ -351,8 +350,8 @@ void NeuronalConnectivity::updateRTMSA(SCMEASLIB::Measurement::SPtr pMeasurement
 
                 // Check row and colum integrity and restart if necessary
                 if(m_connectivitySettings.size() != 0) {
-                    if(m_iBlockSize != m_connectivitySettings.m_dataList.first().matData.cols()) {
-                        m_connectivitySettings.clearData();
+                    if(m_iBlockSize != m_connectivitySettings.at(0).matData.cols()) {
+                        m_connectivitySettings.clearAllData();
                         m_pRtConnectivity->restart();
                     }
                 }
@@ -437,8 +436,8 @@ void NeuronalConnectivity::updateRTEV(SCMEASLIB::Measurement::SPtr pMeasurement)
 
                     // Check row and colum integrity and restart if necessary
                     if(m_connectivitySettings.size() != 0) {
-                        if(m_iBlockSize != m_connectivitySettings.m_dataList.first().matData.cols()) {
-                            m_connectivitySettings.clearData();
+                        if(m_iBlockSize != m_connectivitySettings.at(0).matData.cols()) {
+                            m_connectivitySettings.clearAllData();
                             m_pRtConnectivity->restart();
                         }
                     }
@@ -526,8 +525,8 @@ void NeuronalConnectivity::generateNodeVertices()
     }
 
     //Set node 3D positions to connectivity settings
-    m_connectivitySettings.m_matNodePositions = m_matNodeVertComb;
-    m_connectivitySettings.clearData();
+    m_connectivitySettings.setNodePositions(m_matNodeVertComb);
+    m_connectivitySettings.clearAllData();
 }
 
 
@@ -579,7 +578,7 @@ void NeuronalConnectivity::onNewConnectivityResultAvailable(const Network& conne
 {
     //QMutexLocker locker(&m_mutex);
     m_connectivitySettings = connectivitySettings;
-    m_connectivitySettings.m_sConnectivityMethods = m_sConnectivityMethods;
+    m_connectivitySettings.setConnectivityMethods(m_sConnectivityMethods);
     m_pCircularNetworkBuffer->push(connectivityResult);
 }
 
@@ -605,9 +604,9 @@ void NeuronalConnectivity::onNumberTrialsChanged(int iNumberTrials)
 
 void NeuronalConnectivity::onWindowTypeChanged(const QString& windowType)
 {
-    if(m_connectivitySettings.m_sWindowType != windowType) {
-        m_connectivitySettings.resetData();
-        m_connectivitySettings.m_sWindowType = windowType;
+    if(m_connectivitySettings.getWindowType() != windowType) {
+        m_connectivitySettings.clearIntermediateData();
+        m_connectivitySettings.setWindowType(windowType);
     }
 }
 
@@ -617,7 +616,7 @@ void NeuronalConnectivity::onWindowTypeChanged(const QString& windowType)
 void NeuronalConnectivity::onTriggerTypeChanged(const QString& triggerType)
 {
     if(triggerType != m_sAvrType) {
-        m_connectivitySettings.clearData();
+        m_connectivitySettings.clearAllData();
         m_sAvrType = triggerType;
     }
 }

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.cpp
@@ -298,11 +298,7 @@ void NeuronalConnectivity::updateSource(SCMEASLIB::Measurement::SPtr pMeasuremen
         //Pop data from buffer
         if(m_connectivitySettings.size() > m_iNumberAverages) {
             m_pRtConnectivity->restart();
-            int size = m_connectivitySettings.size();
-
-            for(int i = 0; i < size-m_iNumberAverages; ++i) {
-                m_connectivitySettings.removeFirst();
-            }
+            m_connectivitySettings.removeFirst(m_connectivitySettings.size()-m_iNumberAverages);
         }
 
         m_timer.restart();
@@ -369,10 +365,7 @@ void NeuronalConnectivity::updateRTMSA(SCMEASLIB::Measurement::SPtr pMeasurement
             if(m_connectivitySettings.size() > m_iNumberAverages) {
                 m_pRtConnectivity->restart();
                 int size = m_connectivitySettings.size();
-
-                for(int i = 0; i < size-m_iNumberAverages; ++i) {
-                    m_connectivitySettings.removeFirst();
-                }
+                m_connectivitySettings.removeFirst(m_connectivitySettings.size()-m_iNumberAverages);
             }
 
             m_timer.restart();
@@ -454,11 +447,7 @@ void NeuronalConnectivity::updateRTEV(SCMEASLIB::Measurement::SPtr pMeasurement)
                     //Pop data from buffer
                     if(m_connectivitySettings.size() > m_iNumberAverages) {
                         m_pRtConnectivity->restart();
-                        int size = m_connectivitySettings.size();
-
-                        for(int i = 0; i < size-m_iNumberAverages; ++i) {
-                            m_connectivitySettings.removeFirst();
-                        }
+                        m_connectivitySettings.removeFirst(m_connectivitySettings.size()-m_iNumberAverages);
                     }
 
                     m_timer.restart();

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.h
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.h
@@ -248,6 +248,7 @@ private:
     qint32              m_iBlockSize;           /**< The block size of teh last received data block. In frequency bins. */
 
     QString             m_sAvrType;             /**< The average type */
+    QStringList         m_sConnectivityMethods; /**< The connectivity metric to use */
 
     QMutex              m_mutex;
 

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.h
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.h
@@ -194,7 +194,8 @@ protected:
     *
     * @param [in] connectivityResult        The new connectivity estimate
     */
-    void onNewConnectivityResultAvailable(const CONNECTIVITYLIB::Network& connectivityResult);
+    void onNewConnectivityResultAvailable(const CONNECTIVITYLIB::Network& connectivityResult,
+                                          const CONNECTIVITYLIB::ConnectivitySettings& connectivitySettings);
 
     //=========================================================================================================
     /**

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.h
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.h
@@ -266,12 +266,14 @@ private:
 
     SCSHAREDLIB::PluginOutputData<SCMEASLIB::RealTimeConnectivityEstimate>::SPtr    m_pRTCEOutput;                  /**< The RealTimeSourceEstimate output.*/
 
-    CONNECTIVITYLIB::Network    m_connectivityEstimate;     /**< The current connectivity estimate.*/
-    Eigen::MatrixX3f            m_matNodeVertLeft;          /**< Holds the left hemi vertex postions of the network nodes. Corresponding to the neuronal sources.*/
-    Eigen::MatrixX3f            m_matNodeVertRight;         /**< Holds the right hemi vertex postions of the network nodes. Corresponding to the neuronal sources.*/
-    Eigen::MatrixX3f            m_matNodeVertComb;          /**< Holds both hemi vertex postions of the network nodes. Corresponding to the neuronal sources.*/
+    CONNECTIVITYLIB::Network    m_connectivityEstimate;         /**< The current connectivity estimate.*/
+    Eigen::MatrixX3f            m_matNodeVertLeft;              /**< Holds the left hemi vertex postions of the network nodes. Corresponding to the neuronal sources.*/
+    Eigen::MatrixX3f            m_matNodeVertRight;             /**< Holds the right hemi vertex postions of the network nodes. Corresponding to the neuronal sources.*/
+    Eigen::MatrixX3f            m_matNodeVertComb;              /**< Holds both hemi vertex postions of the network nodes. Corresponding to the neuronal sources.*/
 
-    QVector<int>                m_chIdx;                    /**< The channel indeces to pick from the incoming data.*/
+    QVector<int>                m_chIdx;                        /**< The channel indeces to pick from the incoming data.*/
+
+    CONNECTIVITYLIB::Network    m_currentConnectivityResult;    /**< The current connectivity result.*/
 };
 
 } // NAMESPACE

--- a/applications/mne_scan/plugins/noise/noiseestimate.cpp
+++ b/applications/mne_scan/plugins/noise/noiseestimate.cpp
@@ -224,7 +224,7 @@ IPlugin::PluginType NoiseEstimate::getType() const
 
 QString NoiseEstimate::getName() const
 {
-    return "Noise Estimation";
+    return "Spectrum";
 }
 
 

--- a/applications/mne_scan/plugins/noisereduction/noisereduction.cpp
+++ b/applications/mne_scan/plugins/noisereduction/noisereduction.cpp
@@ -226,7 +226,7 @@ IPlugin::PluginType NoiseReduction::getType() const
 
 QString NoiseReduction::getName() const
 {
-    return "NoiseReduction";
+    return "Noise Reduction";
 }
 
 

--- a/examples/ex_connectivity/connectivitysettingsmanager.h
+++ b/examples/ex_connectivity/connectivitysettingsmanager.h
@@ -106,15 +106,16 @@ public:
         m_iFreqBandHigh = 50 * dScaleFactor;
     }
 
-    ConnectivitySettings    m_settings;
-    RtConnectivity::SPtr    m_pRtConnectivity;
-    QList<Eigen::MatrixXd>  m_matDataListOriginal;
-    Network                 m_networkData;
+    ConnectivitySettings            m_settings;
+    RtConnectivity::SPtr            m_pRtConnectivity;
+    QList<Eigen::MatrixXd>          m_matDataListOriginal;
+    QList<ConnectivityTrialData>    m_dataListOriginal;
+    Network                         m_networkData;
 
-    int                     m_iFreqBandLow;
-    int                     m_iFreqBandHigh;
+    int                             m_iFreqBandLow;
+    int                             m_iFreqBandHigh;
 
-    float                   m_fSFreq;
+    float                           m_fSFreq;
 
     void onConnectivityMetricChanged(const QString& sMetric)
     {
@@ -127,11 +128,11 @@ public:
 
     void onNumberTrialsChanged(int iNumberTrials)
     {
-        if(iNumberTrials > m_matDataListOriginal.size()) {
-            iNumberTrials = m_matDataListOriginal.size();
+        if(iNumberTrials > m_dataListOriginal.size()) {
+            iNumberTrials = m_dataListOriginal.size();
         }
 
-        m_settings.m_matDataList.clear();
+        m_settings.m_dataList.clear();
         QVector<int> indexList;
 
         for(int i = 0; i < iNumberTrials; i++) {
@@ -147,8 +148,7 @@ public:
                 }
             }
 
-            m_settings.m_matDataList << m_matDataListOriginal.at(index);
-            //m_settings.m_matDataList << m_matDataListOriginal.at(i);
+            m_settings.m_dataList << m_dataListOriginal.at(index);
         }
 
         //qDebug() << "ConnectivitySettingsManager::onNumberTrialsChanged - indexList" << indexList;
@@ -158,12 +158,12 @@ public:
 
     void onFreqBandChanged(int iFreqLow, int iFreqHigh)
     {
-        if(m_settings.m_matDataList.isEmpty()) {
+        if(m_settings.m_dataList.isEmpty()) {
             return;
         }
 
         // By default the number of frequency bins is half the signal since we only use the half spectrum
-        double dScaleFactor = m_settings.m_matDataList.first().cols()/m_fSFreq;
+        double dScaleFactor = m_settings.m_dataList.first().matData.cols()/m_fSFreq;
 
         // Convert to frequency bins
         m_iFreqBandLow = iFreqLow * dScaleFactor;

--- a/examples/ex_connectivity/connectivitysettingsmanager.h
+++ b/examples/ex_connectivity/connectivitysettingsmanager.h
@@ -132,10 +132,26 @@ public:
         }
 
         m_settings.m_matDataList.clear();
+        QVector<int> indexList;
 
         for(int i = 0; i < iNumberTrials; i++) {
-            m_settings.m_matDataList << m_matDataListOriginal.at(i);
+            bool finish = false;
+            int index = 0;
+
+            while(!finish) {
+                index = rand() % iNumberTrials;
+
+                if(!indexList.contains(index)) {
+                    indexList.append(index);
+                    finish = true;
+                }
+            }
+
+            m_settings.m_matDataList << m_matDataListOriginal.at(index);
+            //m_settings.m_matDataList << m_matDataListOriginal.at(i);
         }
+
+        //qDebug() << "ConnectivitySettingsManager::onNumberTrialsChanged - indexList" << indexList;
 
         m_pRtConnectivity->append(m_settings);
     }

--- a/examples/ex_connectivity/connectivitysettingsmanager.h
+++ b/examples/ex_connectivity/connectivitysettingsmanager.h
@@ -54,13 +54,13 @@
 
 #include <QWidget>
 #include <QDebug>
+#include <QElapsedTimer>
 
 
 //*************************************************************************************************************
 //=============================================================================================================
 // Eigen INCLUDES
 //=============================================================================================================
-
 
 
 //*************************************************************************************************************
@@ -134,6 +134,10 @@ public:
 
     void onNumberTrialsChanged(int iNumberTrials)
     {
+        QElapsedTimer timer;
+        qint64 iTime = 0;
+        timer.start();
+
         if(iNumberTrials > m_dataListOriginal.size()) {
             iNumberTrials = m_dataListOriginal.size();
         }
@@ -176,6 +180,10 @@ public:
         //qDebug() << "ConnectivitySettingsManager::onNumberTrialsChanged - m_indexList" << m_indexList;
 
         m_pRtConnectivity->append(m_settings);
+
+        iTime = timer.elapsed();
+        qDebug() << "Coherency::computeCoherencyImag timer - Preparation:" << iTime;
+        timer.restart();
     }
 
     void onFreqBandChanged(int iFreqLow, int iFreqHigh)

--- a/examples/ex_connectivity/connectivitysettingsmanager.h
+++ b/examples/ex_connectivity/connectivitysettingsmanager.h
@@ -150,31 +150,23 @@ public:
         int size = m_settings.size();
 
         if(size > iNumberTrials) {
-            m_pRtConnectivity->restart();
-
-            for(int i = 0; i < size-iNumberTrials; ++i) {
-                m_settings.removeFirst();
-
-                if(!m_indexList.isEmpty()) {
-                    m_indexList.pop_front();
-                }
-            }
+            m_settings.removeFirst(size-iNumberTrials);
         }
 
         while(m_settings.size() < iNumberTrials) {
-            bool finish = false;
-            int index = 0;
+//            bool finish = false;
+//            int index = 0;
 
-            while(!finish) {
-                index = rand() % iNumberTrials;
+//            while(!finish) {
+//                index = rand() % iNumberTrials;
 
-                if(!m_indexList.contains(index)) {
-                    m_indexList.append(index);
-                    finish = true;
-                }
-            }
+//                if(!m_indexList.contains(index)) {
+//                    m_indexList.append(index);
+//                    finish = true;
+//                }
+//            }
 
-            m_settings.append(m_dataListOriginal.at(index));
+            m_settings.append(m_dataListOriginal.at(m_settings.size()));
         }
 
         //qDebug() << "ConnectivitySettingsManager::onNumberTrialsChanged - m_indexList" << m_indexList;

--- a/examples/ex_connectivity/connectivitysettingsmanager.h
+++ b/examples/ex_connectivity/connectivitysettingsmanager.h
@@ -169,11 +169,13 @@ public:
         m_iFreqBandLow = iFreqLow * dScaleFactor;
         m_iFreqBandHigh = iFreqHigh * dScaleFactor;
 
-        onNewConnectivityResultAvailable(m_networkData);
+        onNewConnectivityResultAvailable(m_networkData, m_settings);
     }
 
-    void onNewConnectivityResultAvailable(const Network& tNetworkData)
+    void onNewConnectivityResultAvailable(const Network& tNetworkData,
+                                          const ConnectivitySettings& connectivitySettings)
     {
+        m_settings = connectivitySettings;
         m_networkData = tNetworkData;
         m_networkData.setFrequencyBins(m_iFreqBandLow, m_iFreqBandHigh);
         m_networkData.normalize();

--- a/examples/ex_connectivity/main.cpp
+++ b/examples/ex_connectivity/main.cpp
@@ -132,19 +132,19 @@ int main(int argc, char *argv[])
     QCommandLineOption tMinOption("tmin", "The time minimum value for averaging in seconds relativ to the trigger onset.", "value", "-0.1");
     QCommandLineOption tMaxOption("tmax", "The time maximum value for averaging in seconds relativ to the trigger onset.", "value", "1.0");
 
-//    QCommandLineOption eventsFileOption("eve", "Path to the event <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw-eve.fif");
-//    QCommandLineOption rawFileOption("raw", "Path to the raw <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw.fif");
-//    QCommandLineOption subjectOption("subj", "Selected <subject> (for source level usage only).", "subject", "sample");
-//    QCommandLineOption subjectPathOption("subjDir", "Selected <subjectPath> (for source level usage only).", "subjectPath", QCoreApplication::applicationDirPath() + "/MNE-sample-data/subjects");
-//    QCommandLineOption fwdOption("fwd", "Path to forwad solution <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif");
-//    QCommandLineOption covFileOption("cov", "Path to the covariance <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-cov.fif");
+    QCommandLineOption eventsFileOption("eve", "Path to the event <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw-eve.fif");
+    QCommandLineOption rawFileOption("raw", "Path to the raw <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw.fif");
+    QCommandLineOption subjectOption("subj", "Selected <subject> (for source level usage only).", "subject", "sample");
+    QCommandLineOption subjectPathOption("subjDir", "Selected <subjectPath> (for source level usage only).", "subjectPath", QCoreApplication::applicationDirPath() + "/MNE-sample-data/subjects");
+    QCommandLineOption fwdOption("fwd", "Path to forwad solution <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif");
+    QCommandLineOption covFileOption("cov", "Path to the covariance <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-cov.fif");
 
-    QCommandLineOption eventsFileOption("eve", "Path to the event <file>.", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_raw-eve.fif");
-    QCommandLineOption rawFileOption("raw", "Path to the raw <file>.", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_cut_raw.fif");
-    QCommandLineOption subjectOption("subj", "Selected <subject> (for source level usage only).", "subject", "jgs-20160519");
-    QCommandLineOption subjectPathOption("subjDir", "Selected <subjectPath> (for source level usage only).", "subjectPath", "/cluster/fusion/lesch/data/subjects");
-    QCommandLineOption fwdOption("fwd", "Path to forwad solution <file> (for source level usage only).", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/fwd_jgws-fwd.fif");
-    QCommandLineOption covFileOption("cov", "Path to the covariance <file> (for source level usage only).", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/ASSR-cov.fif");
+//    QCommandLineOption eventsFileOption("eve", "Path to the event <file>.", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_raw-eve.fif");
+//    QCommandLineOption rawFileOption("raw", "Path to the raw <file>.", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_cut_raw.fif");
+//    QCommandLineOption subjectOption("subj", "Selected <subject> (for source level usage only).", "subject", "jgs-20160519");
+//    QCommandLineOption subjectPathOption("subjDir", "Selected <subjectPath> (for source level usage only).", "subjectPath", "/cluster/fusion/lesch/data/subjects");
+//    QCommandLineOption fwdOption("fwd", "Path to forwad solution <file> (for source level usage only).", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/fwd_jgws-fwd.fif");
+//    QCommandLineOption covFileOption("cov", "Path to the covariance <file> (for source level usage only).", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/ASSR-cov.fif");
 
     parser.addOption(annotOption);
     parser.addOption(subjectOption);
@@ -236,8 +236,8 @@ int main(int argc, char *argv[])
                                                          fTMin,
                                                          fTMax,
                                                          iEvent,
-                                                         1.75*pow(10.0,-12),
-                                                         "mag");
+                                                         150*pow(10.0,-06),
+                                                         "eog");
     data.dropRejected();
 
     FiffEvoked evoked = data.average(raw.info,

--- a/examples/ex_connectivity/main.cpp
+++ b/examples/ex_connectivity/main.cpp
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
     QCommandLineOption sourceLocMethodOption("sourceLocMethod", "Inverse estimation <method> (for source level usage only), i.e., 'MNE', 'dSPM' or 'sLORETA'.", "method", "dSPM");
     QCommandLineOption connectMethodOption("connectMethod", "Connectivity <method>, i.e., 'COR', 'XCOR.", "method", "COR");
     QCommandLineOption snrOption("snr", "The SNR <value> used for computation (for source level usage only).", "value", "1.0");
-    QCommandLineOption evokedIndexOption("aveIdx", "The average <index> to choose from the average file.", "index", "3");
+    QCommandLineOption evokedIndexOption("aveIdx", "The average <index> to choose from the average file.", "index", "4");
     QCommandLineOption coilTypeOption("coilType", "The coil <type> (for sensor level usage only), i.e. 'grad' or 'mag'.", "type", "grad");
     QCommandLineOption chTypeOption("chType", "The channel <type> (for sensor level usage only), i.e. 'eeg' or 'meg'.", "type", "meg");
     QCommandLineOption tMinOption("tmin", "The time minimum value for averaging in seconds relativ to the trigger onset.", "value", "-0.1");
@@ -285,7 +285,11 @@ int main(int argc, char *argv[])
         QString method(sSourceLocMethod);
 
         // regularize noise covariance
-        noise_cov = noise_cov.regularize(raw.info, 0.05, 0.05, 0.1, true);
+        noise_cov = noise_cov.regularize(raw.info,
+                                         0.05,
+                                         0.05,
+                                         0.1,
+                                         true);
 
         // Cluster forward solution;
         if(bDoClust) {
@@ -294,7 +298,11 @@ int main(int argc, char *argv[])
             t_clusteredFwd = t_Fwd;
         }
 
-        MNEInverseOperator inverse_operator(raw.info, t_clusteredFwd, noise_cov, 0.2f, 0.8f);
+        MNEInverseOperator inverse_operator(raw.info,
+                                            t_clusteredFwd,
+                                            noise_cov,
+                                            0.2f,
+                                            0.8f);
 
         // Compute inverse solution
         MinimumNorm minimumNorm(inverse_operator, lambda2, method);
@@ -306,7 +314,7 @@ int main(int argc, char *argv[])
         for(int i = 0; i < data.size(); i++) {
             sourceEstimate = minimumNorm.calculateInverse(data.at(i)->epoch,
                                                           0.0f,
-                                                          1/raw.info.sfreq);
+                                                          1.0/raw.info.sfreq);
 
             if(sourceEstimate.isEmpty()) {
                 printf("Source estimate is empty");

--- a/examples/ex_connectivity/main.cpp
+++ b/examples/ex_connectivity/main.cpp
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
     QCommandLineOption sourceLocOption("doSourceLoc", "Do source localization (for source level usage only).", "doSourceLoc", "false");
     QCommandLineOption clustOption("doClust", "Do clustering of source space (for source level usage only).", "doClust", "true");
     QCommandLineOption sourceLocMethodOption("sourceLocMethod", "Inverse estimation <method> (for source level usage only), i.e., 'MNE', 'dSPM' or 'sLORETA'.", "method", "dSPM");
-    QCommandLineOption connectMethodOption("connectMethod", "Connectivity <method>, i.e., 'COR', 'XCOR.", "method", "COH");
+    QCommandLineOption connectMethodOption("connectMethod", "Connectivity <method>, i.e., 'COR', 'XCOR.", "method", "COR");
     QCommandLineOption snrOption("snr", "The SNR <value> used for computation (for source level usage only).", "value", "1.0");
     QCommandLineOption evokedIndexOption("aveIdx", "The average <index> to choose from the average file.", "index", "4");
     QCommandLineOption coilTypeOption("coilType", "The coil <type> (for sensor level usage only), i.e. 'grad' or 'mag'.", "type", "grad");

--- a/examples/ex_connectivity/main.cpp
+++ b/examples/ex_connectivity/main.cpp
@@ -123,28 +123,20 @@ int main(int argc, char *argv[])
     QCommandLineOption annotOption("annotType", "Annotation <type> (for source level usage only).", "type", "aparc.a2009s");
     QCommandLineOption sourceLocOption("doSourceLoc", "Do source localization (for source level usage only).", "doSourceLoc", "false");
     QCommandLineOption clustOption("doClust", "Do clustering of source space (for source level usage only).", "doClust", "true");
-    QCommandLineOption sourceLocMethodOption("sourceLocMethod", "Inverse estimation <method> (for source level usage only), i.e., 'MNE', 'dSPM' or 'sLORETA'.", "method", "MNE");
+    QCommandLineOption sourceLocMethodOption("sourceLocMethod", "Inverse estimation <method> (for source level usage only), i.e., 'MNE', 'dSPM' or 'sLORETA'.", "method", "dSPM");
     QCommandLineOption connectMethodOption("connectMethod", "Connectivity <method>, i.e., 'COR', 'XCOR.", "method", "COR");
     QCommandLineOption snrOption("snr", "The SNR <value> used for computation (for source level usage only).", "value", "1.0");
     QCommandLineOption evokedIndexOption("aveIdx", "The average <index> to choose from the average file.", "index", "1");
     QCommandLineOption coilTypeOption("coilType", "The coil <type> (for sensor level usage only), i.e. 'grad' or 'mag'.", "type", "grad");
     QCommandLineOption chTypeOption("chType", "The channel <type> (for sensor level usage only), i.e. 'eeg' or 'meg'.", "type", "meg");
     QCommandLineOption tMinOption("tmin", "The time minimum value for averaging in seconds relativ to the trigger onset.", "value", "-0.1");
-    QCommandLineOption tMaxOption("tmax", "The time maximum value for averaging in seconds relativ to the trigger onset.", "value", "1.0");
-
+    QCommandLineOption tMaxOption("tmax", "The time maximum value for averaging in seconds relativ to the trigger onset.", "value", "0.6");
     QCommandLineOption eventsFileOption("eve", "Path to the event <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw-eve.fif");
     QCommandLineOption rawFileOption("raw", "Path to the raw <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw.fif");
     QCommandLineOption subjectOption("subj", "Selected <subject> (for source level usage only).", "subject", "sample");
     QCommandLineOption subjectPathOption("subjDir", "Selected <subjectPath> (for source level usage only).", "subjectPath", QCoreApplication::applicationDirPath() + "/MNE-sample-data/subjects");
     QCommandLineOption fwdOption("fwd", "Path to forwad solution <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif");
     QCommandLineOption covFileOption("cov", "Path to the covariance <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-cov.fif");
-
-//    QCommandLineOption eventsFileOption("eve", "Path to the event <file>.", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_raw-eve.fif");
-//    QCommandLineOption rawFileOption("raw", "Path to the raw <file>.", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_cut_raw.fif");
-//    QCommandLineOption subjectOption("subj", "Selected <subject> (for source level usage only).", "subject", "jgs-20160519");
-//    QCommandLineOption subjectPathOption("subjDir", "Selected <subjectPath> (for source level usage only).", "subjectPath", "/cluster/fusion/lesch/data/subjects");
-//    QCommandLineOption fwdOption("fwd", "Path to forwad solution <file> (for source level usage only).", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/fwd_jgws-fwd.fif");
-//    QCommandLineOption covFileOption("cov", "Path to the covariance <file> (for source level usage only).", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/ASSR-cov.fif");
 
     parser.addOption(annotOption);
     parser.addOption(subjectOption);

--- a/examples/ex_connectivity/main.cpp
+++ b/examples/ex_connectivity/main.cpp
@@ -241,6 +241,13 @@ int main(int argc, char *argv[])
             picks = raw.info.pick_types(false,true,false,QStringList(),QStringList() << raw.info.bads << "EOG61");
         } else if(sCoilType.contains("grad", Qt::CaseInsensitive)) {
             picks = raw.info.pick_types(QString("grad"),false,false,QStringList(),QStringList() << raw.info.bads << "EOG61");
+            RowVectorXi picksTmp(picks.cols()/2);
+            int count = 0;
+            for(int i = 0; i < picks.cols(); i+=2) {
+                picksTmp(count) = picks(i);
+                count++;
+            }
+            picks = picksTmp;
         } else if (sCoilType.contains("mag", Qt::CaseInsensitive)) {
             picks = raw.info.pick_types(QString("mag"),false,false,QStringList(),QStringList() << raw.info.bads << "EOG61");
         }
@@ -358,17 +365,17 @@ int main(int argc, char *argv[])
     //Do connectivity estimation and visualize results
     QSharedPointer<ConnectivitySettingsManager> pConnectivitySettingsManager = QSharedPointer<ConnectivitySettingsManager>::create(matDataList.first().cols(), raw.info.sfreq);
 
-    pConnectivitySettingsManager->m_settings.m_sConnectivityMethods << sConnectivityMethod;
+    pConnectivitySettingsManager->m_settings.setConnectivityMethods(QStringList() << sConnectivityMethod);
 
-    ConnectivityTrialData connectivityData;
+    ConnectivitySettings::IntermediateTrialData connectivityData;
     for(int i = 0; i < matDataList.size(); i++) {
         connectivityData.matData = matDataList.at(i);
-        pConnectivitySettingsManager->m_settings.m_dataList.append(connectivityData);
+        pConnectivitySettingsManager->m_settings.append(connectivityData);
         pConnectivitySettingsManager->m_dataListOriginal.append(connectivityData);
     }
-    pConnectivitySettingsManager->m_settings.m_matNodePositions = matNodePositions;
-    pConnectivitySettingsManager->m_settings.m_iNfft = -1;
-    pConnectivitySettingsManager->m_settings.m_sWindowType = "hanning";
+    pConnectivitySettingsManager->m_settings.setNodePositions(matNodePositions);
+    pConnectivitySettingsManager->m_settings.setNumberFFT(-1);
+    pConnectivitySettingsManager->m_settings.setWindowType("hanning");
 
     //Create NetworkView and add extra control widgets to output data (will be used by QuickControlView in RealTimeConnectivityEstimateWidget)
     NetworkView tNetworkView;

--- a/examples/ex_connectivity/main.cpp
+++ b/examples/ex_connectivity/main.cpp
@@ -119,22 +119,30 @@ int main(int argc, char *argv[])
     parser.addHelpOption();
 
     QCommandLineOption annotOption("annotType", "Annotation <type> (for source level usage only).", "type", "aparc.a2009s");
-    QCommandLineOption sourceLocOption("doSourceLoc", "Do source localization (for source level usage only).", "doSourceLoc", "false");
+    QCommandLineOption sourceLocOption("doSourceLoc", "Do source localization (for source level usage only).", "doSourceLoc", "true");
     QCommandLineOption clustOption("doClust", "Do clustering of source space (for source level usage only).", "doClust", "true");
     QCommandLineOption sourceLocMethodOption("sourceLocMethod", "Inverse estimation <method> (for source level usage only), i.e., 'MNE', 'dSPM' or 'sLORETA'.", "method", "dSPM");
     QCommandLineOption connectMethodOption("connectMethod", "Connectivity <method>, i.e., 'COR', 'XCOR.", "method", "COR");
     QCommandLineOption snrOption("snr", "The SNR <value> used for computation (for source level usage only).", "value", "1.0");
-    QCommandLineOption evokedIndexOption("aveIdx", "The average <index> to choose from the average file.", "index", "4");
+    QCommandLineOption evokedIndexOption("aveIdx", "The average <index> to choose from the average file.", "index", "1");
     QCommandLineOption coilTypeOption("coilType", "The coil <type> (for sensor level usage only), i.e. 'grad' or 'mag'.", "type", "grad");
     QCommandLineOption chTypeOption("chType", "The channel <type> (for sensor level usage only), i.e. 'eeg' or 'meg'.", "type", "meg");
     QCommandLineOption tMinOption("tmin", "The time minimum value for averaging in seconds relativ to the trigger onset.", "value", "-0.1");
-    QCommandLineOption tMaxOption("tmax", "The time maximum value for averaging in seconds relativ to the trigger onset.", "value", "0.5");
-    QCommandLineOption eventsFileOption("eve", "Path to the event <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw-eve.fif");
-    QCommandLineOption rawFileOption("raw", "Path to the raw <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw.fif");
-    QCommandLineOption subjectOption("subj", "Selected <subject> (for source level usage only).", "subject", "sample");
-    QCommandLineOption subjectPathOption("subjDir", "Selected <subjectPath> (for source level usage only).", "subjectPath", QCoreApplication::applicationDirPath() + "/MNE-sample-data/subjects");
-    QCommandLineOption fwdOption("fwd", "Path to forwad solution <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif");
-    QCommandLineOption covFileOption("cov", "Path to the covariance <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-cov.fif");
+    QCommandLineOption tMaxOption("tmax", "The time maximum value for averaging in seconds relativ to the trigger onset.", "value", "1.0");
+
+//    QCommandLineOption eventsFileOption("eve", "Path to the event <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw-eve.fif");
+//    QCommandLineOption rawFileOption("raw", "Path to the raw <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw.fif");
+//    QCommandLineOption subjectOption("subj", "Selected <subject> (for source level usage only).", "subject", "sample");
+//    QCommandLineOption subjectPathOption("subjDir", "Selected <subjectPath> (for source level usage only).", "subjectPath", QCoreApplication::applicationDirPath() + "/MNE-sample-data/subjects");
+//    QCommandLineOption fwdOption("fwd", "Path to forwad solution <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif");
+//    QCommandLineOption covFileOption("cov", "Path to the covariance <file> (for source level usage only).", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-cov.fif");
+
+    QCommandLineOption eventsFileOption("eve", "Path to the event <file>.", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_raw-eve.fif");
+    QCommandLineOption rawFileOption("raw", "Path to the raw <file>.", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_cut_raw.fif");
+    QCommandLineOption subjectOption("subj", "Selected <subject> (for source level usage only).", "subject", "jgs-20160519");
+    QCommandLineOption subjectPathOption("subjDir", "Selected <subjectPath> (for source level usage only).", "subjectPath", "/cluster/fusion/lesch/data/subjects");
+    QCommandLineOption fwdOption("fwd", "Path to forwad solution <file> (for source level usage only).", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_raw-fwd.fif");
+    QCommandLineOption covFileOption("cov", "Path to the covariance <file> (for source level usage only).", "file", "/cluster/fusion/lesch/data/MEG/jgs-20160519/assr_40_223_raw-cov.fif");
 
     parser.addOption(annotOption);
     parser.addOption(subjectOption);
@@ -209,7 +217,7 @@ int main(int argc, char *argv[])
     FiffRawData raw(t_fileRaw);
 
     // Select bad channels
-    //raw.info.bads << "MEG2412" << "MEG2413";
+    raw.info.bads << "MEG2412" << "MEG2413";
 
     MNE::setup_compensators(raw,
                             dest_comp,
@@ -220,14 +228,14 @@ int main(int argc, char *argv[])
                      sRaw,
                      events);
 
-    // Read the epochs and reject bad epochs
+    // Read the epochs and reject bad epochs. Note, that SSPs are automatically applied
     MNEEpochDataList data = MNEEpochDataList::readEpochs(raw,
                                                          events,
                                                          fTMin,
                                                          fTMax,
                                                          iEvent,
-                                                         150.0*pow(10.0,-6),
-                                                         "eog");
+                                                         1.75*pow(10.0,-12),
+                                                         "mag");
     data.dropRejected();
 
     FiffEvoked evoked = data.average(raw.info,
@@ -243,10 +251,11 @@ int main(int argc, char *argv[])
             picks = raw.info.pick_types(QString("grad"),false,false,QStringList(),QStringList() << raw.info.bads << "EOG61");
             RowVectorXi picksTmp(picks.cols()/2);
             int count = 0;
-            for(int i = 0; i < picks.cols(); i+=2) {
+            for(int i = 0; i < picks.cols()-1; i+=2) {
                 picksTmp(count) = picks(i);
                 count++;
             }
+            qDebug() << "Picking done";
             picks = picksTmp;
         } else if (sCoilType.contains("mag", Qt::CaseInsensitive)) {
             picks = raw.info.pick_types(QString("mag"),false,false,QStringList(),QStringList() << raw.info.bads << "EOG61");
@@ -314,9 +323,8 @@ int main(int argc, char *argv[])
         MinimumNorm minimumNorm(inverse_operator, lambda2, method);
         minimumNorm.doInverseSetup(1,false);
 
-        picks = raw.info.pick_types(QString("all"),true,false,QStringList(),QStringList() << raw.info.bads << "EOG61");
+        picks = raw.info.pick_types(QString("grad"),false,false,QStringList(),QStringList() << raw.info.bads << "EOG61");
         data.pick_channels(picks);
-
         for(int i = 0; i < data.size(); i++) {
             sourceEstimate = minimumNorm.calculateInverse(data.at(i)->epoch,
                                                           0.0f,
@@ -374,7 +382,7 @@ int main(int argc, char *argv[])
         pConnectivitySettingsManager->m_dataListOriginal.append(connectivityData);
     }
     pConnectivitySettingsManager->m_settings.setNodePositions(matNodePositions);
-    pConnectivitySettingsManager->m_settings.setNumberFFT(-1);
+    pConnectivitySettingsManager->m_settings.setSamplingFrequency(raw.info.sfreq);
     pConnectivitySettingsManager->m_settings.setWindowType("hanning");
 
     //Create NetworkView and add extra control widgets to output data (will be used by QuickControlView in RealTimeConnectivityEstimateWidget)

--- a/examples/ex_spectral/ex_spectral.pro
+++ b/examples/ex_spectral/ex_spectral.pro
@@ -8,7 +8,7 @@
 #
 # @section  LICENSE
 #
-# Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
+# Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 # the following conditions are met:

--- a/examples/ex_spectral/ex_spectral.pro
+++ b/examples/ex_spectral/ex_spectral.pro
@@ -8,7 +8,7 @@
 #
 # @section  LICENSE
 #
-# Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+# Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 # the following conditions are met:

--- a/examples/ex_spectral/main.cpp
+++ b/examples/ex_spectral/main.cpp
@@ -8,7 +8,7 @@
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:

--- a/examples/ex_spectral/main.cpp
+++ b/examples/ex_spectral/main.cpp
@@ -8,7 +8,7 @@
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:

--- a/examples/examples.pro
+++ b/examples/examples.pro
@@ -11,7 +11,7 @@
 #
 # @section  LICENSE
 #
-# Copyright (C) 2010, Christoph Dinh, Lorenz Esch, Florian Schlembach, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen.
+# Copyright (C) 2010, Christoph Dinh, Lorenz Esch, Florian Schlembach, Daniel Strohmeier and Matti Hamalainen.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that

--- a/examples/examples.pro
+++ b/examples/examples.pro
@@ -11,7 +11,7 @@
 #
 # @section  LICENSE
 #
-# Copyright (C) 2010, Christoph Dinh, Lorenz Esch, Florian Schlembach, Daniel Strohmeier and Matti Hamalainen.
+# Copyright (C) 2010, Christoph Dinh, Lorenz Esch, Florian Schlembach, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that

--- a/libraries/connectivity/connectivity.cpp
+++ b/libraries/connectivity/connectivity.cpp
@@ -94,7 +94,7 @@ Connectivity::Connectivity()
 
 //*************************************************************************************************************
 
-Network Connectivity::calculate(const ConnectivitySettings& connectivitySettings)
+Network Connectivity::calculate(ConnectivitySettings& connectivitySettings)
 {
     //TODO: Use multithreading to work on multiple connectivity methods at the same time
     if(connectivitySettings.m_sConnectivityMethods.contains("COR")) {

--- a/libraries/connectivity/connectivity.cpp
+++ b/libraries/connectivity/connectivity.cpp
@@ -97,23 +97,23 @@ Connectivity::Connectivity()
 Network Connectivity::calculate(ConnectivitySettings& connectivitySettings)
 {
     //TODO: Use multithreading to work on multiple connectivity methods at the same time
-    if(connectivitySettings.m_sConnectivityMethods.contains("COR")) {
+    if(connectivitySettings.getConnectivityMethods().contains("COR")) {
         return Correlation::calculate(connectivitySettings);
-    } else if(connectivitySettings.m_sConnectivityMethods.contains("XCOR")) {
+    } else if(connectivitySettings.getConnectivityMethods().contains("XCOR")) {
         return CrossCorrelation::calculate(connectivitySettings);
-    } else if(connectivitySettings.m_sConnectivityMethods.contains("PLI")) {
+    } else if(connectivitySettings.getConnectivityMethods().contains("PLI")) {
         return PhaseLagIndex::calculate(connectivitySettings);
-    } else if(connectivitySettings.m_sConnectivityMethods.contains("COH")) {
+    } else if(connectivitySettings.getConnectivityMethods().contains("COH")) {
         return Coherence::calculate(connectivitySettings);
-    } else if(connectivitySettings.m_sConnectivityMethods.contains("IMAGCOH")) {
+    } else if(connectivitySettings.getConnectivityMethods().contains("IMAGCOH")) {
         return ImagCoherence::calculate(connectivitySettings);
-    } else if(connectivitySettings.m_sConnectivityMethods.contains("PLV")) {
+    } else if(connectivitySettings.getConnectivityMethods().contains("PLV")) {
         return PhaseLockingValue::calculate(connectivitySettings);
-    } else if(connectivitySettings.m_sConnectivityMethods.contains("WPLI")) {
+    } else if(connectivitySettings.getConnectivityMethods().contains("WPLI")) {
         return WeightedPhaseLagIndex::calculate(connectivitySettings);
-    } else if(connectivitySettings.m_sConnectivityMethods.contains("USPLI")) {
+    } else if(connectivitySettings.getConnectivityMethods().contains("USPLI")) {
         return UnbiasedSquaredPhaseLagIndex::calculate(connectivitySettings);
-    } else if(connectivitySettings.m_sConnectivityMethods.contains("DSWPLI")) {
+    } else if(connectivitySettings.getConnectivityMethods().contains("DSWPLI")) {
         return DebiasedSquaredWeightedPhaseLagIndex::calculate(connectivitySettings);
     }
 

--- a/libraries/connectivity/connectivity.cpp
+++ b/libraries/connectivity/connectivity.cpp
@@ -98,23 +98,23 @@ Network Connectivity::calculate(const ConnectivitySettings& connectivitySettings
 {
     //TODO: Use multithreading to work on multiple connectivity methods at the same time
     if(connectivitySettings.m_sConnectivityMethods.contains("COR")) {
-        return Correlation::correlationCoeff(connectivitySettings);
+        return Correlation::calculate(connectivitySettings);
     } else if(connectivitySettings.m_sConnectivityMethods.contains("XCOR")) {
-        return CrossCorrelation::crossCorrelation(connectivitySettings);
+        return CrossCorrelation::calculate(connectivitySettings);
     } else if(connectivitySettings.m_sConnectivityMethods.contains("PLI")) {
-        return PhaseLagIndex::phaseLagIndex(connectivitySettings);
+        return PhaseLagIndex::calculate(connectivitySettings);
     } else if(connectivitySettings.m_sConnectivityMethods.contains("COH")) {
-        return Coherence::coherence(connectivitySettings);
+        return Coherence::calculate(connectivitySettings);
     } else if(connectivitySettings.m_sConnectivityMethods.contains("IMAGCOH")) {
-        return ImagCoherence::imagCoherence(connectivitySettings);
+        return ImagCoherence::calculate(connectivitySettings);
     } else if(connectivitySettings.m_sConnectivityMethods.contains("PLV")) {
-        return PhaseLockingValue::phaseLockingValue(connectivitySettings);
+        return PhaseLockingValue::calculate(connectivitySettings);
     } else if(connectivitySettings.m_sConnectivityMethods.contains("WPLI")) {
-        return WeightedPhaseLagIndex::weightedPhaseLagIndex(connectivitySettings);
+        return WeightedPhaseLagIndex::calculate(connectivitySettings);
     } else if(connectivitySettings.m_sConnectivityMethods.contains("USPLI")) {
-        return UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(connectivitySettings);
+        return UnbiasedSquaredPhaseLagIndex::calculate(connectivitySettings);
     } else if(connectivitySettings.m_sConnectivityMethods.contains("DSWPLI")) {
-        return DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex(connectivitySettings);
+        return DebiasedSquaredWeightedPhaseLagIndex::calculate(connectivitySettings);
     }
 
     qDebug() << "Connectivity::calculateConnectivity - Connectivity method unknown.";

--- a/libraries/connectivity/connectivity.cpp
+++ b/libraries/connectivity/connectivity.cpp
@@ -87,58 +87,34 @@ using namespace CONNECTIVITYLIB;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-Connectivity::Connectivity(const ConnectivitySettings& connectivitySettings)
-: m_pConnectivitySettings(ConnectivitySettings::SPtr(new ConnectivitySettings(connectivitySettings)))
+Connectivity::Connectivity()
 {
 }
 
 
 //*************************************************************************************************************
 
-Network Connectivity::calculateConnectivity() const
+Network Connectivity::calculate(const ConnectivitySettings& connectivitySettings)
 {
     //TODO: Use multithreading to work on multiple connectivity methods at the same time
-    if(m_pConnectivitySettings->m_sConnectivityMethods.contains("COR")) {
-        return Correlation::correlationCoeff(m_pConnectivitySettings->m_matDataList,
-                                             m_pConnectivitySettings->m_matNodePositions);
-    } else if(m_pConnectivitySettings->m_sConnectivityMethods.contains("XCOR")) {
-        return CrossCorrelation::crossCorrelation(m_pConnectivitySettings->m_matDataList,
-                                                  m_pConnectivitySettings->m_matNodePositions);
-    } else if(m_pConnectivitySettings->m_sConnectivityMethods.contains("PLI")) {
-        return PhaseLagIndex::phaseLagIndex(m_pConnectivitySettings->m_matDataList,
-                                            m_pConnectivitySettings->m_matNodePositions,
-                                            m_pConnectivitySettings->m_iNfft,
-                                            m_pConnectivitySettings->m_sWindowType);
-    } else if(m_pConnectivitySettings->m_sConnectivityMethods.contains("COH")) {
-        return Coherence::coherence(m_pConnectivitySettings->m_matDataList,
-                                    m_pConnectivitySettings->m_matNodePositions,
-                                    m_pConnectivitySettings->m_iNfft,
-                                    m_pConnectivitySettings->m_sWindowType);
-    } else if(m_pConnectivitySettings->m_sConnectivityMethods.contains("IMAGCOH")) {
-        return ImagCoherence::imagCoherence(m_pConnectivitySettings->m_matDataList,
-                                            m_pConnectivitySettings->m_matNodePositions,
-                                            m_pConnectivitySettings->m_iNfft,
-                                            m_pConnectivitySettings->m_sWindowType);
-    } else if(m_pConnectivitySettings->m_sConnectivityMethods.contains("PLV")) {
-        return PhaseLockingValue::phaseLockingValue(m_pConnectivitySettings->m_matDataList,
-                                                    m_pConnectivitySettings->m_matNodePositions,
-                                                    m_pConnectivitySettings->m_iNfft,
-                                                    m_pConnectivitySettings->m_sWindowType);
-    } else if(m_pConnectivitySettings->m_sConnectivityMethods.contains("WPLI")) {
-        return WeightedPhaseLagIndex::weightedPhaseLagIndex(m_pConnectivitySettings->m_matDataList,
-                                                            m_pConnectivitySettings->m_matNodePositions,
-                                                            m_pConnectivitySettings->m_iNfft,
-                                                            m_pConnectivitySettings->m_sWindowType);
-    } else if(m_pConnectivitySettings->m_sConnectivityMethods.contains("USPLI")) {
-        return UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(m_pConnectivitySettings->m_matDataList,
-                                                                          m_pConnectivitySettings->m_matNodePositions,
-                                                                          m_pConnectivitySettings->m_iNfft,
-                                                                          m_pConnectivitySettings->m_sWindowType);
-    } else if(m_pConnectivitySettings->m_sConnectivityMethods.contains("DSWPLI")) {
-        return DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex(m_pConnectivitySettings->m_matDataList,
-                                                                                          m_pConnectivitySettings->m_matNodePositions,
-                                                                                          m_pConnectivitySettings->m_iNfft,
-                                                                                          m_pConnectivitySettings->m_sWindowType);
+    if(connectivitySettings.m_sConnectivityMethods.contains("COR")) {
+        return Correlation::correlationCoeff(connectivitySettings);
+    } else if(connectivitySettings.m_sConnectivityMethods.contains("XCOR")) {
+        return CrossCorrelation::crossCorrelation(connectivitySettings);
+    } else if(connectivitySettings.m_sConnectivityMethods.contains("PLI")) {
+        return PhaseLagIndex::phaseLagIndex(connectivitySettings);
+    } else if(connectivitySettings.m_sConnectivityMethods.contains("COH")) {
+        return Coherence::coherence(connectivitySettings);
+    } else if(connectivitySettings.m_sConnectivityMethods.contains("IMAGCOH")) {
+        return ImagCoherence::imagCoherence(connectivitySettings);
+    } else if(connectivitySettings.m_sConnectivityMethods.contains("PLV")) {
+        return PhaseLockingValue::phaseLockingValue(connectivitySettings);
+    } else if(connectivitySettings.m_sConnectivityMethods.contains("WPLI")) {
+        return WeightedPhaseLagIndex::weightedPhaseLagIndex(connectivitySettings);
+    } else if(connectivitySettings.m_sConnectivityMethods.contains("USPLI")) {
+        return UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(connectivitySettings);
+    } else if(connectivitySettings.m_sConnectivityMethods.contains("DSWPLI")) {
+        return DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex(connectivitySettings);
     }
 
     qDebug() << "Connectivity::calculateConnectivity - Connectivity method unknown.";

--- a/libraries/connectivity/connectivity.h
+++ b/libraries/connectivity/connectivity.h
@@ -109,7 +109,7 @@ public:
     *
     * @return Returns the network.
     */
-    static Network calculate(const ConnectivitySettings& connectivitySettings);
+    static Network calculate(ConnectivitySettings& connectivitySettings);
 
 protected:
 };

--- a/libraries/connectivity/connectivity.h
+++ b/libraries/connectivity/connectivity.h
@@ -101,7 +101,7 @@ public:
     /**
     * Constructs a Connectivity object.
     */
-    explicit Connectivity(const ConnectivitySettings& connectivitySettings);
+    explicit Connectivity();
 
     //=========================================================================================================
     /**
@@ -109,10 +109,9 @@ public:
     *
     * @return Returns the network.
     */
-    Network calculateConnectivity() const;
+    static Network calculate(const ConnectivitySettings& connectivitySettings);
 
 protected:
-    QSharedPointer<ConnectivitySettings>    m_pConnectivitySettings;           /**< The current connectivity settings. */
 };
 
 

--- a/libraries/connectivity/connectivity.pro
+++ b/libraries/connectivity/connectivity.pro
@@ -9,7 +9,7 @@
 #
 # @section  LICENSE
 #
-# Copyright (C) 2016, Lorenz Esch, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
+# Copyright (C) 2016, Lorenz Esch, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 # the following conditions are met:

--- a/libraries/connectivity/connectivity.pro
+++ b/libraries/connectivity/connectivity.pro
@@ -9,7 +9,7 @@
 #
 # @section  LICENSE
 #
-# Copyright (C) 2016, Lorenz Esch, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+# Copyright (C) 2016, Lorenz Esch, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 # the following conditions are met:

--- a/libraries/connectivity/connectivitysettings.cpp
+++ b/libraries/connectivity/connectivitysettings.cpp
@@ -76,9 +76,11 @@ using namespace CONNECTIVITYLIB;
 //=============================================================================================================
 
 ConnectivitySettings::ConnectivitySettings()
-: m_iNfft(-1)
+: m_fFreqResolution(1.0f)
+, m_fSFreq(1000.0f)
 , m_sWindowType("hanning")
 {
+    m_iNfft = int(m_fSFreq/m_fFreqResolution);
     qRegisterMetaType<CONNECTIVITYLIB::ConnectivitySettings>("CONNECTIVITYLIB::ConnectivitySettings");
 }
 
@@ -238,8 +240,40 @@ const QStringList& ConnectivitySettings::getConnectivityMethods() const
 
 //*******************************************************************************************************
 
+void ConnectivitySettings::setSamplingFrequency(int iSFreq)
+{
+    if(m_fSFreq == iSFreq) {
+        return;
+    }
+
+    clearIntermediateData();
+
+    m_fSFreq = iSFreq;
+
+    if(m_fFreqResolution != 0) {
+        m_iNfft = int(m_fSFreq/m_fFreqResolution);
+    }
+}
+
+
+//*******************************************************************************************************
+
+int ConnectivitySettings::getSamplingFrequency() const
+{
+    return m_fSFreq;
+}
+
+
+//*******************************************************************************************************
+
 void ConnectivitySettings::setNumberFFT(int iNfft)
 {
+    if(m_fSFreq == 0) {
+        return;
+    }
+
+    clearIntermediateData();
+
     m_iNfft = iNfft;
 }
 

--- a/libraries/connectivity/connectivitysettings.cpp
+++ b/libraries/connectivity/connectivitysettings.cpp
@@ -48,6 +48,8 @@
 //=============================================================================================================
 
 #include <QCommandLineParser>
+#include <QElapsedTimer>
+#include <QDebug>
 
 
 //*************************************************************************************************************
@@ -174,6 +176,9 @@ bool ConnectivitySettings::isEmpty() const
 
 void ConnectivitySettings::removeFirst()
 {
+    QElapsedTimer timer;
+    qint64 iTime = 0;
+    timer.start();
     if(!m_trialData.isEmpty()) {
         // Substract the influence by the first item on all intermediate sum data
         // Substract PSD of first trial from overall summed up PSD
@@ -183,42 +188,35 @@ void ConnectivitySettings::removeFirst()
         }
 
         // Substract CSD of first trial from overall summed up CSD
-        if(m_intermediateSumData.vecPairCsdSum.size() == m_trialData.first().vecPairCsd.size()) {
+        if(m_intermediateSumData.vecPairCsdSum.size() == m_trialData.first().vecPairCsd.size() &&
+           m_intermediateSumData.vecPairCsdNormalizedSum.size() == m_trialData.first().vecPairCsdNormalized.size() &&
+           m_intermediateSumData.vecPairCsdImagSignSum.size() == m_trialData.first().vecPairCsdImagSign.size() &&
+           m_intermediateSumData.vecPairCsdImagAbsSum.size() == m_trialData.first().vecPairCsdImagAbs.size() &&
+           m_intermediateSumData.vecPairCsdImagSqrdSum.size() == m_trialData.first().vecPairCsdImagSqrd.size()) {
             for (int i = 0; i < m_intermediateSumData.vecPairCsdSum.size(); ++i) {
-                m_intermediateSumData.vecPairCsdSum[i].second -= m_trialData.first().vecPairCsd.at(i).second;
-            }
-        }
-
-        // Substract normalized CSD of first trial from overall summed up normalized CSD
-        if(m_intermediateSumData.vecPairCsdNormalizedSum.size() == m_trialData.first().vecPairCsdNormalized.size()) {
-            for (int i = 0; i < m_intermediateSumData.vecPairCsdNormalizedSum.size(); ++i) {
-                m_intermediateSumData.vecPairCsdNormalizedSum[i].second -= m_trialData.first().vecPairCsdNormalized.at(i).second;
-            }
-        }
-
-        // Substract sign CSD of first trial from overall summed up sign CSD
-        if(m_intermediateSumData.vecPairCsdImagSignSum.size() == m_trialData.first().vecPairCsdImagSign.size()) {
-            for (int i = 0; i < m_intermediateSumData.vecPairCsdImagSignSum.size(); ++i) {
-                m_intermediateSumData.vecPairCsdImagSignSum[i].second -= m_trialData.first().vecPairCsdImagSign.at(i).second;
-            }
-        }
-
-        // Substract imag abs CSD of first trial from overall summed up imag abs CSD
-        if(m_intermediateSumData.vecPairCsdImagAbsSum.size() == m_trialData.first().vecPairCsdImagAbs.size()) {
-            for (int i = 0; i < m_intermediateSumData.vecPairCsdImagAbsSum.size(); ++i) {
-                m_intermediateSumData.vecPairCsdImagAbsSum[i].second -= m_trialData.first().vecPairCsdImagAbs.at(i).second;
-            }
-        }
-
-        // Substract imag sqrd CSD of first trial from overall summed up imag sqrd CSD
-        if(m_intermediateSumData.vecPairCsdImagSqrdSum.size() == m_trialData.first().vecPairCsdImagSqrd.size()) {
-            for (int i = 0; i < m_intermediateSumData.vecPairCsdImagSqrdSum.size(); ++i) {
-                m_intermediateSumData.vecPairCsdImagSqrdSum[i].second -= m_trialData.first().vecPairCsdImagSqrd.at(i).second;
+                if(i < m_intermediateSumData.vecPairCsdSum.size()) {
+                    m_intermediateSumData.vecPairCsdSum[i].second -= m_trialData.first().vecPairCsd.at(i).second;
+                }
+                if(i < m_intermediateSumData.vecPairCsdNormalizedSum.size()) {
+                    m_intermediateSumData.vecPairCsdNormalizedSum[i].second -= m_trialData.first().vecPairCsdNormalized.at(i).second;
+                }
+                if(i < m_intermediateSumData.vecPairCsdImagSignSum.size()) {
+                    m_intermediateSumData.vecPairCsdImagSignSum[i].second -= m_trialData.first().vecPairCsdImagSign.at(i).second;
+                }
+                if(i < m_intermediateSumData.vecPairCsdImagAbsSum.size()) {
+                    m_intermediateSumData.vecPairCsdImagAbsSum[i].second -= m_trialData.first().vecPairCsdImagAbs.at(i).second;
+                }
+                if(i < m_intermediateSumData.vecPairCsdImagSqrdSum.size()) {
+                    m_intermediateSumData.vecPairCsdImagSqrdSum[i].second -= m_trialData.first().vecPairCsdImagSqrd.at(i).second;
+                }
             }
         }
 
         m_trialData.removeFirst();
     }
+    iTime = timer.elapsed();
+    qDebug() << "ConnectivitySettings::removeFirst" << iTime;
+    timer.restart();
 }
 
 

--- a/libraries/connectivity/connectivitysettings.cpp
+++ b/libraries/connectivity/connectivitysettings.cpp
@@ -173,6 +173,7 @@ bool ConnectivitySettings::isEmpty() const
 void ConnectivitySettings::removeFirst()
 {
     if(!m_trialData.isEmpty()) {
+        // Substract the influence by the first item on all intermediate sum data
         // Substract PSD of first trial from overall summed up PSD
         if(m_intermediateSumData.matPsdSum.rows() == m_trialData.first().matPsd.rows() &&
            m_intermediateSumData.matPsdSum.cols() == m_trialData.first().matPsd.cols() ) {

--- a/libraries/connectivity/connectivitysettings.cpp
+++ b/libraries/connectivity/connectivitysettings.cpp
@@ -79,6 +79,7 @@ ConnectivitySettings::ConnectivitySettings()
 : m_iNfft(-1)
 , m_sWindowType("hanning")
 {
+    clearData();
     qRegisterMetaType<CONNECTIVITYLIB::ConnectivitySettings>("CONNECTIVITYLIB::ConnectivitySettings");
 }
 

--- a/libraries/connectivity/connectivitysettings.cpp
+++ b/libraries/connectivity/connectivitysettings.cpp
@@ -176,9 +176,10 @@ bool ConnectivitySettings::isEmpty() const
 
 void ConnectivitySettings::removeFirst(int iAmount)
 {
-    QElapsedTimer timer;
-    qint64 iTime = 0;
-    timer.start();
+//    QElapsedTimer timer;
+//    qint64 iTime = 0;
+//    timer.start();
+
     if(!m_trialData.isEmpty()) {
         // Substract the influence by the first item on all intermediate sum data
         // Substract PSD of first trial from overall summed up PSD
@@ -221,9 +222,10 @@ void ConnectivitySettings::removeFirst(int iAmount)
             counter--;
         }
     }
-    iTime = timer.elapsed();
-    qDebug() << "ConnectivitySettings::removeFirst" << iTime;
-    timer.restart();
+
+//    iTime = timer.elapsed();
+//    qDebug() << "ConnectivitySettings::removeFirst" << iTime;
+//    timer.restart();
 }
 
 

--- a/libraries/connectivity/connectivitysettings.cpp
+++ b/libraries/connectivity/connectivitysettings.cpp
@@ -174,7 +174,7 @@ bool ConnectivitySettings::isEmpty() const
 
 //*******************************************************************************************************
 
-void ConnectivitySettings::removeFirst()
+void ConnectivitySettings::removeFirst(int iAmount)
 {
     QElapsedTimer timer;
     qint64 iTime = 0;
@@ -187,32 +187,39 @@ void ConnectivitySettings::removeFirst()
             m_intermediateSumData.matPsdSum -= m_trialData.first().matPsd;
         }
 
-        // Substract CSD of first trial from overall summed up CSD
-        if(m_intermediateSumData.vecPairCsdSum.size() == m_trialData.first().vecPairCsd.size() &&
-           m_intermediateSumData.vecPairCsdNormalizedSum.size() == m_trialData.first().vecPairCsdNormalized.size() &&
-           m_intermediateSumData.vecPairCsdImagSignSum.size() == m_trialData.first().vecPairCsdImagSign.size() &&
-           m_intermediateSumData.vecPairCsdImagAbsSum.size() == m_trialData.first().vecPairCsdImagAbs.size() &&
-           m_intermediateSumData.vecPairCsdImagSqrdSum.size() == m_trialData.first().vecPairCsdImagSqrd.size()) {
-            for (int i = 0; i < m_intermediateSumData.vecPairCsdSum.size(); ++i) {
-                if(i < m_intermediateSumData.vecPairCsdSum.size()) {
+        // Substract influence of trials from overall summed up intermediate data
+        int counter = iAmount;
+
+        for (int i = 0; i < m_trialData.first().matData.rows(); ++i) {
+            counter = iAmount;
+
+            while(counter > 0){
+                if(i < m_intermediateSumData.vecPairCsdSum.size() && (m_intermediateSumData.vecPairCsdSum.size() == m_trialData.first().vecPairCsd.size())) {
                     m_intermediateSumData.vecPairCsdSum[i].second -= m_trialData.first().vecPairCsd.at(i).second;
                 }
-                if(i < m_intermediateSumData.vecPairCsdNormalizedSum.size()) {
+                if(i < m_intermediateSumData.vecPairCsdNormalizedSum.size() && (m_intermediateSumData.vecPairCsdNormalizedSum.size() == m_trialData.first().vecPairCsdNormalized.size())) {
                     m_intermediateSumData.vecPairCsdNormalizedSum[i].second -= m_trialData.first().vecPairCsdNormalized.at(i).second;
                 }
-                if(i < m_intermediateSumData.vecPairCsdImagSignSum.size()) {
+                if(i < m_intermediateSumData.vecPairCsdImagSignSum.size() && (m_intermediateSumData.vecPairCsdImagSignSum.size() == m_trialData.first().vecPairCsdImagSign.size())) {
                     m_intermediateSumData.vecPairCsdImagSignSum[i].second -= m_trialData.first().vecPairCsdImagSign.at(i).second;
                 }
-                if(i < m_intermediateSumData.vecPairCsdImagAbsSum.size()) {
+                if(i < m_intermediateSumData.vecPairCsdImagAbsSum.size() && (m_intermediateSumData.vecPairCsdImagAbsSum.size() == m_trialData.first().vecPairCsdImagAbs.size())) {
                     m_intermediateSumData.vecPairCsdImagAbsSum[i].second -= m_trialData.first().vecPairCsdImagAbs.at(i).second;
                 }
-                if(i < m_intermediateSumData.vecPairCsdImagSqrdSum.size()) {
+                if(i < m_intermediateSumData.vecPairCsdImagSqrdSum.size() && (m_intermediateSumData.vecPairCsdImagSqrdSum.size() == m_trialData.first().vecPairCsdImagSqrd.size())) {
                     m_intermediateSumData.vecPairCsdImagSqrdSum[i].second -= m_trialData.first().vecPairCsdImagSqrd.at(i).second;
                 }
+
+                counter--;
             }
         }
 
-        m_trialData.removeFirst();
+        // Remove the actual data from the trial list
+        counter = iAmount;
+        while(counter > 0 && !m_trialData.isEmpty()){
+            m_trialData.removeFirst();
+            counter--;
+        }
     }
     iTime = timer.elapsed();
     qDebug() << "ConnectivitySettings::removeFirst" << iTime;

--- a/libraries/connectivity/connectivitysettings.h
+++ b/libraries/connectivity/connectivitysettings.h
@@ -138,7 +138,7 @@ public:
 
     bool isEmpty() const;
 
-    void removeFirst();
+    void removeFirst(int iAmount = 1);
 
     void setConnectivityMethods(const QStringList& sConnectivityMethods);
 

--- a/libraries/connectivity/connectivitysettings.h
+++ b/libraries/connectivity/connectivitysettings.h
@@ -80,11 +80,16 @@ struct ConnectivityTrialData {
     Eigen::MatrixXd matData;
     Eigen::MatrixXd matPsd;
     QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsd;
+    QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdNormalized;
+    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSign;
+    QVector<Eigen::MatrixXcd> vecTapSpectra;
 };
 
 struct ConnectivityData {
     Eigen::MatrixXd matPsdSum;
     QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdSum;
+    QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdNormalizedSum;
+    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSignSum;
 };
 
 
@@ -113,17 +118,18 @@ public:
     */
     explicit ConnectivitySettings();
 
-    void clear() {
+    void clearData() {
         m_dataList.clear();
-        m_matDataList.clear();
         data.matPsdSum.resize(0,0);
         data.vecPairCsdSum.clear();
+        data.vecPairCsdNormalizedSum.clear();
     }
 
-    void reset() {
+    void resetData() {
         for (int i = 0; i < m_dataList.size(); ++i) {
             m_dataList[i].matPsd.resize(0,0);
             m_dataList[i].vecPairCsd.clear();
+            m_dataList[i].vecTapSpectra.clear();
         }
 
         data.matPsdSum.resize(0,0);
@@ -143,6 +149,10 @@ public:
         m_dataList.append(tempData);
     }
 
+    int size() const {
+        return m_dataList.size();
+    }
+
     void removeFirst() {
         if(!m_dataList.isEmpty()) {
             // Substract PSD of first trial from overall summed up PSD
@@ -158,18 +168,27 @@ public:
                 }
             }
 
+            // Substract normalized CSD of first trial from overall summed up normalized CSD
+            if(data.vecPairCsdNormalizedSum.size() == m_dataList.first().vecPairCsdNormalized.size()) {
+                for (int i = 0; i < data.vecPairCsdNormalizedSum.size(); ++i) {
+                    data.vecPairCsdNormalizedSum[i].second -= m_dataList.first().vecPairCsdNormalized.at(i).second;
+                }
+            }
+
+            // Substract sign CSD of first trial from overall summed up sign CSD
+            if(data.vecPairCsdImagSignSum.size() == m_dataList.first().vecPairCsdImagSign.size()) {
+                for (int i = 0; i < data.vecPairCsdImagSignSum.size(); ++i) {
+                    data.vecPairCsdImagSignSum[i].second -= m_dataList.first().vecPairCsdImagSign.at(i).second;
+                }
+            }
+
             m_dataList.removeFirst();
-        }
-        if(!m_matDataList.isEmpty()) {
-            m_matDataList.removeFirst();
         }
     };
 
     QStringList                 m_sConnectivityMethods;         /**< The connectivity methods. */
 
     QList<ConnectivityTrialData>     m_dataList;                     /**< The input data. */
-
-    QList<Eigen::MatrixXd>      m_matDataList;                  /**< The input data. */
 
     Eigen::MatrixX3f            m_matNodePositions;             /**< The node position in 3D space. */
 

--- a/libraries/connectivity/connectivitysettings.h
+++ b/libraries/connectivity/connectivitysettings.h
@@ -144,6 +144,10 @@ public:
 
     const QStringList& getConnectivityMethods() const;
 
+    void setSamplingFrequency(int iSFreq);
+
+    int getSamplingFrequency() const;
+
     void setNumberFFT(int iNfft);
 
     int getNumberFFT() const;
@@ -164,7 +168,9 @@ protected:
     QStringList                     m_sConnectivityMethods;         /**< The connectivity methods. */
     QString                         m_sWindowType;                  /**< The window type used to compute tapered spectra. */
 
-    int                             m_iNfft;                        /**< The FFT length used for spectral estimation. */
+    float                           m_fSFreq;                       /**< The sampling frequency. */
+    int                             m_iNfft;                        /**< The FFT length. Gets automatically calculated if the sFreq or spectrum resolution change. */
+    float                           m_fFreqResolution;              /**< The spectrum's resolution. */
 
     Eigen::MatrixX3f                m_matNodePositions;             /**< The node position in 3D space. */
 

--- a/libraries/connectivity/connectivitysettings.h
+++ b/libraries/connectivity/connectivitysettings.h
@@ -113,6 +113,23 @@ public:
     */
     explicit ConnectivitySettings();
 
+    void clear() {
+        m_dataList.clear();
+        m_matDataList.clear();
+        data.matPsdSum.resize(0,0);
+        data.vecPairCsdSum.clear();
+    }
+
+    void reset() {
+        for (int i = 0; i < m_dataList.size(); ++i) {
+            m_dataList[i].matPsd.resize(0,0);
+            m_dataList[i].vecPairCsd.clear();
+        }
+
+        data.matPsdSum.resize(0,0);
+        data.vecPairCsdSum.clear();
+    }
+
     void append(const QList<Eigen::MatrixXd>& matInputData) {
         for(int i = 0; i < matInputData.size(); ++i) {
             this->append(matInputData.at(i));

--- a/libraries/connectivity/connectivitysettings.h
+++ b/libraries/connectivity/connectivitysettings.h
@@ -83,8 +83,8 @@ struct ConnectivityTrialData {
 };
 
 struct ConnectivityData {
-    Eigen::MatrixXd matPsdAvg;
-    QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdAvg;
+    Eigen::MatrixXd matPsdSum;
+    QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdSum;
 };
 
 
@@ -113,6 +113,12 @@ public:
     */
     explicit ConnectivitySettings();
 
+    void append(const QList<Eigen::MatrixXd>& matInputData) {
+        for(int i = 0; i < matInputData.size(); ++i) {
+            this->append(matInputData.at(i));
+        }
+    }
+
     void append(const Eigen::MatrixXd& matInputData) {
         ConnectivityTrialData tempData;
         tempData.matData = matInputData;
@@ -123,15 +129,15 @@ public:
     void removeFirst() {
         if(!m_dataList.isEmpty()) {
             // Substract PSD of first trial from overall summed up PSD
-            if(data.matPsdAvg.rows() == m_dataList.first().matPsd.rows() &&
-               data.matPsdAvg.cols() == m_dataList.first().matPsd.cols() ) {
-                data.matPsdAvg -= m_dataList.first().matPsd;
+            if(data.matPsdSum.rows() == m_dataList.first().matPsd.rows() &&
+               data.matPsdSum.cols() == m_dataList.first().matPsd.cols() ) {
+                data.matPsdSum -= m_dataList.first().matPsd;
             }
 
             // Substract CSD of first trial from overall summed up CSD
-            if(data.vecPairCsdAvg.size() == m_dataList.first().vecPairCsd.size()) {
-                for (int i = 0; i < data.vecPairCsdAvg.size(); ++i) {
-                    data.vecPairCsdAvg[i].second -= m_dataList.first().vecPairCsd.at(i).second;
+            if(data.vecPairCsdSum.size() == m_dataList.first().vecPairCsd.size()) {
+                for (int i = 0; i < data.vecPairCsdSum.size(); ++i) {
+                    data.vecPairCsdSum[i].second -= m_dataList.first().vecPairCsd.at(i).second;
                 }
             }
 
@@ -154,6 +160,7 @@ public:
     QString                     m_sWindowType;                  /**< The window type used to compute tapered spectra. */
 
     ConnectivityData            data;
+
 protected:
 
 };

--- a/libraries/connectivity/connectivitysettings.h
+++ b/libraries/connectivity/connectivitysettings.h
@@ -82,6 +82,8 @@ struct ConnectivityTrialData {
     QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsd;
     QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdNormalized;
     QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSign;
+    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagAbs;
+    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSqrd;
     QVector<Eigen::MatrixXcd> vecTapSpectra;
 };
 
@@ -90,6 +92,8 @@ struct ConnectivityData {
     QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdSum;
     QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdNormalizedSum;
     QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSignSum;
+    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagAbsSum;
+    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSqrdSum;
 };
 
 
@@ -181,6 +185,22 @@ public:
                     data.vecPairCsdImagSignSum[i].second -= m_dataList.first().vecPairCsdImagSign.at(i).second;
                 }
             }
+
+            // Substract imag abs CSD of first trial from overall summed up imag abs CSD
+            if(data.vecPairCsdImagAbsSum.size() == m_dataList.first().vecPairCsdImagAbs.size()) {
+                for (int i = 0; i < data.vecPairCsdImagAbsSum.size(); ++i) {
+                    data.vecPairCsdImagAbsSum[i].second -= m_dataList.first().vecPairCsdImagAbs.at(i).second;
+                }
+            }
+
+            // Substract imag sqrd CSD of first trial from overall summed up imag sqrd CSD
+            if(data.vecPairCsdImagSqrdSum.size() == m_dataList.first().vecPairCsdImagSqrd.size()) {
+                for (int i = 0; i < data.vecPairCsdImagSqrdSum.size(); ++i) {
+                    data.vecPairCsdImagSqrdSum[i].second -= m_dataList.first().vecPairCsdImagSqrd.at(i).second;
+                }
+            }
+
+
 
             m_dataList.removeFirst();
         }

--- a/libraries/connectivity/connectivitysettings.h
+++ b/libraries/connectivity/connectivitysettings.h
@@ -76,26 +76,6 @@
 
 namespace CONNECTIVITYLIB {
 
-struct ConnectivityTrialData {
-    Eigen::MatrixXd matData;
-    Eigen::MatrixXd matPsd;
-    QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsd;
-    QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdNormalized;
-    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSign;
-    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagAbs;
-    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSqrd;
-    QVector<Eigen::MatrixXcd> vecTapSpectra;
-};
-
-struct ConnectivityData {
-    Eigen::MatrixXd matPsdSum;
-    QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdSum;
-    QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdNormalizedSum;
-    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSignSum;
-    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagAbsSum;
-    QVector<QPair<int,Eigen::MatrixXd> > vecPairCsdImagSqrdSum;
-};
-
 
 //*************************************************************************************************************
 //=============================================================================================================
@@ -110,11 +90,31 @@ struct ConnectivityData {
 * @brief This class is a container for connectivity settings.
 */
 class CONNECTIVITYSHARED_EXPORT ConnectivitySettings
-{
+{    
 
 public:
     typedef QSharedPointer<ConnectivitySettings> SPtr;            /**< Shared pointer type for ConnectivitySettings. */
     typedef QSharedPointer<const ConnectivitySettings> ConstSPtr; /**< Const shared pointer type for ConnectivitySettings. */
+
+    struct IntermediateTrialData {
+        Eigen::MatrixXd     matData;
+        Eigen::MatrixXd     matPsd;
+        QVector<Eigen::MatrixXcd>               vecTapSpectra;
+        QVector<QPair<int,Eigen::MatrixXcd> >   vecPairCsd;
+        QVector<QPair<int,Eigen::MatrixXcd> >   vecPairCsdNormalized;
+        QVector<QPair<int,Eigen::MatrixXd> >    vecPairCsdImagSign;
+        QVector<QPair<int,Eigen::MatrixXd> >    vecPairCsdImagAbs;
+        QVector<QPair<int,Eigen::MatrixXd> >    vecPairCsdImagSqrd;
+    };
+
+    struct IntermediateSumData {
+        Eigen::MatrixXd     matPsdSum;
+        QVector<QPair<int,Eigen::MatrixXcd> >   vecPairCsdSum;
+        QVector<QPair<int,Eigen::MatrixXcd> >   vecPairCsdNormalizedSum;
+        QVector<QPair<int,Eigen::MatrixXd> >    vecPairCsdImagSignSum;
+        QVector<QPair<int,Eigen::MatrixXd> >    vecPairCsdImagAbsSum;
+        QVector<QPair<int,Eigen::MatrixXd> >    vecPairCsdImagSqrdSum;
+    };
 
     //=========================================================================================================
     /**
@@ -122,102 +122,54 @@ public:
     */
     explicit ConnectivitySettings();
 
-    void clearData() {
-        m_dataList.clear();
-        data.matPsdSum.resize(0,0);
-        data.vecPairCsdSum.clear();
-        data.vecPairCsdNormalizedSum.clear();
-    }
+    void clearAllData();
 
-    void resetData() {
-        for (int i = 0; i < m_dataList.size(); ++i) {
-            m_dataList[i].matPsd.resize(0,0);
-            m_dataList[i].vecPairCsd.clear();
-            m_dataList[i].vecTapSpectra.clear();
-        }
+    void clearIntermediateData();
 
-        data.matPsdSum.resize(0,0);
-        data.vecPairCsdSum.clear();
-    }
+    void append(const QList<Eigen::MatrixXd>& matInputData);
 
-    void append(const QList<Eigen::MatrixXd>& matInputData) {
-        for(int i = 0; i < matInputData.size(); ++i) {
-            this->append(matInputData.at(i));
-        }
-    }
+    void append(const Eigen::MatrixXd& matInputData);
 
-    void append(const Eigen::MatrixXd& matInputData) {
-        ConnectivityTrialData tempData;
-        tempData.matData = matInputData;
+    void append(const ConnectivitySettings::IntermediateTrialData& inputData);
 
-        m_dataList.append(tempData);
-    }
+    const IntermediateTrialData& at(int i) const;
 
-    int size() const {
-        return m_dataList.size();
-    }
+    int size() const;
 
-    void removeFirst() {
-        if(!m_dataList.isEmpty()) {
-            // Substract PSD of first trial from overall summed up PSD
-            if(data.matPsdSum.rows() == m_dataList.first().matPsd.rows() &&
-               data.matPsdSum.cols() == m_dataList.first().matPsd.cols() ) {
-                data.matPsdSum -= m_dataList.first().matPsd;
-            }
+    bool isEmpty() const;
 
-            // Substract CSD of first trial from overall summed up CSD
-            if(data.vecPairCsdSum.size() == m_dataList.first().vecPairCsd.size()) {
-                for (int i = 0; i < data.vecPairCsdSum.size(); ++i) {
-                    data.vecPairCsdSum[i].second -= m_dataList.first().vecPairCsd.at(i).second;
-                }
-            }
+    void removeFirst();
 
-            // Substract normalized CSD of first trial from overall summed up normalized CSD
-            if(data.vecPairCsdNormalizedSum.size() == m_dataList.first().vecPairCsdNormalized.size()) {
-                for (int i = 0; i < data.vecPairCsdNormalizedSum.size(); ++i) {
-                    data.vecPairCsdNormalizedSum[i].second -= m_dataList.first().vecPairCsdNormalized.at(i).second;
-                }
-            }
+    void setConnectivityMethods(const QStringList& sConnectivityMethods);
 
-            // Substract sign CSD of first trial from overall summed up sign CSD
-            if(data.vecPairCsdImagSignSum.size() == m_dataList.first().vecPairCsdImagSign.size()) {
-                for (int i = 0; i < data.vecPairCsdImagSignSum.size(); ++i) {
-                    data.vecPairCsdImagSignSum[i].second -= m_dataList.first().vecPairCsdImagSign.at(i).second;
-                }
-            }
+    const QStringList& getConnectivityMethods() const;
 
-            // Substract imag abs CSD of first trial from overall summed up imag abs CSD
-            if(data.vecPairCsdImagAbsSum.size() == m_dataList.first().vecPairCsdImagAbs.size()) {
-                for (int i = 0; i < data.vecPairCsdImagAbsSum.size(); ++i) {
-                    data.vecPairCsdImagAbsSum[i].second -= m_dataList.first().vecPairCsdImagAbs.at(i).second;
-                }
-            }
+    void setNumberFFT(int iNfft);
 
-            // Substract imag sqrd CSD of first trial from overall summed up imag sqrd CSD
-            if(data.vecPairCsdImagSqrdSum.size() == m_dataList.first().vecPairCsdImagSqrd.size()) {
-                for (int i = 0; i < data.vecPairCsdImagSqrdSum.size(); ++i) {
-                    data.vecPairCsdImagSqrdSum[i].second -= m_dataList.first().vecPairCsdImagSqrd.at(i).second;
-                }
-            }
+    int getNumberFFT() const;
 
+    void setWindowType(const QString& sWindowType);
 
+    const QString& getWindowType() const;
 
-            m_dataList.removeFirst();
-        }
-    };
+    void setNodePositions(const Eigen::MatrixX3f& matNodePositions);
 
-    QStringList                 m_sConnectivityMethods;         /**< The connectivity methods. */
+    const Eigen::MatrixX3f& getNodePositions() const;
 
-    QList<ConnectivityTrialData>     m_dataList;                     /**< The input data. */
+    QList<IntermediateTrialData>& getTrialData();
 
-    Eigen::MatrixX3f            m_matNodePositions;             /**< The node position in 3D space. */
-
-    int                         m_iNfft;                        /**< The FFT length used for spectral estimation. */
-    QString                     m_sWindowType;                  /**< The window type used to compute tapered spectra. */
-
-    ConnectivityData            data;
+    IntermediateSumData& getIntermediateSumData();
 
 protected:
+    QStringList                     m_sConnectivityMethods;         /**< The connectivity methods. */
+    QString                         m_sWindowType;                  /**< The window type used to compute tapered spectra. */
+
+    int                             m_iNfft;                        /**< The FFT length used for spectral estimation. */
+
+    Eigen::MatrixX3f                m_matNodePositions;             /**< The node position in 3D space. */
+
+    IntermediateSumData             m_intermediateSumData;          /**< The intermediate sum data holds data calculated over all trials as a whole. */
+    QList<IntermediateTrialData>    m_trialData;                    /**< The trial data holds the actual and intermediate data calcualted for each trial. */
 
 };
 

--- a/libraries/connectivity/metrics/abstractmetric.h
+++ b/libraries/connectivity/metrics/abstractmetric.h
@@ -75,11 +75,6 @@
 
 namespace CONNECTIVITYLIB {
 
-struct AbstractMetricInputData {
-    Eigen::MatrixXd matInputData;
-    QPair<Eigen::MatrixXd, Eigen::VectorXd> tapers;
-};
-
 struct AbstractMetricResultData {
     Eigen::MatrixXd matPsdAvg;
     QVector<Eigen::MatrixXcd> vecCsdAvg;

--- a/libraries/connectivity/metrics/abstractmetric.h
+++ b/libraries/connectivity/metrics/abstractmetric.h
@@ -75,15 +75,6 @@
 
 namespace CONNECTIVITYLIB {
 
-struct AbstractMetricResultData {
-    Eigen::MatrixXd matPsdAvg;
-    QVector<Eigen::MatrixXcd> vecCsdAvg;
-    QVector<Eigen::MatrixXd> vecCsdAvgImag;
-    QVector<Eigen::MatrixXd> vecSquaredCsdAvgImag;
-    QVector<Eigen::MatrixXd> vecCsdAbsAvgImag;
-    QVector<QPair<int,Eigen::MatrixXcd> > vecPairCsdAvg;
-};
-
 
 //*************************************************************************************************************
 //=============================================================================================================

--- a/libraries/connectivity/metrics/coherence.cpp
+++ b/libraries/connectivity/metrics/coherence.cpp
@@ -140,34 +140,3 @@ Network Coherence::calculate(ConnectivitySettings& connectivitySettings)
 
     return finalNetwork;
 }
-
-
-//*******************************************************************************************************
-
-QVector<MatrixXd> Coherence::computeCoherence(const QList<MatrixXd> &matDataList,
-                                              int iNfft,
-                                              const QString &sWindowType)
-{
-    //Calculate all-to-all coherence matrix over epochs
-    QVector<QPair<int,Eigen::MatrixXcd> > vecCoh;
-
-    ConnectivitySettings connectivitySettings;
-    ConnectivityTrialData data;
-    for(int i = 0; i < matDataList.size(); i++) {
-        data.matData = matDataList.at(i);
-        connectivitySettings.m_dataList.append(data);
-    }
-    connectivitySettings.m_iNfft = iNfft;
-    connectivitySettings.m_sWindowType = sWindowType;
-
-    Coherency::calculate(vecCoh,
-                         connectivitySettings);
-
-    QVector<Eigen::MatrixXd> result;
-
-    for(int i = 0; i < vecCoh.length(); ++i) {
-        result << vecCoh.at(i).second.cwiseAbs();
-    }
-
-    return result;
-}

--- a/libraries/connectivity/metrics/coherence.cpp
+++ b/libraries/connectivity/metrics/coherence.cpp
@@ -130,9 +130,7 @@ Network Coherence::coherence(const ConnectivitySettings& connectivitySettings)
 
     //Calculate all-to-all coherence matrix over epochs
     Coherency::computeCoherencyReal(finalNetwork,
-                                    connectivitySettings.m_matDataList,
-                                    connectivitySettings.m_iNfft,
-                                    connectivitySettings.m_sWindowType);
+                                    connectivitySettings);
 
 //    iTime = timer.elapsed();
 //    qDebug() << "Coherence::coherence timer - Actual computation:" << iTime;
@@ -151,10 +149,13 @@ QVector<MatrixXd> Coherence::computeCoherence(const QList<MatrixXd> &matDataList
     //Calculate all-to-all coherence matrix over epochs
     QVector<QPair<int,Eigen::MatrixXcd> > vecCoh;
 
+    ConnectivitySettings connectivitySettings;
+    connectivitySettings.m_matDataList = matDataList;
+    connectivitySettings.m_iNfft = iNfft;
+    connectivitySettings.m_sWindowType = sWindowType;
+
     Coherency::computeCoherency(vecCoh,
-                                matDataList,
-                                iNfft,
-                                sWindowType);
+                                connectivitySettings);
 
     QVector<Eigen::MatrixXd> result;
 

--- a/libraries/connectivity/metrics/coherence.cpp
+++ b/libraries/connectivity/metrics/coherence.cpp
@@ -93,7 +93,7 @@ Coherence::Coherence()
 
 //*******************************************************************************************************
 
-Network Coherence::calculate(const ConnectivitySettings& connectivitySettings)
+Network Coherence::calculate(ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -101,7 +101,7 @@ Network Coherence::calculate(const ConnectivitySettings& connectivitySettings)
 
     Network finalNetwork("Coherence");
 
-    if(connectivitySettings.m_matDataList.empty()) {
+    if(connectivitySettings.m_dataList.empty()) {
         qDebug() << "Coherence::coherence - Input data is empty";
         return finalNetwork;
     }
@@ -111,7 +111,7 @@ Network Coherence::calculate(const ConnectivitySettings& connectivitySettings)
 //    timer.restart();
 
     //Create nodes
-    int rows = connectivitySettings.m_matDataList.first().rows();
+    int rows = connectivitySettings.m_dataList.first().matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
@@ -150,7 +150,11 @@ QVector<MatrixXd> Coherence::computeCoherence(const QList<MatrixXd> &matDataList
     QVector<QPair<int,Eigen::MatrixXcd> > vecCoh;
 
     ConnectivitySettings connectivitySettings;
-    connectivitySettings.m_matDataList = matDataList;
+    ConnectivityTrialData data;
+    for(int i = 0; i < matDataList.size(); i++) {
+        data.matData = matDataList.at(i);
+        connectivitySettings.m_dataList.append(data);
+    }
     connectivitySettings.m_iNfft = iNfft;
     connectivitySettings.m_sWindowType = sWindowType;
 

--- a/libraries/connectivity/metrics/coherence.cpp
+++ b/libraries/connectivity/metrics/coherence.cpp
@@ -115,6 +115,8 @@ Network Coherence::calculate(ConnectivitySettings& connectivitySettings)
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
+        rowVert = RowVectorXf::Zero(3);
+
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
             rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
             rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);

--- a/libraries/connectivity/metrics/coherence.cpp
+++ b/libraries/connectivity/metrics/coherence.cpp
@@ -93,7 +93,7 @@ Coherence::Coherence()
 
 //*******************************************************************************************************
 
-Network Coherence::coherence(const ConnectivitySettings& connectivitySettings)
+Network Coherence::calculate(const ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -129,8 +129,8 @@ Network Coherence::coherence(const ConnectivitySettings& connectivitySettings)
 //    timer.restart();
 
     //Calculate all-to-all coherence matrix over epochs
-    Coherency::computeCoherencyReal(finalNetwork,
-                                    connectivitySettings);
+    Coherency::calculateReal(finalNetwork,
+                             connectivitySettings);
 
 //    iTime = timer.elapsed();
 //    qDebug() << "Coherence::coherence timer - Actual computation:" << iTime;
@@ -154,8 +154,8 @@ QVector<MatrixXd> Coherence::computeCoherence(const QList<MatrixXd> &matDataList
     connectivitySettings.m_iNfft = iNfft;
     connectivitySettings.m_sWindowType = sWindowType;
 
-    Coherency::computeCoherency(vecCoh,
-                                connectivitySettings);
+    Coherency::calculate(vecCoh,
+                         connectivitySettings);
 
     QVector<Eigen::MatrixXd> result;
 

--- a/libraries/connectivity/metrics/coherence.cpp
+++ b/libraries/connectivity/metrics/coherence.cpp
@@ -9,7 +9,7 @@
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -102,7 +102,7 @@ Network Coherence::calculate(ConnectivitySettings& connectivitySettings)
 
     Network finalNetwork("Coherence");
 
-    if(connectivitySettings.m_dataList.empty()) {
+    if(connectivitySettings.isEmpty()) {
         qDebug() << "Coherence::coherence - Input data is empty";
         return finalNetwork;
     }
@@ -112,16 +112,16 @@ Network Coherence::calculate(ConnectivitySettings& connectivitySettings)
 //    timer.restart();
 
     //Create nodes
-    int rows = connectivitySettings.m_dataList.first().matData.rows();
+    int rows = connectivitySettings.at(0).matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
         rowVert = RowVectorXf::Zero(3);
 
-        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
-            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
-            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
-            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
+        if(connectivitySettings.getNodePositions().rows() != 0 && i < connectivitySettings.getNodePositions().rows()) {
+            rowVert(0) = connectivitySettings.getNodePositions().row(i)(0);
+            rowVert(1) = connectivitySettings.getNodePositions().row(i)(1);
+            rowVert(2) = connectivitySettings.getNodePositions().row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));

--- a/libraries/connectivity/metrics/coherence.cpp
+++ b/libraries/connectivity/metrics/coherence.cpp
@@ -46,6 +46,7 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -92,10 +93,7 @@ Coherence::Coherence()
 
 //*******************************************************************************************************
 
-Network Coherence::coherence(const QList<MatrixXd> &matDataList,
-                             const MatrixX3f& matVert,
-                             int iNfft,
-                             const QString &sWindowType)
+Network Coherence::coherence(const ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -103,7 +101,7 @@ Network Coherence::coherence(const QList<MatrixXd> &matDataList,
 
     Network finalNetwork("Coherence");
 
-    if(matDataList.empty()) {
+    if(connectivitySettings.m_matDataList.empty()) {
         qDebug() << "Coherence::coherence - Input data is empty";
         return finalNetwork;
     }
@@ -113,14 +111,14 @@ Network Coherence::coherence(const QList<MatrixXd> &matDataList,
 //    timer.restart();
 
     //Create nodes
-    int rows = matDataList.first().rows();
+    int rows = connectivitySettings.m_matDataList.first().rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
-        if(matVert.rows() != 0 && i < matVert.rows()) {
-            rowVert(0) = matVert.row(i)(0);
-            rowVert(1) = matVert.row(i)(1);
-            rowVert(2) = matVert.row(i)(2);
+        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
+            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
+            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
+            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
@@ -132,9 +130,9 @@ Network Coherence::coherence(const QList<MatrixXd> &matDataList,
 
     //Calculate all-to-all coherence matrix over epochs
     Coherency::computeCoherencyReal(finalNetwork,
-                                    matDataList,
-                                    iNfft,
-                                    sWindowType);
+                                    connectivitySettings.m_matDataList,
+                                    connectivitySettings.m_iNfft,
+                                    connectivitySettings.m_sWindowType);
 
 //    iTime = timer.elapsed();
 //    qDebug() << "Coherence::coherence timer - Actual computation:" << iTime;

--- a/libraries/connectivity/metrics/coherence.cpp
+++ b/libraries/connectivity/metrics/coherence.cpp
@@ -2,6 +2,7 @@
 /**
 * @file     coherence.cpp
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018

--- a/libraries/connectivity/metrics/coherence.h
+++ b/libraries/connectivity/metrics/coherence.h
@@ -87,6 +87,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -119,10 +120,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network coherence(const QList<Eigen::MatrixXd> &matDataList,
-                             const Eigen::MatrixX3f& matVert,
-                             int iNfft=-1,
-                             const QString &sWindowType="hanning");
+    static Network coherence(const ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**

--- a/libraries/connectivity/metrics/coherence.h
+++ b/libraries/connectivity/metrics/coherence.h
@@ -118,20 +118,6 @@ public:
     * @return                   The connectivity information in form of a network structure.
     */
     static Network calculate(ConnectivitySettings &connectivitySettings);
-
-    //=========================================================================================================
-    /**
-    * Calculates the coherence of the rows of the data matrix.
-    *
-    * @param[in] matDataList    The input data.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
-    *
-    * @return                   The connectivity information in form of a QVector of matrices.
-    */
-    static QVector<Eigen::MatrixXd> computeCoherence(const QList<Eigen::MatrixXd> &matDataList,
-                                                     int iNfft,
-                                                     const QString &sWindowType="hanning");
 };
 
 

--- a/libraries/connectivity/metrics/coherence.h
+++ b/libraries/connectivity/metrics/coherence.h
@@ -117,7 +117,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network calculate(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**

--- a/libraries/connectivity/metrics/coherence.h
+++ b/libraries/connectivity/metrics/coherence.h
@@ -117,7 +117,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network coherence(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(const ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**

--- a/libraries/connectivity/metrics/coherence.h
+++ b/libraries/connectivity/metrics/coherence.h
@@ -113,10 +113,7 @@ public:
     /**
     * Calculates the coherence between the rows of the data matrix.
     *
-    * @param[in] matDataList    The input data.
-    * @param[in] matVert        The vertices of each network node.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[in] connectivitySettings   The input data and parameters.
     *
     * @return                   The connectivity information in form of a network structure.
     */

--- a/libraries/connectivity/metrics/coherence.h
+++ b/libraries/connectivity/metrics/coherence.h
@@ -2,13 +2,14 @@
 /**
 * @file     coherence.h
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:

--- a/libraries/connectivity/metrics/coherency.cpp
+++ b/libraries/connectivity/metrics/coherency.cpp
@@ -115,6 +115,9 @@ void Coherency::calculateReal(Network& finalNetwork,
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
+    if(iNfft > iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());
@@ -188,6 +191,9 @@ void Coherency::calculateImag(Network& finalNetwork,
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
+    if(iNfft > iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/coherency.cpp
+++ b/libraries/connectivity/metrics/coherency.cpp
@@ -46,6 +46,7 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
+#include "../connectivitysettings.h"
 
 #include <utils/spectral.h>
 
@@ -96,15 +97,13 @@ Coherency::Coherency()
 //*************************************************************************************************************
 
 void Coherency::computeCoherencyReal(Network& finalNetwork,
-                                     const QList<MatrixXd> &matDataList,
-                                     int iNfft,
-                                     const QString &sWindowType)
+                                     const ConnectivitySettings &connectivitySettings)
 {
     QElapsedTimer timer;
     qint64 iTime = 0;
     timer.start();
 
-    if(matDataList.empty()) {
+    if(connectivitySettings.m_matDataList.empty()) {
         qDebug() << "Coherency::computeCoherencyReal - Input data is empty";
         return;
     }
@@ -114,17 +113,18 @@ void Coherency::computeCoherencyReal(Network& finalNetwork,
     #endif
 
     // Check that iNfft >= signal length
-    int iSignalLength = matDataList.at(0).cols();
-    if (iNfft < iSignalLength) {
+    int iSignalLength = connectivitySettings.m_matDataList.at(0).cols();
+    int iNfft = connectivitySettings.m_iNfft;
+    if (connectivitySettings.m_iNfft < iSignalLength) {
         iNfft = iSignalLength;
     }
 
     // Generate tapers
-    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.m_sWindowType);
 
     // Initialize vecPsdAvg and vecCsdAvg
-    int iNRows = matDataList.at(0).rows();
-    int iNFreqs = int(floor(iNfft / 2.0)) + 1;
+    int iNRows = connectivitySettings.m_matDataList.at(0).rows();
+    int iNFreqs = int(floor(connectivitySettings.m_iNfft / 2.0)) + 1;
 
     std::function<AbstractMetricResultData(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
         return compute(matInputData,
@@ -147,7 +147,7 @@ void Coherency::computeCoherencyReal(Network& finalNetwork,
 
     // Parallel
 
-    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
+    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(connectivitySettings.m_matDataList,
                                                                            computeLambda,
                                                                            reduce);
     result.waitForFinished();
@@ -190,15 +190,13 @@ void Coherency::computeCoherencyReal(Network& finalNetwork,
 //*************************************************************************************************************
 
 void Coherency::computeCoherencyImag(Network& finalNetwork,
-                                     const QList<MatrixXd> &matDataList,
-                                     int iNfft,
-                                     const QString &sWindowType)
+                                     const ConnectivitySettings &connectivitySettings)
 {
 //        QElapsedTimer timer;
 //        qint64 iTime = 0;
 //        timer.start();
 
-    if(matDataList.empty()) {
+    if(connectivitySettings.m_matDataList.empty()) {
         qDebug() << "Coherency::computeCoherencyImag - Input data is empty";
         return;
     }
@@ -208,16 +206,17 @@ void Coherency::computeCoherencyImag(Network& finalNetwork,
     #endif
 
     // Check that iNfft >= signal length
-    int iSignalLength = matDataList.at(0).cols();
-    if (iNfft < iSignalLength) {
+    int iSignalLength = connectivitySettings.m_matDataList.at(0).cols();
+    int iNfft = connectivitySettings.m_iNfft;
+    if (connectivitySettings.m_iNfft < iSignalLength) {
         iNfft = iSignalLength;
     }
 
     // Generate tapers
-    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.m_sWindowType);
 
     // Initialize vecPsdAvg and vecCsdAvg
-    int iNRows = matDataList.at(0).rows();
+    int iNRows = connectivitySettings.m_matDataList.at(0).rows();
     int iNFreqs = int(floor(iNfft / 2.0)) + 1;
 
     std::function<AbstractMetricResultData(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
@@ -240,7 +239,7 @@ void Coherency::computeCoherencyImag(Network& finalNetwork,
 //        qDebug() << "Coherency::computeCoherencyImag timer - Preparation:" << iTime;
 //        timer.restart();
 
-    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
+    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(connectivitySettings.m_matDataList,
                                                                            computeLambda,
                                                                            reduce);
     result.waitForFinished();
@@ -283,15 +282,13 @@ void Coherency::computeCoherencyImag(Network& finalNetwork,
 //*************************************************************************************************************
 
 void Coherency::computeCoherency(QVector<QPair<int,MatrixXcd> >& vecCoherency,
-                                 const QList<MatrixXd> &matDataList,
-                                 int iNfft,
-                                 const QString &sWindowType)
+                                 const ConnectivitySettings &connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
 //    timer.start();
 
-    if(matDataList.empty()) {
+    if(connectivitySettings.m_matDataList.empty()) {
         qDebug() << "Coherency::computeCoherency - Input data is empty";
         return;
     }
@@ -301,16 +298,17 @@ void Coherency::computeCoherency(QVector<QPair<int,MatrixXcd> >& vecCoherency,
     #endif
 
     // Check that iNfft >= signal length
-    int iSignalLength = matDataList.at(0).cols();
-    if (iNfft < iSignalLength) {
+    int iSignalLength = connectivitySettings.m_matDataList.at(0).cols();
+    int iNfft = connectivitySettings.m_iNfft;
+    if (connectivitySettings.m_iNfft < iSignalLength) {
         iNfft = iSignalLength;
     }
 
     // Generate tapers
-    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.m_sWindowType);
 
     // Initialize vecPsdAvg and vecCsdAvg
-    int iNRows = matDataList.at(0).rows();
+    int iNRows = connectivitySettings.m_matDataList.at(0).rows();
     int iNFreqs = int(floor(iNfft / 2.0)) + 1;
 
     std::function<AbstractMetricResultData(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
@@ -333,7 +331,7 @@ void Coherency::computeCoherency(QVector<QPair<int,MatrixXcd> >& vecCoherency,
 //    qDebug() << "Coherency::computeCoherency timer - Preparation:" << iTime;
 //    timer.restart();
 
-    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
+    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(connectivitySettings.m_matDataList,
                                                                            computeLambda,
                                                                            reduce);
     result.waitForFinished();

--- a/libraries/connectivity/metrics/coherency.cpp
+++ b/libraries/connectivity/metrics/coherency.cpp
@@ -2,6 +2,7 @@
 /**
 * @file     coherency.cpp
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018

--- a/libraries/connectivity/metrics/coherency.cpp
+++ b/libraries/connectivity/metrics/coherency.cpp
@@ -100,9 +100,9 @@ void Coherency::computeCoherencyReal(Network& finalNetwork,
                                      int iNfft,
                                      const QString &sWindowType)
 {
-//        QElapsedTimer timer;
-//        qint64 iTime = 0;
-//        timer.start();
+    QElapsedTimer timer;
+    qint64 iTime = 0;
+    timer.start();
 
     if(matDataList.empty()) {
         qDebug() << "Coherency::computeCoherencyReal - Input data is empty";
@@ -141,31 +141,32 @@ void Coherency::computeCoherencyReal(Network& finalNetwork,
 //        reduce(finalResult, computeLambda(matDataList.at(i)));
 //    }
 
+    iTime = timer.elapsed();
+    qDebug() << "Coherency::computeCoherencyReal timer - Preparation:" << iTime;
+    timer.restart();
+
     // Parallel
-//        iTime = timer.elapsed();
-//        qDebug() << "Coherency::computeCoherencyReal timer - Preparation:" << iTime;
-//        timer.restart();
 
     QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
                                                                            computeLambda,
                                                                            reduce);
     result.waitForFinished();
 
-//        iTime = timer.elapsed();
-//        qDebug() << "Coherency::computeCoherencyReal timer - Parallel computation:" << iTime;
-//        timer.restart();
+    iTime = timer.elapsed();
+    qDebug() << "Coherency::computeCoherencyReal timer - Parallel computation:" << iTime;
+    timer.restart();
 
     AbstractMetricResultData finalResult = result.result();
 
-//        iTime = timer.elapsed();
-//        qDebug() << "Coherency::computeCoherencyReal timer - Result copy:" << iTime;
-//        timer.restart();
+    iTime = timer.elapsed();
+    qDebug() << "Coherency::computeCoherencyReal timer - Result copy:" << iTime;
+    timer.restart();
 
     finalResult.matPsdAvg = finalResult.matPsdAvg.cwiseSqrt();
 
-//        iTime = timer.elapsed();
-//        qDebug() << "Coherency::computeCoherencyReal timer - Cwise sqrt:" << iTime;
-//        timer.restart();
+    iTime = timer.elapsed();
+    qDebug() << "Coherency::computeCoherencyReal timer - Cwise sqrt:" << iTime;
+    timer.restart();
 
     // Compute CSD/(PSD_X * PSD_Y)
     QMutex mutex;
@@ -180,9 +181,9 @@ void Coherency::computeCoherencyReal(Network& finalNetwork,
                                                    computePSDCSDLambda);
     resultCSDPSD.waitForFinished();
 
-//        iTime = timer.elapsed();
-//        qDebug() << "Coherency::computeCoherencyReal timer - CSD/(PSD_X * PSD_Y):" << iTime;
-//        timer.restart();
+    iTime = timer.elapsed();
+    qDebug() << "Coherency::computeCoherencyReal timer - CSD/(PSD_X * PSD_Y):" << iTime;
+    timer.restart();
 }
 
 

--- a/libraries/connectivity/metrics/coherency.cpp
+++ b/libraries/connectivity/metrics/coherency.cpp
@@ -96,7 +96,7 @@ Coherency::Coherency()
 
 //*************************************************************************************************************
 
-void Coherency::computeCoherencyReal(Network& finalNetwork,
+void Coherency::calculateReal(Network& finalNetwork,
                                      const ConnectivitySettings &connectivitySettings)
 {
     QElapsedTimer timer;
@@ -189,8 +189,8 @@ void Coherency::computeCoherencyReal(Network& finalNetwork,
 
 //*************************************************************************************************************
 
-void Coherency::computeCoherencyImag(Network& finalNetwork,
-                                     const ConnectivitySettings &connectivitySettings)
+void Coherency::calculateImag(Network& finalNetwork,
+                              const ConnectivitySettings &connectivitySettings)
 {
 //        QElapsedTimer timer;
 //        qint64 iTime = 0;
@@ -281,8 +281,8 @@ void Coherency::computeCoherencyImag(Network& finalNetwork,
 
 //*************************************************************************************************************
 
-void Coherency::computeCoherency(QVector<QPair<int,MatrixXcd> >& vecCoherency,
-                                 const ConnectivitySettings &connectivitySettings)
+void Coherency::calculate(QVector<QPair<int,MatrixXcd> >& vecCoherency,
+                          const ConnectivitySettings &connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;

--- a/libraries/connectivity/metrics/coherency.cpp
+++ b/libraries/connectivity/metrics/coherency.cpp
@@ -99,9 +99,9 @@ Coherency::Coherency()
 void Coherency::calculateReal(Network& finalNetwork,
                               ConnectivitySettings &connectivitySettings)
 {
-    QElapsedTimer timer;
-    qint64 iTime = 0;
-    timer.start();
+//    QElapsedTimer timer;
+//    qint64 iTime = 0;
+//    timer.start();
 
     if(connectivitySettings.isEmpty()) {
         qDebug() << "Coherency::computeCoherencyReal - Input data is empty";
@@ -140,17 +140,17 @@ void Coherency::calculateReal(Network& finalNetwork,
                 tapers);
     };
 
-    iTime = timer.elapsed();
-    qDebug() << "Coherency::computeCoherencyReal timer - Preparation:" << iTime;
-    timer.restart();
+//    iTime = timer.elapsed();
+//    qDebug() << "Coherency::computeCoherencyReal timer - Preparation:" << iTime;
+//    timer.restart();
 
     QFuture<void> result = QtConcurrent::map(connectivitySettings.getTrialData(),
                                              computeLambda);
     result.waitForFinished();
 
-    iTime = timer.elapsed();
-    qDebug() << "Coherency::computeCoherencyReal timer - PSD/CSD computation:" << iTime;
-    timer.restart();
+//    iTime = timer.elapsed();
+//    qDebug() << "Coherency::computeCoherencyReal timer - PSD/CSD computation:" << iTime;
+//    timer.restart();
 
     // Compute CSD/sqrt(PSD_X * PSD_Y)
     std::function<void(QPair<int,MatrixXcd>&)> computePSDCSDLambda = [&](QPair<int,MatrixXcd>& pairInput) {
@@ -164,9 +164,9 @@ void Coherency::calculateReal(Network& finalNetwork,
                                                    computePSDCSDLambda);
     resultCSDPSD.waitForFinished();
 
-    iTime = timer.elapsed();
-    qDebug() << "Coherency::computeCoherencyReal timer - Network creation CSD/sqrt(PSD_X * PSD_Y):" << iTime;
-    timer.restart();
+//    iTime = timer.elapsed();
+//    qDebug() << "Coherency::computeCoherencyReal timer - Network creation CSD/sqrt(PSD_X * PSD_Y):" << iTime;
+//    timer.restart();
 }
 
 

--- a/libraries/connectivity/metrics/coherency.cpp
+++ b/libraries/connectivity/metrics/coherency.cpp
@@ -104,81 +104,81 @@ void Coherency::computeCoherencyReal(Network& finalNetwork,
 //        qint64 iTime = 0;
 //        timer.start();
 
-        if(matDataList.empty()) {
-            qDebug() << "Coherency::computeCoherencyReal - Input data is empty";
-            return;
-        }
+    if(matDataList.empty()) {
+        qDebug() << "Coherency::computeCoherencyReal - Input data is empty";
+        return;
+    }
 
-        #ifdef EIGEN_FFTW_DEFAULT
-            fftw_make_planner_thread_safe();
-        #endif
+    #ifdef EIGEN_FFTW_DEFAULT
+        fftw_make_planner_thread_safe();
+    #endif
 
-        // Check that iNfft >= signal length
-        int iSignalLength = matDataList.at(0).cols();
-        if (iNfft < iSignalLength) {
-            iNfft = iSignalLength;
-        }
+    // Check that iNfft >= signal length
+    int iSignalLength = matDataList.at(0).cols();
+    if (iNfft < iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
-        // Generate tapers
-        QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
+    // Generate tapers
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
 
-        // Initialize vecPsdAvg and vecCsdAvg
-        int iNRows = matDataList.at(0).rows();
-        int iNFreqs = int(floor(iNfft / 2.0)) + 1;
+    // Initialize vecPsdAvg and vecCsdAvg
+    int iNRows = matDataList.at(0).rows();
+    int iNFreqs = int(floor(iNfft / 2.0)) + 1;
 
-        std::function<AbstractMetricResultData(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
-            return compute(matInputData,
-                           iNRows,
-                           iNFreqs,
-                           iNfft,
-                           tapers);
-        };
+    std::function<AbstractMetricResultData(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
+        return compute(matInputData,
+                       iNRows,
+                       iNFreqs,
+                       iNfft,
+                       tapers);
+    };
 
-    //    // Sequential
-    //    AbstractMetricResultData finalResult;
+//    // Sequential
+//    AbstractMetricResultData finalResult;
 
-    //    for (int i = 0; i < matDataList.length(); ++i) {
-    //        reduce(finalResult, computeLambda(matDataList.at(i)));
-    //    }
+//    for (int i = 0; i < matDataList.length(); ++i) {
+//        reduce(finalResult, computeLambda(matDataList.at(i)));
+//    }
 
-        // Parallel
+    // Parallel
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyReal timer - Preparation:" << iTime;
 //        timer.restart();
 
-        QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
-                                                                               computeLambda,
-                                                                               reduce);
-        result.waitForFinished();
+    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
+                                                                           computeLambda,
+                                                                           reduce);
+    result.waitForFinished();
 
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyReal timer - Parallel computation:" << iTime;
 //        timer.restart();
 
-        AbstractMetricResultData finalResult = result.result();
+    AbstractMetricResultData finalResult = result.result();
 
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyReal timer - Result copy:" << iTime;
 //        timer.restart();
 
-        finalResult.matPsdAvg = finalResult.matPsdAvg.cwiseSqrt();
+    finalResult.matPsdAvg = finalResult.matPsdAvg.cwiseSqrt();
 
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyReal timer - Cwise sqrt:" << iTime;
 //        timer.restart();
 
-        // Compute CSD/(PSD_X * PSD_Y)
-        QMutex mutex;
-        std::function<void(QPair<int,MatrixXcd>&)> computePSDCSDLambda = [&](QPair<int,MatrixXcd>& pairInput) {
-            computePSDCSDReal(mutex,
-                              finalNetwork,
-                              pairInput,
-                              finalResult.matPsdAvg);
-        };
+    // Compute CSD/(PSD_X * PSD_Y)
+    QMutex mutex;
+    std::function<void(QPair<int,MatrixXcd>&)> computePSDCSDLambda = [&](QPair<int,MatrixXcd>& pairInput) {
+        computePSDCSDReal(mutex,
+                          finalNetwork,
+                          pairInput,
+                          finalResult.matPsdAvg);
+    };
 
-        QFuture<void> resultCSDPSD = QtConcurrent::map(finalResult.vecPairCsdAvg,
-                                                       computePSDCSDLambda);
-        resultCSDPSD.waitForFinished();
+    QFuture<void> resultCSDPSD = QtConcurrent::map(finalResult.vecPairCsdAvg,
+                                                   computePSDCSDLambda);
+    resultCSDPSD.waitForFinished();
 
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyReal timer - CSD/(PSD_X * PSD_Y):" << iTime;
@@ -197,81 +197,81 @@ void Coherency::computeCoherencyImag(Network& finalNetwork,
 //        qint64 iTime = 0;
 //        timer.start();
 
-        if(matDataList.empty()) {
-            qDebug() << "Coherency::computeCoherencyImag - Input data is empty";
-            return;
-        }
+    if(matDataList.empty()) {
+        qDebug() << "Coherency::computeCoherencyImag - Input data is empty";
+        return;
+    }
 
-        #ifdef EIGEN_FFTW_DEFAULT
-            fftw_make_planner_thread_safe();
-        #endif
+    #ifdef EIGEN_FFTW_DEFAULT
+        fftw_make_planner_thread_safe();
+    #endif
 
-        // Check that iNfft >= signal length
-        int iSignalLength = matDataList.at(0).cols();
-        if (iNfft < iSignalLength) {
-            iNfft = iSignalLength;
-        }
+    // Check that iNfft >= signal length
+    int iSignalLength = matDataList.at(0).cols();
+    if (iNfft < iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
-        // Generate tapers
-        QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
+    // Generate tapers
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
 
-        // Initialize vecPsdAvg and vecCsdAvg
-        int iNRows = matDataList.at(0).rows();
-        int iNFreqs = int(floor(iNfft / 2.0)) + 1;
+    // Initialize vecPsdAvg and vecCsdAvg
+    int iNRows = matDataList.at(0).rows();
+    int iNFreqs = int(floor(iNfft / 2.0)) + 1;
 
-        std::function<AbstractMetricResultData(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
-            return compute(matInputData,
-                           iNRows,
-                           iNFreqs,
-                           iNfft,
-                           tapers);
-        };
+    std::function<AbstractMetricResultData(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
+        return compute(matInputData,
+                       iNRows,
+                       iNFreqs,
+                       iNfft,
+                       tapers);
+    };
 
-    //    // Sequential
-    //    AbstractMetricResultData finalResult;
+//    // Sequential
+//    AbstractMetricResultData finalResult;
 
-    //    for (int i = 0; i < matDataList.length(); ++i) {
-    //        reduce(finalResult, computeLambda(matDataList.at(i)));
-    //    }
+//    for (int i = 0; i < matDataList.length(); ++i) {
+//        reduce(finalResult, computeLambda(matDataList.at(i)));
+//    }
 
-        // Parallel
+    // Parallel
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyImag timer - Preparation:" << iTime;
 //        timer.restart();
 
-        QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
-                                                                               computeLambda,
-                                                                               reduce);
-        result.waitForFinished();
+    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
+                                                                           computeLambda,
+                                                                           reduce);
+    result.waitForFinished();
 
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyImag timer - Parallel computation:" << iTime;
 //        timer.restart();
 
-        AbstractMetricResultData finalResult = result.result();
+    AbstractMetricResultData finalResult = result.result();
 
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyImag timer - Result copy:" << iTime;
 //        timer.restart();
 
-        finalResult.matPsdAvg = finalResult.matPsdAvg.cwiseSqrt();
+    finalResult.matPsdAvg = finalResult.matPsdAvg.cwiseSqrt();
 
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyImag timer - Cwise sqrt:" << iTime;
 //        timer.restart();
 
-        // Compute CSD/(PSD_X * PSD_Y)
-        QMutex mutex;
-        std::function<void(QPair<int,MatrixXcd>&)> computePSDCSDLambda = [&](QPair<int,MatrixXcd>& pairInput) {
-            computePSDCSDImag(mutex,
-                              finalNetwork,
-                              pairInput,
-                              finalResult.matPsdAvg);
-        };
+    // Compute CSD/(PSD_X * PSD_Y)
+    QMutex mutex;
+    std::function<void(QPair<int,MatrixXcd>&)> computePSDCSDLambda = [&](QPair<int,MatrixXcd>& pairInput) {
+        computePSDCSDImag(mutex,
+                          finalNetwork,
+                          pairInput,
+                          finalResult.matPsdAvg);
+    };
 
-        QFuture<void> resultCSDPSD = QtConcurrent::map(finalResult.vecPairCsdAvg,
-                                                       computePSDCSDLambda);
-        resultCSDPSD.waitForFinished();
+    QFuture<void> resultCSDPSD = QtConcurrent::map(finalResult.vecPairCsdAvg,
+                                                   computePSDCSDLambda);
+    resultCSDPSD.waitForFinished();
 
 //        iTime = timer.elapsed();
 //        qDebug() << "Coherency::computeCoherencyImag timer - CSD/(PSD_X * PSD_Y):" << iTime;

--- a/libraries/connectivity/metrics/coherency.cpp
+++ b/libraries/connectivity/metrics/coherency.cpp
@@ -115,9 +115,6 @@ void Coherency::calculateReal(Network& finalNetwork,
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
-    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());
@@ -191,9 +188,6 @@ void Coherency::calculateImag(Network& finalNetwork,
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
-    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/coherency.h
+++ b/libraries/connectivity/metrics/coherency.h
@@ -145,17 +145,20 @@ private:
     /**
     * Computes the coherency values. This function gets called in parallel.
     *
-    * @param[in] matInputData           The input data.
-    * @param[in] iNRows                 The number of rows.
-    * @param[in] iNFreqs                The number of frequenciy bins.
-    * @param[in] iNfft                  The FFT length.
-    * @param[in] tapers                 The taper information.
+    * @param[in]    inputData           The input data.
+    * @param[out]   matPsdSum           The sum of all PSD matrices for each trial.
+    * @param[out]   vecPairCsdSum       The sum of all CSD matrices for each trial.
+    * @param[in]    mutex               The mutex used to safely access matPsdSum and vecPairCsdAvg.
+    * @param[in]    iNRows              The number of rows.
+    * @param[in]    iNFreqs             The number of frequenciy bins.
+    * @param[in]    iNfft               The FFT length.
+    * @param[in]    tapers              The taper information.
     *
     * @return            The coherency result in form of ConnectivityData.
     */
     static void compute(ConnectivityTrialData& inputData,
-                        Eigen::MatrixXd& matPsdAvg,
-                        QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdAvg,
+                        Eigen::MatrixXd& matPsdSum,
+                        QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
                         QMutex& mutex,
                         int iNRows,
                         int iNFreqs,
@@ -164,28 +167,18 @@ private:
 
     //=========================================================================================================
     /**
-    * Reduces the coherency computation to a final result. This function gets called in parallel.
-    *
-    * @param[out] finalData    The final data data.
-    * @param[in]  resultData   The resulting data from the computation step.
-    */
-    static void reduce(ConnectivityTrialData &finalData,
-                       const ConnectivityTrialData &resultData);
-
-    //=========================================================================================================
-    /**
     * Computes the PSD and CSD. This function gets called in parallel.
     */
     static void computePSDCSDReal(QMutex& mutex,
                                   Network& finalNetwork,
                                   const QPair<int,Eigen::MatrixXcd>& pairInput,
-                                  const Eigen::MatrixXd& matPsdAvg);
+                                  const Eigen::MatrixXd& matPsdSum);
     static void computePSDCSDImag(QMutex& mutex,
                                   Network& finalNetwork,
                                   const QPair<int,Eigen::MatrixXcd>& pairInput,
-                                  const Eigen::MatrixXd& matPsdAvg);
+                                  const Eigen::MatrixXd& matPsdSum);
     static void computePSDCSD(QPair<int,Eigen::MatrixXcd>& pairInput,
-                              const Eigen::MatrixXd& matPsdAvg);
+                              const Eigen::MatrixXd& matPsdSum);
 };
 
 

--- a/libraries/connectivity/metrics/coherency.h
+++ b/libraries/connectivity/metrics/coherency.h
@@ -130,16 +130,6 @@ public:
     static void calculateImag(Network& finalNetwork,
                               ConnectivitySettings &connectivitySettings);
 
-    //=========================================================================================================
-    /**
-    * Calculates the coherency of the rows of the data matrix.
-    *
-    * @param[out]   finalNetwork          The resulting network.
-    * @param[in]    connectivitySettings  The input data and parameters.
-    */
-    static void calculate(QVector<QPair<int,Eigen::MatrixXcd> >& vecCoherency,
-                          ConnectivitySettings &connectivitySettings);
-
 private:
     //=========================================================================================================
     /**
@@ -177,8 +167,6 @@ private:
                                   Network& finalNetwork,
                                   const QPair<int,Eigen::MatrixXcd>& pairInput,
                                   const Eigen::MatrixXd& matPsdSum);
-    static void computePSDCSD(QPair<int,Eigen::MatrixXcd>& pairInput,
-                              const Eigen::MatrixXd& matPsdSum);
 };
 
 

--- a/libraries/connectivity/metrics/coherency.h
+++ b/libraries/connectivity/metrics/coherency.h
@@ -88,6 +88,7 @@ namespace CONNECTIVITYLIB {
 
 class Network;
 class ConnectivitySettings;
+class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -113,31 +114,31 @@ public:
     /**
     * Calculates the real part of coherency of the rows of the data matrix.
     *
-    * @param[out] finalNetwork          The resulting network.
-    * @param[in] connectivitySettings   The input data and parameters.
+    * @param[out]   finalNetwork          The resulting network.
+    * @param[in]    connectivitySettings  The input data and parameters.
     */
     static void calculateReal(Network& finalNetwork,
-                                     const ConnectivitySettings &connectivitySettings);
+                              ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**
     * Calculates the imaginary part of coherency of the rows of the data matrix.
     *
-    * @param[out] finalNetwork          The resulting network.
-    * @param[in] connectivitySettings   The input data and parameters.
+    * @param[out]   finalNetwork          The resulting network.
+    * @param[in]    connectivitySettings  The input data and parameters.
     */
     static void calculateImag(Network& finalNetwork,
-                                     const ConnectivitySettings &connectivitySettings);
+                              ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**
     * Calculates the coherency of the rows of the data matrix.
     *
-    * @param[out] finalNetwork          The resulting network.
-    * @param[in] connectivitySettings   The input data and parameters.
+    * @param[out]   finalNetwork          The resulting network.
+    * @param[in]    connectivitySettings  The input data and parameters.
     */
     static void calculate(QVector<QPair<int,Eigen::MatrixXcd> >& vecCoherency,
-                                 const ConnectivitySettings &connectivitySettings);
+                          ConnectivitySettings &connectivitySettings);
 
 private:
     //=========================================================================================================
@@ -150,13 +151,16 @@ private:
     * @param[in] iNfft                  The FFT length.
     * @param[in] tapers                 The taper information.
     *
-    * @return            The coherency result in form of AbstractMetricResultData.
+    * @return            The coherency result in form of ConnectivityData.
     */
-    static AbstractMetricResultData compute(const Eigen::MatrixXd& matInputData,
-                                            int iNRows,
-                                            int iNFreqs,
-                                            int iNfft,
-                                            const QPair<Eigen::MatrixXd, Eigen::VectorXd>& tapers);
+    static void compute(ConnectivityTrialData& inputData,
+                        Eigen::MatrixXd& matPsdAvg,
+                        QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdAvg,
+                        QMutex& mutex,
+                        int iNRows,
+                        int iNFreqs,
+                        int iNfft,
+                        const QPair<Eigen::MatrixXd, Eigen::VectorXd>& tapers);
 
     //=========================================================================================================
     /**
@@ -165,26 +169,23 @@ private:
     * @param[out] finalData    The final data data.
     * @param[in]  resultData   The resulting data from the computation step.
     */
-    static void reduce(AbstractMetricResultData &finalData,
-                       const AbstractMetricResultData& resultData);
+    static void reduce(ConnectivityTrialData &finalData,
+                       const ConnectivityTrialData &resultData);
 
     //=========================================================================================================
     /**
     * Computes the PSD and CSD. This function gets called in parallel.
-    *
-    * @param[out] pairInput     The in/out data.
-    * @param[in]  matPsdAvg     The averaged PSD.
     */
-    static void computePSDCSD(QPair<int,Eigen::MatrixXcd>& pairInput,
-                              const Eigen::MatrixXd& matPsdAvg);
     static void computePSDCSDReal(QMutex& mutex,
                                   Network& finalNetwork,
-                                  QPair<int,Eigen::MatrixXcd>& pairInput,
+                                  const QPair<int,Eigen::MatrixXcd>& pairInput,
                                   const Eigen::MatrixXd& matPsdAvg);
     static void computePSDCSDImag(QMutex& mutex,
                                   Network& finalNetwork,
-                                  QPair<int,Eigen::MatrixXcd>& pairInput,
+                                  const QPair<int,Eigen::MatrixXcd>& pairInput,
                                   const Eigen::MatrixXd& matPsdAvg);
+    static void computePSDCSD(QPair<int,Eigen::MatrixXcd>& pairInput,
+                              const Eigen::MatrixXd& matPsdAvg);
 };
 
 

--- a/libraries/connectivity/metrics/coherency.h
+++ b/libraries/connectivity/metrics/coherency.h
@@ -116,7 +116,7 @@ public:
     * @param[out] finalNetwork          The resulting network.
     * @param[in] connectivitySettings   The input data and parameters.
     */
-    static void computeCoherencyReal(Network& finalNetwork,
+    static void calculateReal(Network& finalNetwork,
                                      const ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
@@ -126,7 +126,7 @@ public:
     * @param[out] finalNetwork          The resulting network.
     * @param[in] connectivitySettings   The input data and parameters.
     */
-    static void computeCoherencyImag(Network& finalNetwork,
+    static void calculateImag(Network& finalNetwork,
                                      const ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
@@ -136,7 +136,7 @@ public:
     * @param[out] finalNetwork          The resulting network.
     * @param[in] connectivitySettings   The input data and parameters.
     */
-    static void computeCoherency(QVector<QPair<int,Eigen::MatrixXcd> >& vecCoherency,
+    static void calculate(QVector<QPair<int,Eigen::MatrixXcd> >& vecCoherency,
                                  const ConnectivitySettings &connectivitySettings);
 
 private:

--- a/libraries/connectivity/metrics/coherency.h
+++ b/libraries/connectivity/metrics/coherency.h
@@ -2,13 +2,14 @@
 /**
 * @file     coherency.h
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -48,6 +49,7 @@
 #include "../connectivity_global.h"
 
 #include "abstractmetric.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -87,8 +89,6 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
-class ConnectivitySettings;
-class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -144,7 +144,7 @@ private:
     * @param[in]    iNfft               The FFT length.
     * @param[in]    tapers              The taper information.
     */
-    static void compute(ConnectivityTrialData& inputData,
+    static void compute(ConnectivitySettings::IntermediateTrialData& inputData,
                         Eigen::MatrixXd& matPsdSum,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
                         QMutex& mutex,

--- a/libraries/connectivity/metrics/coherency.h
+++ b/libraries/connectivity/metrics/coherency.h
@@ -87,6 +87,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -112,46 +113,31 @@ public:
     /**
     * Calculates the real part of coherency of the rows of the data matrix.
     *
-    * @param[out] finalNetwork  The resulting network.
-    * @param[in] matDataList    The input data.
-    * @param[in] iNfft          FFT length.
-    * @param[in] sReturnType    The return type. Can return imag or real part of coherency. Default is real.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[out] finalNetwork          The resulting network.
+    * @param[in] connectivitySettings   The input data and parameters.
     */
     static void computeCoherencyReal(Network& finalNetwork,
-                                     const QList<Eigen::MatrixXd> &matDataList,
-                                     int iNfft = -1,
-                                     const QString &sWindowType="hanning");
+                                     const ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**
     * Calculates the imaginary part of coherency of the rows of the data matrix.
     *
-    * @param[out] finalNetwork  The resulting network.
-    * @param[in] matDataList    The input data.
-    * @param[in] iNfft          FFT length.
-    * @param[in] sReturnType    The return type. Can return imag or real part of coherency. Default is real.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[out] finalNetwork          The resulting network.
+    * @param[in] connectivitySettings   The input data and parameters.
     */
     static void computeCoherencyImag(Network& finalNetwork,
-                                     const QList<Eigen::MatrixXd> &matDataList,
-                                     int iNfft = -1,
-                                     const QString &sWindowType="hanning");
+                                     const ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**
     * Calculates the coherency of the rows of the data matrix.
     *
-    * @param[out] vecCoherency  The resulting data.
-    * @param[in] matDataList    The input data.
-    * @param[in] iNfft          FFT length.
-    * @param[in] sReturnType    The return type. Can return imag or real part of coherency. Default is real.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[out] finalNetwork          The resulting network.
+    * @param[in] connectivitySettings   The input data and parameters.
     */
     static void computeCoherency(QVector<QPair<int,Eigen::MatrixXcd> >& vecCoherency,
-                                 const QList<Eigen::MatrixXd> &matDataList,
-                                 int iNfft = -1,
-                                 const QString &sWindowType="hanning");
+                                 const ConnectivitySettings &connectivitySettings);
 
 private:
     //=========================================================================================================

--- a/libraries/connectivity/metrics/coherency.h
+++ b/libraries/connectivity/metrics/coherency.h
@@ -138,13 +138,11 @@ private:
     * @param[in]    inputData           The input data.
     * @param[out]   matPsdSum           The sum of all PSD matrices for each trial.
     * @param[out]   vecPairCsdSum       The sum of all CSD matrices for each trial.
-    * @param[in]    mutex               The mutex used to safely access matPsdSum and vecPairCsdAvg.
+    * @param[in]    mutex               The mutex used to safely access matPsdSum and vecPairCsdSum.
     * @param[in]    iNRows              The number of rows.
     * @param[in]    iNFreqs             The number of frequenciy bins.
     * @param[in]    iNfft               The FFT length.
     * @param[in]    tapers              The taper information.
-    *
-    * @return            The coherency result in form of ConnectivityData.
     */
     static void compute(ConnectivityTrialData& inputData,
                         Eigen::MatrixXd& matPsdSum,

--- a/libraries/connectivity/metrics/correlation.cpp
+++ b/libraries/connectivity/metrics/correlation.cpp
@@ -43,7 +43,6 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
-#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -95,22 +94,22 @@ Network Correlation::calculate(ConnectivitySettings& connectivitySettings)
 {
     Network finalNetwork("Correlation");
 
-    if(connectivitySettings.m_dataList.empty()) {
+    if(connectivitySettings.isEmpty()) {
         qDebug() << "Correlation::correlationCoeff - Input data is empty";
         return finalNetwork;
     }   
 
     //Create nodes
-    int rows = connectivitySettings.m_dataList.first().matData.rows();
+    int rows = connectivitySettings.at(0).matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
         rowVert = RowVectorXf::Zero(3);
 
-        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
-            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
-            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
-            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
+        if(connectivitySettings.getNodePositions().rows() != 0 && i < connectivitySettings.getNodePositions().rows()) {
+            rowVert(0) = connectivitySettings.getNodePositions().row(i)(0);
+            rowVert(1) = connectivitySettings.getNodePositions().row(i)(1);
+            rowVert(2) = connectivitySettings.getNodePositions().row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
@@ -120,7 +119,7 @@ Network Correlation::calculate(ConnectivitySettings& connectivitySettings)
     //double dScalingStep = 1.0/matDataList.size();
     //dataTemp.matInputData = dScalingStep * (i+1) * matDataList.at(i);
 
-    QFuture<MatrixXd> resultMat = QtConcurrent::mappedReduced(connectivitySettings.m_dataList,
+    QFuture<MatrixXd> resultMat = QtConcurrent::mappedReduced(connectivitySettings.getTrialData(),
                                                               compute,
                                                               reduce);
     resultMat.waitForFinished();
@@ -152,7 +151,7 @@ Network Correlation::calculate(ConnectivitySettings& connectivitySettings)
 
 //*************************************************************************************************************
 
-MatrixXd Correlation::compute(const ConnectivityTrialData& inputData)
+MatrixXd Correlation::compute(const ConnectivitySettings::IntermediateTrialData& inputData)
 {
     MatrixXd matDist = MatrixXd::Zero(inputData.matData.rows(), inputData.matData.rows());
     RowVectorXd vecRow;

--- a/libraries/connectivity/metrics/correlation.cpp
+++ b/libraries/connectivity/metrics/correlation.cpp
@@ -91,7 +91,7 @@ Correlation::Correlation()
 
 //*************************************************************************************************************
 
-Network Correlation::correlationCoeff(const ConnectivitySettings& connectivitySettings)
+Network Correlation::calculate(const ConnectivitySettings& connectivitySettings)
 {
     Network finalNetwork("Correlation");
 

--- a/libraries/connectivity/metrics/correlation.cpp
+++ b/libraries/connectivity/metrics/correlation.cpp
@@ -105,6 +105,8 @@ Network Correlation::calculate(const ConnectivitySettings& connectivitySettings)
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
+        rowVert = RowVectorXf::Zero(3);
+
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
             rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
             rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);

--- a/libraries/connectivity/metrics/correlation.h
+++ b/libraries/connectivity/metrics/correlation.h
@@ -45,6 +45,7 @@
 #include "../connectivity_global.h"
 
 #include "abstractmetric.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -83,8 +84,6 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
-class ConnectivitySettings;
-class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -125,7 +124,7 @@ protected:
     *
     * @return                   The connectivity matrix.
     */
-    static Eigen::MatrixXd compute(const ConnectivityTrialData& inputData);
+    static Eigen::MatrixXd compute(const ConnectivitySettings::IntermediateTrialData& inputData);
 
     //=========================================================================================================
     /**

--- a/libraries/connectivity/metrics/correlation.h
+++ b/libraries/connectivity/metrics/correlation.h
@@ -109,8 +109,7 @@ public:
     /**
     * Calculates the correlation coefficient between the rows of the data matrix.
     *
-    * @param[in] matDataList    The input data.
-    * @param[in] matVert        The vertices of each network node.
+    * @param[in] connectivitySettings   The input data and parameters.
     *
     * @return                   The connectivity information in form of a network structure.
     */

--- a/libraries/connectivity/metrics/correlation.h
+++ b/libraries/connectivity/metrics/correlation.h
@@ -84,6 +84,7 @@ namespace CONNECTIVITYLIB {
 
 class Network;
 class ConnectivitySettings;
+class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -113,18 +114,18 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network calculate(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(ConnectivitySettings &connectivitySettings);
 
 protected:
     //=========================================================================================================
     /**
     * Calculates the connectivity matrix for a given input data matrix based on the correlation coefficient.
     *
-    * @param[in] data       The input data.
+    * @param[in] inputData      The input data.
     *
-    * @return               The connectivity matrix.
+    * @return                   The connectivity matrix.
     */
-    static Eigen::MatrixXd compute(const Eigen::MatrixXd& data);
+    static Eigen::MatrixXd compute(const ConnectivityTrialData& inputData);
 
     //=========================================================================================================
     /**

--- a/libraries/connectivity/metrics/correlation.h
+++ b/libraries/connectivity/metrics/correlation.h
@@ -113,7 +113,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network correlationCoeff(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(const ConnectivitySettings &connectivitySettings);
 
 protected:
     //=========================================================================================================

--- a/libraries/connectivity/metrics/correlation.h
+++ b/libraries/connectivity/metrics/correlation.h
@@ -83,6 +83,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -113,8 +114,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network correlationCoeff(const QList<Eigen::MatrixXd> &matDataList,
-                                    const Eigen::MatrixX3f& matVert);
+    static Network correlationCoeff(const ConnectivitySettings &connectivitySettings);
 
 protected:
     //=========================================================================================================

--- a/libraries/connectivity/metrics/crosscorrelation.cpp
+++ b/libraries/connectivity/metrics/crosscorrelation.cpp
@@ -189,9 +189,7 @@ void CrossCorrelation::compute(ConnectivityTrialData& inputData,
 
     int i, j;
 
-    if(inputData.vecTapSpectra.size() != inputData.matData.rows()) {
-        inputData.vecTapSpectra.clear();
-
+    if(inputData.vecTapSpectra.isEmpty()) {
         // This code was copied and modified from Utils/Spectra since we do not want to call the function due to time loss.
         bool bNfftEven = false;
         if (iNfft % 2 == 0){

--- a/libraries/connectivity/metrics/crosscorrelation.cpp
+++ b/libraries/connectivity/metrics/crosscorrelation.cpp
@@ -93,7 +93,7 @@ CrossCorrelation::CrossCorrelation()
 
 //*************************************************************************************************************
 
-Network CrossCorrelation::crossCorrelation(const ConnectivitySettings& connectivitySettings)
+Network CrossCorrelation::calculate(const ConnectivitySettings& connectivitySettings)
 {
     #ifdef EIGEN_FFTW_DEFAULT
         fftw_make_planner_thread_safe();
@@ -125,15 +125,15 @@ Network CrossCorrelation::crossCorrelation(const ConnectivitySettings& connectiv
 
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iNfft, "Ones");
 
-    std::function<MatrixXd(const MatrixXd&)> calculateLambda = [&](const MatrixXd& matInputData) {
-        return calculate(matInputData,
+    std::function<MatrixXd(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
+        return compute(matInputData,
                          iNfft,
                          tapers);
     };
 
     // Calculate connectivity matrix over epochs and average afterwards
     QFuture<MatrixXd> resultMat = QtConcurrent::mappedReduced(connectivitySettings.m_matDataList,
-                                                              calculateLambda,
+                                                              computeLambda,
                                                               sum);
     resultMat.waitForFinished();
 
@@ -163,7 +163,7 @@ Network CrossCorrelation::crossCorrelation(const ConnectivitySettings& connectiv
 
 //*************************************************************************************************************
 
-MatrixXd CrossCorrelation::calculate(const MatrixXd& matInputData,
+MatrixXd CrossCorrelation::compute(const MatrixXd& matInputData,
                                      int iNfft,
                                      const QPair<MatrixXd, VectorXd>& tapers)
 {

--- a/libraries/connectivity/metrics/crosscorrelation.cpp
+++ b/libraries/connectivity/metrics/crosscorrelation.cpp
@@ -45,7 +45,6 @@
 #include "network/network.h"
 
 #include <utils/spectral.h>
-#include <utils/ioutils.h>
 
 
 //*************************************************************************************************************

--- a/libraries/connectivity/metrics/crosscorrelation.cpp
+++ b/libraries/connectivity/metrics/crosscorrelation.cpp
@@ -111,6 +111,8 @@ Network CrossCorrelation::calculate(const ConnectivitySettings& connectivitySett
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
+        rowVert = RowVectorXf::Zero(3);
+
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
             rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
             rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);

--- a/libraries/connectivity/metrics/crosscorrelation.cpp
+++ b/libraries/connectivity/metrics/crosscorrelation.cpp
@@ -101,7 +101,7 @@ Network CrossCorrelation::calculate(ConnectivitySettings& connectivitySettings)
     Network finalNetwork("Cross Correlation");
 
     if(connectivitySettings.isEmpty()) {
-        qDebug() << "CrossCorrelation::crossCorrelation - Input data is empty";
+        qDebug() << "CrossCorrelation::calculate - Input data is empty";
         return finalNetwork;
     }
 

--- a/libraries/connectivity/metrics/crosscorrelation.cpp
+++ b/libraries/connectivity/metrics/crosscorrelation.cpp
@@ -124,9 +124,6 @@ Network CrossCorrelation::calculate(ConnectivitySettings& connectivitySettings)
     // Generate tapers
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
-    }
 
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iNfft, "Ones");
 

--- a/libraries/connectivity/metrics/crosscorrelation.cpp
+++ b/libraries/connectivity/metrics/crosscorrelation.cpp
@@ -121,7 +121,11 @@ Network CrossCorrelation::calculate(const ConnectivitySettings& connectivitySett
     }
 
     // Generate tapers
-    int iNfft = connectivitySettings.m_matDataList.at(0).cols();
+    int iSignalLength = connectivitySettings.m_dataList.first().matData.cols();
+    int iNfft = connectivitySettings.m_iNfft;
+    if (connectivitySettings.m_iNfft < iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iNfft, "Ones");
 

--- a/libraries/connectivity/metrics/crosscorrelation.h
+++ b/libraries/connectivity/metrics/crosscorrelation.h
@@ -109,8 +109,7 @@ public:
     /**
     * Calculates the cross correlation between the rows of the data matrix.
     *
-    * @param[in] matDataList    The input data.
-    * @param[in] matVert        The vertices of each network node.
+    * @param[in] connectivitySettings   The input data and parameters.
     *
     * @return                   The connectivity information in form of a network structure.
     */

--- a/libraries/connectivity/metrics/crosscorrelation.h
+++ b/libraries/connectivity/metrics/crosscorrelation.h
@@ -45,6 +45,7 @@
 #include "../connectivity_global.h"
 
 #include "abstractmetric.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -84,8 +85,6 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
-class ConnectivitySettings;
-class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -128,7 +127,7 @@ protected:
     * @param[in]    iNfft               The FFT length.
     * @param[in]    tapers              The taper information.
     */
-    static void compute(ConnectivityTrialData& inputData,
+    static void compute(ConnectivitySettings::IntermediateTrialData& inputData,
                         Eigen::MatrixXd& matDist,
                         QMutex& mutex,
                         int iNfft,

--- a/libraries/connectivity/metrics/crosscorrelation.h
+++ b/libraries/connectivity/metrics/crosscorrelation.h
@@ -83,6 +83,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -113,8 +114,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network crossCorrelation(const QList<Eigen::MatrixXd> &matDataList,
-                                    const Eigen::MatrixX3f& matVert);
+    static Network crossCorrelation(const ConnectivitySettings &connectivitySettings);
 
 protected:
     //=========================================================================================================

--- a/libraries/connectivity/metrics/crosscorrelation.h
+++ b/libraries/connectivity/metrics/crosscorrelation.h
@@ -53,6 +53,7 @@
 //=============================================================================================================
 
 #include <QSharedPointer>
+#include <QMutex>
 
 
 //*************************************************************************************************************
@@ -84,6 +85,7 @@ namespace CONNECTIVITYLIB {
 
 class Network;
 class ConnectivitySettings;
+class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -113,29 +115,24 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network calculate(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(ConnectivitySettings &connectivitySettings);
 
 protected:
     //=========================================================================================================
     /**
     * Calculates the connectivity matrix for a given input data matrix based on the cross correlation coefficient.
     *
-    * @param[in] data       The input data.
-    *
-    * @return               The connectivity matrix.
+    * @param[in]    inputData           The input data.
+    * @param[out]   matDist             The sum of all edge weights.
+    * @param[in]    mutex               The mutex used to safely access matDist.
+    * @param[in]    iNfft               The FFT length.
+    * @param[in]    tapers              The taper information.
     */
-    static Eigen::MatrixXd compute(const Eigen::MatrixXd& matInputData,
-                                     int iNfft,
-                                     const QPair<Eigen::MatrixXd, Eigen::VectorXd>& tapers);
-
-    //=========================================================================================================
-    /**
-    * Sums up (reduces) the in parallel processed connectivity matrix.
-    *
-    * @param[out] resultData    The result data.
-    * @param[in]  data          The incoming and temporary result data.
-    */
-    static void sum(Eigen::MatrixXd &resultData, const Eigen::MatrixXd &data);
+    static void compute(ConnectivityTrialData& inputData,
+                        Eigen::MatrixXd& matDist,
+                        QMutex& mutex,
+                        int iNfft,
+                        const QPair<Eigen::MatrixXd, Eigen::VectorXd>& tapers);
 
 };
 

--- a/libraries/connectivity/metrics/crosscorrelation.h
+++ b/libraries/connectivity/metrics/crosscorrelation.h
@@ -113,7 +113,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network crossCorrelation(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(const ConnectivitySettings &connectivitySettings);
 
 protected:
     //=========================================================================================================
@@ -124,7 +124,7 @@ protected:
     *
     * @return               The connectivity matrix.
     */
-    static Eigen::MatrixXd calculate(const Eigen::MatrixXd& matInputData,
+    static Eigen::MatrixXd compute(const Eigen::MatrixXd& matInputData,
                                      int iNfft,
                                      const QPair<Eigen::MatrixXd, Eigen::VectorXd>& tapers);
 

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
@@ -96,7 +96,7 @@ DebiasedSquaredWeightedPhaseLagIndex::DebiasedSquaredWeightedPhaseLagIndex()
 
 //*******************************************************************************************************
 
-Network DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex(const ConnectivitySettings& connectivitySettings)
+Network DebiasedSquaredWeightedPhaseLagIndex::calculate(const ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -129,10 +129,10 @@ Network DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagInd
 
     //Calculate all-to-all coherence matrix over epochs
     QVector<MatrixXd> vecDebiasedSquaredWPLI;
-    DebiasedSquaredWeightedPhaseLagIndex::computeDebiasedSquaredWPLI(vecDebiasedSquaredWPLI,
-                                                                     connectivitySettings.m_matDataList,
-                                                                     connectivitySettings.m_iNfft,
-                                                                     connectivitySettings.m_sWindowType);
+    DebiasedSquaredWeightedPhaseLagIndex::calculate(vecDebiasedSquaredWPLI,
+                                                    connectivitySettings.m_matDataList,
+                                                    connectivitySettings.m_iNfft,
+                                                    connectivitySettings.m_sWindowType);
 
 //    iTime = timer.elapsed();
 //    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex timer - Actual computation:" << iTime;
@@ -165,10 +165,10 @@ Network DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagInd
 
 //*************************************************************************************************************
 
-void DebiasedSquaredWeightedPhaseLagIndex::computeDebiasedSquaredWPLI(QVector<MatrixXd>& vecDebiasedSquaredWPLI,
-                                                                      const QList<MatrixXd> &matDataList,
-                                                                      int iNfft,
-                                                                      const QString &sWindowType)
+void DebiasedSquaredWeightedPhaseLagIndex::calculate(QVector<MatrixXd>& vecDebiasedSquaredWPLI,
+                                                    const QList<MatrixXd> &matDataList,
+                                                    int iNfft,
+                                                    const QString &sWindowType)
 {
     #ifdef EIGEN_FFTW_DEFAULT
         fftw_make_planner_thread_safe();

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
@@ -132,6 +132,9 @@ Network DebiasedSquaredWeightedPhaseLagIndex::calculate(ConnectivitySettings& co
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
+    if(iNfft > iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
@@ -132,9 +132,6 @@ Network DebiasedSquaredWeightedPhaseLagIndex::calculate(ConnectivitySettings& co
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
-    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
@@ -96,7 +96,7 @@ DebiasedSquaredWeightedPhaseLagIndex::DebiasedSquaredWeightedPhaseLagIndex()
 
 //*******************************************************************************************************
 
-Network DebiasedSquaredWeightedPhaseLagIndex::calculate(const ConnectivitySettings& connectivitySettings)
+Network DebiasedSquaredWeightedPhaseLagIndex::calculate(ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -104,13 +104,17 @@ Network DebiasedSquaredWeightedPhaseLagIndex::calculate(const ConnectivitySettin
 
     Network finalNetwork("Debiased Squared Weighted Phase Lag Index");
 
-    if(connectivitySettings.m_matDataList.empty()) {
-        qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex - Input data is empty";
+    if(connectivitySettings.m_dataList.empty()) {
+        qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::calculate - Input data is empty";
         return finalNetwork;
     }
 
+    #ifdef EIGEN_FFTW_DEFAULT
+        fftw_make_planner_thread_safe();
+    #endif
+
     //Create nodes
-    int rows = connectivitySettings.m_matDataList.first().rows();
+    int rows = connectivitySettings.m_dataList.first().matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
@@ -125,40 +129,51 @@ Network DebiasedSquaredWeightedPhaseLagIndex::calculate(const ConnectivitySettin
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
     }
 
-//    iTime = timer.elapsed();
-//    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex timer - Preparation:" << iTime;
-//    timer.restart();
-
-    //Calculate all-to-all coherence matrix over epochs
-    QVector<MatrixXd> vecDebiasedSquaredWPLI;
-    DebiasedSquaredWeightedPhaseLagIndex::calculate(vecDebiasedSquaredWPLI,
-                                                    connectivitySettings.m_matDataList,
-                                                    connectivitySettings.m_iNfft,
-                                                    connectivitySettings.m_sWindowType);
-
-//    iTime = timer.elapsed();
-//    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex timer - Actual computation:" << iTime;
-//    timer.restart();
-
-    //Add edges to network
-    MatrixXd matWeight;
-    QSharedPointer<NetworkEdge> pEdge;
-    int j;
-
-    for(int i = 0; i < vecDebiasedSquaredWPLI.length(); ++i) {
-        for(j = i; j < connectivitySettings.m_matDataList.at(0).rows(); ++j) {
-            matWeight = vecDebiasedSquaredWPLI.at(i).row(j).transpose();
-
-            pEdge = QSharedPointer<NetworkEdge>(new NetworkEdge(i, j, matWeight));
-
-            finalNetwork.getNodeAt(i)->append(pEdge);
-            finalNetwork.getNodeAt(j)->append(pEdge);
-            finalNetwork.append(pEdge);
-        }
+    // Check that iNfft >= signal length
+    int iSignalLength = connectivitySettings.m_dataList.at(0).matData.cols();
+    int iNfft = connectivitySettings.m_iNfft;
+    if (iNfft < iSignalLength) {
+        iNfft = iSignalLength;
     }
 
+    // Generate tapers
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.m_sWindowType);
+
+    // Initialize
+    int iNRows = connectivitySettings.m_dataList.at(0).matData.rows();
+    int iNFreqs = int(floor(iNfft / 2.0)) + 1;
+
+    QMutex mutex;
+
+    std::function<void(ConnectivityTrialData&)> computeLambda = [&](ConnectivityTrialData& inputData) {
+        return compute(inputData,
+                       connectivitySettings.data.vecPairCsdSum,
+                       mutex,
+                       iNRows,
+                       iNFreqs,
+                       iNfft,
+                       tapers);
+    };
+
+    //    iTime = timer.elapsed();
+    //    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::calculate timer - Preparation:" << iTime;
+    //    timer.restart();
+
+    // Compute DSWPLV in parallel for all trials
+    QFuture<void> result = QtConcurrent::map(connectivitySettings.m_dataList,
+                                             computeLambda);
+    result.waitForFinished();
+
 //    iTime = timer.elapsed();
-//    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex timer - Network creation:" << iTime;
+//    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::calculate timer - Compute DSWPLV per trial:" << iTime;
+//    timer.restart();
+
+    // Compute DSWPLV
+    computeDSWPLV(connectivitySettings,
+                  finalNetwork);
+
+//    iTime = timer.elapsed();
+//    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::calculate timer - Compute DSWPLV, Network creation:" << iTime;
 //    timer.restart();
 
     return finalNetwork;
@@ -167,100 +182,51 @@ Network DebiasedSquaredWeightedPhaseLagIndex::calculate(const ConnectivitySettin
 
 //*************************************************************************************************************
 
-void DebiasedSquaredWeightedPhaseLagIndex::calculate(QVector<MatrixXd>& vecDebiasedSquaredWPLI,
-                                                    const QList<MatrixXd> &matDataList,
-                                                    int iNfft,
-                                                    const QString &sWindowType)
+void DebiasedSquaredWeightedPhaseLagIndex::compute(ConnectivityTrialData& inputData,
+                                                   QVector<QPair<int,MatrixXcd> >& vecPairCsdSum,
+                                                   QMutex& mutex,
+                                                   int iNRows,
+                                                   int iNFreqs,
+                                                   int iNfft,
+                                                   const QPair<MatrixXd, VectorXd>& tapers)
 {
-    #ifdef EIGEN_FFTW_DEFAULT
-        fftw_make_planner_thread_safe();
-    #endif
-
-    // Check that iNfft >= signal length
-    int iSignalLength = matDataList.at(0).cols();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
+    if(inputData.vecPairCsd.size() == iNRows) {
+        //qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::compute - vecPairCsd was already computed for this trial.";
+        return;
     }
-
-    // Generate tapers
-    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
-
-    // Initialize
-    int iNRows = matDataList.at(0).rows();
-    int iNFreqs = int(floor(iNfft / 2.0)) + 1;
-
-    //    // Sequential
-    //    AbstractMetricResultData finalResult;
-
-    //    for (int i = 0; i < matDataList.length(); ++i) {
-    //        reduce(finalResult, computeLambda(matDataList.at(i)));
-    //    }
-
-    std::function<AbstractMetricResultData(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
-        return compute(matInputData,
-                       iNRows,
-                       iNFreqs,
-                       iNfft,
-                       tapers);
-    };
-
-    // Parallel
-    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
-                                                                           computeLambda,
-                                                                           reduce);
-    result.waitForFinished();
-
-    AbstractMetricResultData finalResult = result.result();
-
-    MatrixXd matNom, matDenom;
-
-    for (int j = 0; j < iNRows; ++j) {
-        matNom = finalResult.vecCsdAvgImag.at(j).array().square();
-        matNom -= finalResult.vecSquaredCsdAvgImag.at(j);
-
-        matDenom = finalResult.vecCsdAbsAvgImag.at(j).array().square();
-        matDenom -= finalResult.vecSquaredCsdAvgImag.at(j);
-        matDenom = (matDenom.array() == 0.).select(INFINITY, matDenom);
-
-        vecDebiasedSquaredWPLI.append(matNom.cwiseQuotient(matDenom));
-    }
-}
-
-
-//*************************************************************************************************************
-
-AbstractMetricResultData DebiasedSquaredWeightedPhaseLagIndex::compute(const MatrixXd& matInputData,
-                                                                       int iNRows,
-                                                                       int iNFreqs,
-                                                                       int iNfft,
-                                                                       const QPair<MatrixXd, VectorXd>& tapers)
-{
-    // Subtract mean, generate tapered spectra and CSD
-    // This code was copied and changed modified Utils/Spectra since we do not want to call the function due to time loss.
-    RowVectorXd vecInputFFT, rowData;
-    RowVectorXcd vecTmpFreq;
-
-    MatrixXcd matTapSpectrum(tapers.first.rows(), iNFreqs);
-
-    QVector<Eigen::MatrixXcd> vecTapSpectra;
 
     int i,j;
 
-    FFT<double> fft;
-    fft.SetFlag(fft.HalfSpectrum);
+    // Calculate tapered spectra if not available already
+    // This code was copied and changed modified Utils/Spectra since we do not want to call the function due to time loss.
+    if(inputData.vecTapSpectra.size() != iNRows) {
+        inputData.vecTapSpectra.clear();
 
-    for (i = 0; i < iNRows; ++i) {
-        // Substract mean
-        rowData.array() = matInputData.row(i).array() - matInputData.row(i).mean();
+        RowVectorXd vecInputFFT, rowData;
+        RowVectorXcd vecTmpFreq;
 
-        // FFT for freq domain returning the half spectrum and multiply taper weights
-        for(j = 0; j < tapers.first.rows(); j++) {
-            vecInputFFT = rowData.cwiseProduct(tapers.first.row(j));
-            fft.fwd(vecTmpFreq, vecInputFFT, iNfft);
-            matTapSpectrum.row(j) = vecTmpFreq * tapers.second(j);
+        MatrixXcd matTapSpectrum(tapers.first.rows(), iNFreqs);
+
+        QVector<Eigen::MatrixXcd> vecTapSpectra;
+
+
+        FFT<double> fft;
+        fft.SetFlag(fft.HalfSpectrum);
+
+        for (i = 0; i < iNRows; ++i) {
+            // Substract mean
+            rowData.array() = inputData.matData.row(i).array() - inputData.matData.row(i).mean();
+
+            // Calculate tapered spectra if not available already
+            for(j = 0; j < tapers.first.rows(); j++) {
+                vecInputFFT = rowData.cwiseProduct(tapers.first.row(j));
+                // FFT for freq domain returning the half spectrum and multiply taper weights
+                fft.fwd(vecTmpFreq, vecInputFFT, iNfft);
+                matTapSpectrum.row(j) = vecTmpFreq * tapers.second(j);
+            }
+
+            inputData.vecTapSpectra.append(matTapSpectrum);
         }
-
-        vecTapSpectra.append(matTapSpectrum);
     }
 
     // Compute CSD
@@ -271,14 +237,12 @@ AbstractMetricResultData DebiasedSquaredWeightedPhaseLagIndex::compute(const Mat
 
     double denomCSD = sqrt(tapers.second.cwiseAbs2().sum()) * sqrt(tapers.second.cwiseAbs2().sum()) / 2.0;
 
-    MatrixXd matCsd(iNRows, iNFreqs);
-
-    AbstractMetricResultData resultData;
+    MatrixXcd matCsd(iNRows, iNFreqs);
 
     for (i = 0; i < iNRows; ++i) {
         for (j = i; j < iNRows; ++j) {
             // Compute CSD (average over tapers if necessary)
-            matCsd.row(j) = vecTapSpectra.at(i).cwiseProduct(vecTapSpectra.at(j).conjugate()).colwise().sum().imag() / denomCSD;
+            matCsd.row(j) = inputData.vecTapSpectra.at(i).cwiseProduct(inputData.vecTapSpectra.at(j).conjugate()).colwise().sum() / denomCSD;
 
             // Divide first and last element by 2 due to half spectrum
             matCsd.row(j)(0) /= 2.0;
@@ -287,43 +251,65 @@ AbstractMetricResultData DebiasedSquaredWeightedPhaseLagIndex::compute(const Mat
             }
         }
 
-        resultData.vecCsdAvgImag.append(matCsd);
-        resultData.vecCsdAbsAvgImag.append(matCsd.cwiseAbs());
-        resultData.vecSquaredCsdAvgImag.append(matCsd.array().square());
+        inputData.vecPairCsd.append(QPair<int,MatrixXcd>(i,matCsd));
+
+//        resultData.vecCsdAvgImag.append(matCsd);
+//        resultData.vecCsdAbsAvgImag.append(matCsd.cwiseAbs());
+//        resultData.vecSquaredCsdAvgImag.append(matCsd.array().square());
     }
 
-    return resultData;
+    mutex.lock();
+
+    if(vecPairCsdSum.isEmpty()) {
+        vecPairCsdSum = inputData.vecPairCsd;
+    } else {
+        for (int j = 0; j < vecPairCsdSum.size(); ++j) {
+            vecPairCsdSum[j].second += inputData.vecPairCsd.at(j).second;
+        }
+    }
+
+    mutex.unlock();
 }
 
 
 //*************************************************************************************************************
 
-void DebiasedSquaredWeightedPhaseLagIndex::reduce(AbstractMetricResultData& finalData,
-                                                  const AbstractMetricResultData& resultData)
-{
-    // Sum over epoch
-    if(finalData.vecCsdAvgImag.isEmpty()) {
-        finalData.vecCsdAvgImag = resultData.vecCsdAvgImag;
-    } else {
-        for (int j = 0; j < finalData.vecCsdAvgImag.size(); ++j) {
-            finalData.vecCsdAvgImag[j] += resultData.vecCsdAvgImag.at(j);
-        }
-    }
+void DebiasedSquaredWeightedPhaseLagIndex::computeDSWPLV(ConnectivitySettings &connectivitySettings,
+                                                         Network& finalNetwork)
+{    
+    // Compute final DSWPLV and create Network
+    MatrixXd matNom, matDenom;
+    MatrixXd matWeight;
+    QSharedPointer<NetworkEdge> pEdge;
+    int j;
 
-    if(finalData.vecSquaredCsdAvgImag.isEmpty()) {
-        finalData.vecSquaredCsdAvgImag = resultData.vecSquaredCsdAvgImag;
-    } else {
-        for (int j = 0; j < finalData.vecSquaredCsdAvgImag.size(); ++j) {
-            finalData.vecSquaredCsdAvgImag[j] += resultData.vecSquaredCsdAvgImag.at(j);
-        }
-    }
+    for (int i = 0; i < connectivitySettings.m_dataList.first().matData.rows(); ++i) {
 
-    if(finalData.vecCsdAbsAvgImag.isEmpty()) {
-        finalData.vecCsdAbsAvgImag = resultData.vecCsdAbsAvgImag;
-    } else {
-        for (int j = 0; j < finalData.vecCsdAbsAvgImag.size(); ++j) {
-            finalData.vecCsdAbsAvgImag[j] += resultData.vecCsdAbsAvgImag.at(j);
+        matNom = connectivitySettings.data.vecPairCsdSum.at(i).second.imag().array().square();
+        matNom = matNom.array() - connectivitySettings.data.vecPairCsdSum.at(i).second.imag().array().square();
+
+        matDenom = connectivitySettings.data.vecPairCsdSum.at(i).second.imag().cwiseAbs().array().square();
+        matDenom = matDenom.array() - connectivitySettings.data.vecPairCsdSum.at(i).second.imag().array().square();
+
+//        matNom = finalResult.vecCsdAvgImag.at(j).array().square();
+//        matNom -= finalResult.vecSquaredCsdAvgImag.at(j);
+
+//        matDenom = finalResult.vecCsdAbsAvgImag.at(j).array().square();
+//        matDenom -= finalResult.vecSquaredCsdAvgImag.at(j);
+
+        matDenom = (matDenom.array() == 0.).select(INFINITY, matDenom);
+        matDenom = matNom.cwiseQuotient(matDenom);
+
+        for(j = i; j < connectivitySettings.m_dataList.at(0).matData.rows(); ++j) {
+            matWeight = matDenom.row(j).transpose();
+
+            pEdge = QSharedPointer<NetworkEdge>(new NetworkEdge(i, j, matWeight));
+
+            finalNetwork.getNodeAt(i)->append(pEdge);
+            finalNetwork.getNodeAt(j)->append(pEdge);
+            finalNetwork.append(pEdge);
         }
+
     }
 }
 

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
@@ -114,6 +114,8 @@ Network DebiasedSquaredWeightedPhaseLagIndex::calculate(const ConnectivitySettin
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
+        rowVert = RowVectorXf::Zero(3);
+
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
             rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
             rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
@@ -2,6 +2,7 @@
 /**
 * @file     debiasedsquaredweightedphaselagindex.cpp
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018
@@ -161,21 +162,21 @@ Network DebiasedSquaredWeightedPhaseLagIndex::calculate(ConnectivitySettings& co
     //    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::calculate timer - Preparation:" << iTime;
     //    timer.restart();
 
-    // Compute DSWPLV in parallel for all trials
+    // Compute DSWPLI in parallel for all trials
     QFuture<void> result = QtConcurrent::map(connectivitySettings.m_dataList,
                                              computeLambda);
     result.waitForFinished();
 
 //    iTime = timer.elapsed();
-//    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::calculate timer - Compute DSWPLV per trial:" << iTime;
+//    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::calculate timer - Compute DSWPLI per trial:" << iTime;
 //    timer.restart();
 
-    // Compute DSWPLV
-    computeDSWPLV(connectivitySettings,
+    // Compute DSWPLI
+    computeDSWPLI(connectivitySettings,
                   finalNetwork);
 
 //    iTime = timer.elapsed();
-//    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::calculate timer - Compute DSWPLV, Network creation:" << iTime;
+//    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::calculate timer - Compute DSWPLI, Network creation:" << iTime;
 //    timer.restart();
 
     return finalNetwork;
@@ -315,10 +316,10 @@ void DebiasedSquaredWeightedPhaseLagIndex::compute(ConnectivityTrialData& inputD
 
 //*************************************************************************************************************
 
-void DebiasedSquaredWeightedPhaseLagIndex::computeDSWPLV(ConnectivitySettings &connectivitySettings,
+void DebiasedSquaredWeightedPhaseLagIndex::computeDSWPLI(ConnectivitySettings &connectivitySettings,
                                                          Network& finalNetwork)
 {
-    // Compute final DSWPLV and create Network
+    // Compute final DSWPLI and create Network
     MatrixXd matNom, matDenom;
     MatrixXd matWeight;
     QSharedPointer<NetworkEdge> pEdge;

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.cpp
@@ -46,6 +46,7 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
+#include "../connectivitysettings.h"
 
 #include <utils/spectral.h>
 
@@ -95,10 +96,7 @@ DebiasedSquaredWeightedPhaseLagIndex::DebiasedSquaredWeightedPhaseLagIndex()
 
 //*******************************************************************************************************
 
-Network DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex(const QList<MatrixXd> &matDataList,
-                                                                                   const MatrixX3f& matVert,
-                                                                                   int iNfft,
-                                                                                   const QString &sWindowType)
+Network DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex(const ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -106,20 +104,20 @@ Network DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagInd
 
     Network finalNetwork("Debiased Squared Weighted Phase Lag Index");
 
-    if(matDataList.empty()) {
+    if(connectivitySettings.m_matDataList.empty()) {
         qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex - Input data is empty";
         return finalNetwork;
     }
 
     //Create nodes
-    int rows = matDataList.first().rows();
+    int rows = connectivitySettings.m_matDataList.first().rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
-        if(matVert.rows() != 0 && i < matVert.rows()) {
-            rowVert(0) = matVert.row(i)(0);
-            rowVert(1) = matVert.row(i)(1);
-            rowVert(2) = matVert.row(i)(2);
+        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
+            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
+            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
+            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
@@ -132,9 +130,9 @@ Network DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagInd
     //Calculate all-to-all coherence matrix over epochs
     QVector<MatrixXd> vecDebiasedSquaredWPLI;
     DebiasedSquaredWeightedPhaseLagIndex::computeDebiasedSquaredWPLI(vecDebiasedSquaredWPLI,
-                                                                     matDataList,
-                                                                     iNfft,
-                                                                     sWindowType);
+                                                                     connectivitySettings.m_matDataList,
+                                                                     connectivitySettings.m_iNfft,
+                                                                     connectivitySettings.m_sWindowType);
 
 //    iTime = timer.elapsed();
 //    qDebug() << "DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagIndex timer - Actual computation:" << iTime;
@@ -146,7 +144,7 @@ Network DebiasedSquaredWeightedPhaseLagIndex::debiasedSquaredWeightedPhaseLagInd
     int j;
 
     for(int i = 0; i < vecDebiasedSquaredWPLI.length(); ++i) {
-        for(j = i; j < matDataList.at(0).rows(); ++j) {
+        for(j = i; j < connectivitySettings.m_matDataList.at(0).rows(); ++j) {
             matWeight = vecDebiasedSquaredWPLI.at(i).row(j).transpose();
 
             pEdge = QSharedPointer<NetworkEdge>(new NetworkEdge(i, j, matWeight));

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
@@ -9,7 +9,7 @@
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -49,6 +49,7 @@
 #include "../connectivity_global.h"
 
 #include "abstractmetric.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -88,8 +89,6 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
-class ConnectivitySettings;
-class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -136,7 +135,7 @@ protected:
     * @param[in] iNfft                  The FFT length.
     * @param[in] tapers                 The taper information.
     */
-    static void compute(ConnectivityTrialData& inputData,
+    static void compute(ConnectivitySettings::IntermediateTrialData& inputData,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
                         QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagAbsSum,
                         QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagSqrdSum,

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
@@ -116,7 +116,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network debiasedSquaredWeightedPhaseLagIndex(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(const ConnectivitySettings &connectivitySettings);
 
     //==========================================================================================================
     /**
@@ -129,10 +129,10 @@ public:
     *
     * @return                   The DebiasedSquaredWPLI value.
     */
-    static void computeDebiasedSquaredWPLI(QVector<Eigen::MatrixXd>& vecDebiasedSquaredWPLI,
-                                           const QList<Eigen::MatrixXd> &matDataList,
-                                           int iNfft,
-                                           const QString &sWindowType);
+    static void calculate(QVector<Eigen::MatrixXd>& vecDebiasedSquaredWPLI,
+                          const QList<Eigen::MatrixXd> &matDataList,
+                          int iNfft,
+                          const QString &sWindowType);
 
 protected:
     //=========================================================================================================

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
@@ -86,6 +86,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -118,10 +119,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network debiasedSquaredWeightedPhaseLagIndex(const QList<Eigen::MatrixXd> &matDataList,
-                                                        const Eigen::MatrixX3f& matVert,
-                                                        int iNfft=-1,
-                                                        const QString &sWindowType="hanning");
+    static Network debiasedSquaredWeightedPhaseLagIndex(const ConnectivitySettings &connectivitySettings);
 
     //==========================================================================================================
     /**

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
@@ -112,10 +112,7 @@ public:
     /**
     * Calculates the debiased squared weighted phase lag index between the rows of the data matrix.
     *
-    * @param[in] matDataList    The input data.
-    * @param[in] matVert        The vertices of each network node.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[in] connectivitySettings   The input data and parameters.
     *
     * @return                   The connectivity information in form of a network structure.
     */

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
@@ -2,6 +2,7 @@
 /**
 * @file     debiasedsquaredweightedphaselagindex.h
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018
@@ -123,7 +124,7 @@ public:
 protected:
     //=========================================================================================================
     /**
-    * Computes the DSWPLV values. This function gets called in parallel.
+    * Computes the DSWPLI values. This function gets called in parallel.
     *
     * @param[in] inputData              The input data.
     * @param[out]vecPairCsdSum          The sum of all CSD matrices for each trial.
@@ -147,12 +148,12 @@ protected:
 
     //=========================================================================================================
     /**
-    * Reduces the DSWPLV computation to a final result.
+    * Reduces the DSWPLI computation to a final result.
     *
     * @param[out] connectivitySettings   The input data.
     * @param[in]  finalNetwork           The final network.
     */
-    static void computeDSWPLV(ConnectivitySettings &connectivitySettings,
+    static void computeDSWPLI(ConnectivitySettings &connectivitySettings,
                               Network& finalNetwork);
 };
 

--- a/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
+++ b/libraries/connectivity/metrics/debiasedsquaredweightedphaselagindex.h
@@ -125,16 +125,20 @@ protected:
     /**
     * Computes the DSWPLV values. This function gets called in parallel.
     *
-    * @param[in] inputData          The input data.
-    * @param[out]vecPairCsdSum      The sum of all CSD matrices for each trial.
-    * @param[in] mutex              The mutex used to safely access vecPairCsdSum.
-    * @param[in] iNRows             The number of rows.
-    * @param[in] iNFreqs            The number of frequenciy bins.
-    * @param[in] iNfft              The FFT length.
-    * @param[in] tapers             The taper information.
+    * @param[in] inputData              The input data.
+    * @param[out]vecPairCsdSum          The sum of all CSD matrices for each trial.
+    * @param[out]vecPairCsdImagAbsSum   The sum of all imag abs CSD matrices for each trial.
+    * @param[out]vecPairCsdImagSqrdSum  The sum of all imag aqrd CSD matrices for each trial.
+    * @param[in] mutex                  The mutex used to safely access vecPairCsdSum.
+    * @param[in] iNRows                 The number of rows.
+    * @param[in] iNFreqs                The number of frequenciy bins.
+    * @param[in] iNfft                  The FFT length.
+    * @param[in] tapers                 The taper information.
     */
     static void compute(ConnectivityTrialData& inputData,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
+                        QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagAbsSum,
+                        QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagSqrdSum,
                         QMutex& mutex,
                         int iNRows,
                         int iNFreqs,

--- a/libraries/connectivity/metrics/imagcoherence.cpp
+++ b/libraries/connectivity/metrics/imagcoherence.cpp
@@ -93,7 +93,7 @@ ImagCoherence::ImagCoherence()
 
 //*******************************************************************************************************
 
-Network ImagCoherence::calculate(const ConnectivitySettings& connectivitySettings)
+Network ImagCoherence::calculate(ConnectivitySettings& connectivitySettings)
 {
     Network finalNetwork("Imaginary Coherence");
 
@@ -133,7 +133,11 @@ QVector<MatrixXd> ImagCoherence::calculate(const QList<MatrixXd> &matDataList,
     QVector<QPair<int,Eigen::MatrixXcd> > vecCoh;
 
     ConnectivitySettings connectivitySettings;
-    connectivitySettings.m_matDataList = matDataList;
+    ConnectivityTrialData data;
+    for(int i = 0; i < matDataList.size(); i++) {
+        data.matData = matDataList.at(i);
+        connectivitySettings.m_dataList.append(data);
+    }
     connectivitySettings.m_iNfft = iNfft;
     connectivitySettings.m_sWindowType = sWindowType;
     Coherency::calculate(vecCoh,

--- a/libraries/connectivity/metrics/imagcoherence.cpp
+++ b/libraries/connectivity/metrics/imagcoherence.cpp
@@ -2,13 +2,14 @@
 /**
 * @file     imagcoherence.cpp
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -46,7 +47,6 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
-#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -97,22 +97,22 @@ Network ImagCoherence::calculate(ConnectivitySettings& connectivitySettings)
 {
     Network finalNetwork("Imaginary Coherence");
 
-    if(connectivitySettings.m_dataList.empty()) {
+    if(connectivitySettings.isEmpty()) {
         qDebug() << "ImagCoherence::imagcoherence - Input data is empty";
         return finalNetwork;
     }
 
     //Create nodes
-    int rows = connectivitySettings.m_dataList.first().matData.rows();
+    int rows = connectivitySettings.at(0).matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
         rowVert = RowVectorXf::Zero(3);
 
-        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
-            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
-            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
-            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
+        if(connectivitySettings.getNodePositions().rows() != 0 && i < connectivitySettings.getNodePositions().rows()) {
+            rowVert(0) = connectivitySettings.getNodePositions().row(i)(0);
+            rowVert(1) = connectivitySettings.getNodePositions().row(i)(1);
+            rowVert(2) = connectivitySettings.getNodePositions().row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));

--- a/libraries/connectivity/metrics/imagcoherence.cpp
+++ b/libraries/connectivity/metrics/imagcoherence.cpp
@@ -107,6 +107,8 @@ Network ImagCoherence::calculate(ConnectivitySettings& connectivitySettings)
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
+        rowVert = RowVectorXf::Zero(3);
+
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
             rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
             rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);

--- a/libraries/connectivity/metrics/imagcoherence.cpp
+++ b/libraries/connectivity/metrics/imagcoherence.cpp
@@ -46,6 +46,7 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -92,27 +93,24 @@ ImagCoherence::ImagCoherence()
 
 //*******************************************************************************************************
 
-Network ImagCoherence::imagCoherence(const QList<MatrixXd> &matDataList,
-                                     const MatrixX3f& matVert,
-                                     int iNfft,
-                                     const QString &sWindowType)
+Network ImagCoherence::imagCoherence(const ConnectivitySettings& connectivitySettings)
 {
     Network finalNetwork("Imaginary Coherence");
 
-    if(matDataList.empty()) {
+    if(connectivitySettings.m_matDataList.empty()) {
         qDebug() << "ImagCoherence::imagcoherence - Input data is empty";
         return finalNetwork;
     }
 
     //Create nodes
-    int rows = matDataList.first().rows();
+    int rows = connectivitySettings.m_matDataList.first().rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
-        if(matVert.rows() != 0 && i < matVert.rows()) {
-            rowVert(0) = matVert.row(i)(0);
-            rowVert(1) = matVert.row(i)(1);
-            rowVert(2) = matVert.row(i)(2);
+        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
+            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
+            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
+            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
@@ -120,9 +118,9 @@ Network ImagCoherence::imagCoherence(const QList<MatrixXd> &matDataList,
 
     //Calculate all-to-all imaginary coherence matrix over epochs
     Coherency::computeCoherencyImag(finalNetwork,
-                                    matDataList,
-                                    iNfft,
-                                    sWindowType);
+                                    connectivitySettings.m_matDataList,
+                                    connectivitySettings.m_iNfft,
+                                    connectivitySettings.m_sWindowType);
 
     return finalNetwork;
 }

--- a/libraries/connectivity/metrics/imagcoherence.cpp
+++ b/libraries/connectivity/metrics/imagcoherence.cpp
@@ -118,9 +118,7 @@ Network ImagCoherence::imagCoherence(const ConnectivitySettings& connectivitySet
 
     //Calculate all-to-all imaginary coherence matrix over epochs
     Coherency::computeCoherencyImag(finalNetwork,
-                                    connectivitySettings.m_matDataList,
-                                    connectivitySettings.m_iNfft,
-                                    connectivitySettings.m_sWindowType);
+                                    connectivitySettings);
 
     return finalNetwork;
 }
@@ -134,10 +132,12 @@ QVector<MatrixXd> ImagCoherence::computeImagCoherence(const QList<MatrixXd> &mat
 {
     QVector<QPair<int,Eigen::MatrixXcd> > vecCoh;
 
+    ConnectivitySettings connectivitySettings;
+    connectivitySettings.m_matDataList = matDataList;
+    connectivitySettings.m_iNfft = iNfft;
+    connectivitySettings.m_sWindowType = sWindowType;
     Coherency::computeCoherency(vecCoh,
-                                matDataList,
-                                iNfft,
-                                sWindowType);
+                                connectivitySettings);
 
 
     QVector<MatrixXd> result;

--- a/libraries/connectivity/metrics/imagcoherence.cpp
+++ b/libraries/connectivity/metrics/imagcoherence.cpp
@@ -93,7 +93,7 @@ ImagCoherence::ImagCoherence()
 
 //*******************************************************************************************************
 
-Network ImagCoherence::imagCoherence(const ConnectivitySettings& connectivitySettings)
+Network ImagCoherence::calculate(const ConnectivitySettings& connectivitySettings)
 {
     Network finalNetwork("Imaginary Coherence");
 
@@ -117,8 +117,8 @@ Network ImagCoherence::imagCoherence(const ConnectivitySettings& connectivitySet
     }
 
     //Calculate all-to-all imaginary coherence matrix over epochs
-    Coherency::computeCoherencyImag(finalNetwork,
-                                    connectivitySettings);
+    Coherency::calculateImag(finalNetwork,
+                             connectivitySettings);
 
     return finalNetwork;
 }
@@ -126,9 +126,9 @@ Network ImagCoherence::imagCoherence(const ConnectivitySettings& connectivitySet
 
 //*************************************************************************************************************
 
-QVector<MatrixXd> ImagCoherence::computeImagCoherence(const QList<MatrixXd> &matDataList,
-                                                      int iNfft,
-                                                      const QString &sWindowType)
+QVector<MatrixXd> ImagCoherence::calculate(const QList<MatrixXd> &matDataList,
+                                          int iNfft,
+                                          const QString &sWindowType)
 {
     QVector<QPair<int,Eigen::MatrixXcd> > vecCoh;
 
@@ -136,8 +136,8 @@ QVector<MatrixXd> ImagCoherence::computeImagCoherence(const QList<MatrixXd> &mat
     connectivitySettings.m_matDataList = matDataList;
     connectivitySettings.m_iNfft = iNfft;
     connectivitySettings.m_sWindowType = sWindowType;
-    Coherency::computeCoherency(vecCoh,
-                                connectivitySettings);
+    Coherency::calculate(vecCoh,
+                         connectivitySettings);
 
 
     QVector<MatrixXd> result;

--- a/libraries/connectivity/metrics/imagcoherence.cpp
+++ b/libraries/connectivity/metrics/imagcoherence.cpp
@@ -97,13 +97,13 @@ Network ImagCoherence::calculate(ConnectivitySettings& connectivitySettings)
 {
     Network finalNetwork("Imaginary Coherence");
 
-    if(connectivitySettings.m_matDataList.empty()) {
+    if(connectivitySettings.m_dataList.empty()) {
         qDebug() << "ImagCoherence::imagcoherence - Input data is empty";
         return finalNetwork;
     }
 
     //Create nodes
-    int rows = connectivitySettings.m_matDataList.first().rows();
+    int rows = connectivitySettings.m_dataList.first().matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
@@ -123,34 +123,4 @@ Network ImagCoherence::calculate(ConnectivitySettings& connectivitySettings)
                              connectivitySettings);
 
     return finalNetwork;
-}
-
-
-//*************************************************************************************************************
-
-QVector<MatrixXd> ImagCoherence::calculate(const QList<MatrixXd> &matDataList,
-                                          int iNfft,
-                                          const QString &sWindowType)
-{
-    QVector<QPair<int,Eigen::MatrixXcd> > vecCoh;
-
-    ConnectivitySettings connectivitySettings;
-    ConnectivityTrialData data;
-    for(int i = 0; i < matDataList.size(); i++) {
-        data.matData = matDataList.at(i);
-        connectivitySettings.m_dataList.append(data);
-    }
-    connectivitySettings.m_iNfft = iNfft;
-    connectivitySettings.m_sWindowType = sWindowType;
-    Coherency::calculate(vecCoh,
-                         connectivitySettings);
-
-
-    QVector<MatrixXd> result;
-
-    for(int i = 0; i < vecCoh.length(); ++i) {
-        result << vecCoh.at(i).second.imag();
-    }
-
-    return result;
 }

--- a/libraries/connectivity/metrics/imagcoherence.h
+++ b/libraries/connectivity/metrics/imagcoherence.h
@@ -116,7 +116,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network calculate(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**

--- a/libraries/connectivity/metrics/imagcoherence.h
+++ b/libraries/connectivity/metrics/imagcoherence.h
@@ -86,6 +86,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -118,10 +119,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network imagCoherence(const QList<Eigen::MatrixXd> &matDataList,
-                                 const Eigen::MatrixX3f& matVert,
-                                 int iNfft=-1,
-                                 const QString &sWindowType="hanning");
+    static Network imagCoherence(const ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**

--- a/libraries/connectivity/metrics/imagcoherence.h
+++ b/libraries/connectivity/metrics/imagcoherence.h
@@ -112,10 +112,7 @@ public:
     /**
     * Calculates the imaginary coherence between the rows of the data matrix.
     *
-    * @param[in] matDataList    The input data.
-    * @param[in] matVert        The vertices of each network node.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[in] connectivitySettings   The input data and parameters.
     *
     * @return                   The connectivity information in form of a network structure.
     */

--- a/libraries/connectivity/metrics/imagcoherence.h
+++ b/libraries/connectivity/metrics/imagcoherence.h
@@ -116,7 +116,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network imagCoherence(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(const ConnectivitySettings &connectivitySettings);
 
     //=========================================================================================================
     /**
@@ -128,7 +128,7 @@ public:
     *
     * @return                   The connectivity information in form of a QVector of matrices.
     */
-    static QVector<Eigen::MatrixXd> computeImagCoherence(const QList<Eigen::MatrixXd> &matDataList,
+    static QVector<Eigen::MatrixXd> calculate(const QList<Eigen::MatrixXd> &matDataList,
                                                          int iNfft,
                                                          const QString &sWindowType="hanning");
 };

--- a/libraries/connectivity/metrics/imagcoherence.h
+++ b/libraries/connectivity/metrics/imagcoherence.h
@@ -2,13 +2,14 @@
 /**
 * @file     imagcoherenence.h
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -48,6 +49,7 @@
 #include "../connectivity_global.h"
 
 #include "abstractmetric.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -86,7 +88,6 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
-class ConnectivitySettings;
 
 
 //=============================================================================================================

--- a/libraries/connectivity/metrics/imagcoherence.h
+++ b/libraries/connectivity/metrics/imagcoherence.h
@@ -117,20 +117,6 @@ public:
     * @return                   The connectivity information in form of a network structure.
     */
     static Network calculate(ConnectivitySettings &connectivitySettings);
-
-    //=========================================================================================================
-    /**
-    * Calculates the imaginary coherence of the rows of the data matrix.
-    *
-    * @param[in] matDataList    The input data.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
-    *
-    * @return                   The connectivity information in form of a QVector of matrices.
-    */
-    static QVector<Eigen::MatrixXd> calculate(const QList<Eigen::MatrixXd> &matDataList,
-                                                         int iNfft,
-                                                         const QString &sWindowType="hanning");
 };
 
 

--- a/libraries/connectivity/metrics/phaselagindex.cpp
+++ b/libraries/connectivity/metrics/phaselagindex.cpp
@@ -9,7 +9,7 @@
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -47,7 +47,6 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
-#include "../connectivitysettings.h"
 
 #include <utils/spectral.h>
 
@@ -105,7 +104,7 @@ Network PhaseLagIndex::calculate(ConnectivitySettings& connectivitySettings)
 
     Network finalNetwork("Phase Lag Index");
 
-    if(connectivitySettings.m_dataList.empty()) {
+    if(connectivitySettings.isEmpty()) {
         qDebug() << "PhaseLagIndex::calculate - Input data is empty";
         return finalNetwork;
     }
@@ -115,40 +114,40 @@ Network PhaseLagIndex::calculate(ConnectivitySettings& connectivitySettings)
     #endif
 
     //Create nodes
-    int iNRows = connectivitySettings.m_dataList.first().matData.rows();
+    int iNRows = connectivitySettings.at(0).matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < iNRows; ++i) {
         rowVert = RowVectorXf::Zero(3);
 
-        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
-            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
-            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
-            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
+        if(connectivitySettings.getNodePositions().rows() != 0 && i < connectivitySettings.getNodePositions().rows()) {
+            rowVert(0) = connectivitySettings.getNodePositions().row(i)(0);
+            rowVert(1) = connectivitySettings.getNodePositions().row(i)(1);
+            rowVert(2) = connectivitySettings.getNodePositions().row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
     }
 
     // Check that iNfft >= signal length
-    int iSignalLength = connectivitySettings.m_dataList.at(0).matData.cols();
-    int iNfft = connectivitySettings.m_iNfft;
+    int iSignalLength = connectivitySettings.at(0).matData.cols();
+    int iNfft = connectivitySettings.getNumberFFT();
     if (iNfft < iSignalLength) {
         iNfft = iSignalLength;
     }
 
     // Generate tapers
-    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.m_sWindowType);
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());
 
     // Initialize
     int iNFreqs = int(floor(iNfft / 2.0)) + 1;
 
     QMutex mutex;
 
-    std::function<void(ConnectivityTrialData&)> computeLambda = [&](ConnectivityTrialData& inputData) {
+    std::function<void(ConnectivitySettings::IntermediateTrialData&)> computeLambda = [&](ConnectivitySettings::IntermediateTrialData& inputData) {
         compute(inputData,
-                connectivitySettings.data.vecPairCsdSum,
-                connectivitySettings.data.vecPairCsdImagSignSum,
+                connectivitySettings.getIntermediateSumData().vecPairCsdSum,
+                connectivitySettings.getIntermediateSumData().vecPairCsdImagSignSum,
                 mutex,
                 iNRows,
                 iNFreqs,
@@ -161,7 +160,7 @@ Network PhaseLagIndex::calculate(ConnectivitySettings& connectivitySettings)
 //    timer.restart();
 
     // Compute DSWPLV in parallel for all trials
-    QFuture<void> result = QtConcurrent::map(connectivitySettings.m_dataList,
+    QFuture<void> result = QtConcurrent::map(connectivitySettings.getTrialData(),
                                              computeLambda);
     result.waitForFinished();
 
@@ -183,7 +182,7 @@ Network PhaseLagIndex::calculate(ConnectivitySettings& connectivitySettings)
 
 //*************************************************************************************************************
 
-void PhaseLagIndex::compute(ConnectivityTrialData& inputData,
+void PhaseLagIndex::compute(ConnectivitySettings::IntermediateTrialData& inputData,
                             QVector<QPair<int,MatrixXcd> >& vecPairCsdSum,
                             QVector<QPair<int,MatrixXd> >& vecPairCsdImagSignSum,
                             QMutex& mutex,
@@ -299,8 +298,8 @@ void PhaseLagIndex::computePLI(ConnectivitySettings &connectivitySettings,
     QSharedPointer<NetworkEdge> pEdge;
     int j;
 
-    for (int i = 0; i < connectivitySettings.data.vecPairCsdImagSignSum.size(); ++i) {
-        matNom = connectivitySettings.data.vecPairCsdImagSignSum.at(i).second.cwiseAbs() / connectivitySettings.size();
+    for (int i = 0; i < connectivitySettings.getIntermediateSumData().vecPairCsdImagSignSum.size(); ++i) {
+        matNom = connectivitySettings.getIntermediateSumData().vecPairCsdImagSignSum.at(i).second.cwiseAbs() / connectivitySettings.size();
 
         for(j = i; j < matNom.rows(); ++j) {
             matWeight = matNom.row(j).transpose();

--- a/libraries/connectivity/metrics/phaselagindex.cpp
+++ b/libraries/connectivity/metrics/phaselagindex.cpp
@@ -114,6 +114,8 @@ Network PhaseLagIndex::calculate(const ConnectivitySettings& connectivitySetting
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
+        rowVert = RowVectorXf::Zero(3);
+
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
             rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
             rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);

--- a/libraries/connectivity/metrics/phaselagindex.cpp
+++ b/libraries/connectivity/metrics/phaselagindex.cpp
@@ -132,6 +132,9 @@ Network PhaseLagIndex::calculate(ConnectivitySettings& connectivitySettings)
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
+    if(iNfft > iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());
@@ -210,7 +213,7 @@ void PhaseLagIndex::compute(ConnectivitySettings::IntermediateTrialData& inputDa
             // Substract mean
             rowData.array() = inputData.matData.row(i).array() - inputData.matData.row(i).mean();
 
-            // Calculate tapered spectra if not available already
+            // Calculate tapered spectra
             for(j = 0; j < tapers.first.rows(); j++) {
                 vecInputFFT = rowData.cwiseProduct(tapers.first.row(j));
                 // FFT for freq domain returning the half spectrum and multiply taper weights

--- a/libraries/connectivity/metrics/phaselagindex.cpp
+++ b/libraries/connectivity/metrics/phaselagindex.cpp
@@ -96,7 +96,7 @@ PhaseLagIndex::PhaseLagIndex()
 
 //*******************************************************************************************************
 
-Network PhaseLagIndex::phaseLagIndex(const ConnectivitySettings& connectivitySettings)
+Network PhaseLagIndex::calculate(const ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -129,10 +129,10 @@ Network PhaseLagIndex::phaseLagIndex(const ConnectivitySettings& connectivitySet
 
     //Calculate all-to-all coherence matrix over epochs
     QVector<MatrixXd> vecPLI;
-    PhaseLagIndex::computePLI(vecPLI,
-                              connectivitySettings.m_matDataList,
-                              connectivitySettings.m_iNfft,
-                              connectivitySettings.m_sWindowType);
+    PhaseLagIndex::calculate(vecPLI,
+                             connectivitySettings.m_matDataList,
+                             connectivitySettings.m_iNfft,
+                             connectivitySettings.m_sWindowType);
 
 //    iTime = timer.elapsed();
 //    qDebug() << "PhaseLagIndex::phaseLagIndex timer - Actual computation:" << iTime;
@@ -165,10 +165,10 @@ Network PhaseLagIndex::phaseLagIndex(const ConnectivitySettings& connectivitySet
 
 //*************************************************************************************************************
 
-void PhaseLagIndex::computePLI(QVector<MatrixXd>& vecPLI,
-                               const QList<MatrixXd> &matDataList,
-                               int iNfft,
-                               const QString &sWindowType)
+void PhaseLagIndex::calculate(QVector<MatrixXd>& vecPLI,
+                              const QList<MatrixXd> &matDataList,
+                              int iNfft,
+                              const QString &sWindowType)
 {
     #ifdef EIGEN_FFTW_DEFAULT
         fftw_make_planner_thread_safe();

--- a/libraries/connectivity/metrics/phaselagindex.cpp
+++ b/libraries/connectivity/metrics/phaselagindex.cpp
@@ -2,6 +2,7 @@
 /**
 * @file     phaselagindex.cpp
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018

--- a/libraries/connectivity/metrics/phaselagindex.cpp
+++ b/libraries/connectivity/metrics/phaselagindex.cpp
@@ -132,9 +132,6 @@ Network PhaseLagIndex::calculate(ConnectivitySettings& connectivitySettings)
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
-    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/phaselagindex.h
+++ b/libraries/connectivity/metrics/phaselagindex.h
@@ -56,6 +56,7 @@
 //=============================================================================================================
 
 #include <QSharedPointer>
+#include <QMutex>
 
 
 //*************************************************************************************************************
@@ -87,6 +88,7 @@ namespace CONNECTIVITYLIB {
 
 class Network;
 class ConnectivitySettings;
+class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -116,52 +118,38 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network calculate(const ConnectivitySettings& connectivitySettings);
-
-    //==========================================================================================================
-    /**
-    * Calculates the actual phase lag index between two data vectors.
-    *
-    * @param[out] vecPLI        The resulting data.
-    * @param[in] matDataList    The input data.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
-    *
-    * @return                   The PLI value.
-    */
-    static void calculate(QVector<Eigen::MatrixXd>& vecPLI,
-                          const QList<Eigen::MatrixXd> &matDataList,
-                          int iNfft,
-                          const QString &sWindowType);
+    static Network calculate(ConnectivitySettings& connectivitySettings);
 
 protected:
     //=========================================================================================================
     /**
     * Computes the PLI values. This function gets called in parallel.
     *
-    * @param[in] matInputData           The input data.
+    * @param[in] inputData              The input data.
+    * @param[out]vecPairCsdImagSignSum  The sum of all imag sign CSD matrices for each trial.
+    * @param[in] mutex                  The mutex used to safely access vecPairCsdSum.
     * @param[in] iNRows                 The number of rows.
     * @param[in] iNFreqs                The number of frequenciy bins.
     * @param[in] iNfft                  The FFT length.
     * @param[in] tapers                 The taper information.
-    *
-    * @return            The coherency result in form of AbstractMetricResultData.
     */
-    static QVector<Eigen::MatrixXcd> compute(const Eigen::MatrixXd& matInputData,
-                                             int iNRows,
-                                             int iNFreqs,
-                                             int iNfft,
-                                             const QPair<Eigen::MatrixXd, Eigen::VectorXd>& tapers);
+    static void compute(ConnectivityTrialData& inputData,
+                        QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagSignSum,
+                        QMutex& mutex,
+                        int iNRows,
+                        int iNFreqs,
+                        int iNfft,
+                        const QPair<Eigen::MatrixXd, Eigen::VectorXd>& tapers);
 
     //=========================================================================================================
     /**
-    * Reduces the PLI computation to a final result. This function gets called in parallel.
+    * Reduces the PLI computation to a final result.
     *
-    * @param[out] finalData    The final data.
-    * @param[in]  resultData   The resulting data from the computation step.
+    * @param[out] connectivitySettings   The input data.
+    * @param[in]  finalNetwork           The final network.
     */
-    static void reduce(QVector<Eigen::MatrixXcd>& finalData,
-                       const QVector<Eigen::MatrixXcd>& resultData);
+    static void computePLI(ConnectivitySettings &connectivitySettings,
+                          Network& finalNetwork);
 
 };
 

--- a/libraries/connectivity/metrics/phaselagindex.h
+++ b/libraries/connectivity/metrics/phaselagindex.h
@@ -2,6 +2,7 @@
 /**
 * @file     phaselagindex.h
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018

--- a/libraries/connectivity/metrics/phaselagindex.h
+++ b/libraries/connectivity/metrics/phaselagindex.h
@@ -112,10 +112,7 @@ public:
     /**
     * Calculates the PLI between the rows of the data matrix.
     *
-    * @param[in] matDataList    The input data.
-    * @param[in] matVert        The vertices of each network node.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[in] connectivitySettings   The input data and parameters.
     *
     * @return                   The connectivity information in form of a network structure.
     */

--- a/libraries/connectivity/metrics/phaselagindex.h
+++ b/libraries/connectivity/metrics/phaselagindex.h
@@ -9,7 +9,7 @@
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -49,6 +49,7 @@
 #include "../connectivity_global.h"
 
 #include "abstractmetric.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -88,8 +89,6 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
-class ConnectivitySettings;
-class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -135,7 +134,7 @@ protected:
     * @param[in] iNfft                  The FFT length.
     * @param[in] tapers                 The taper information.
     */
-    static void compute(ConnectivityTrialData& inputData,
+    static void compute(ConnectivitySettings::IntermediateTrialData& inputData,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
                         QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagSignSum,
                         QMutex& mutex,

--- a/libraries/connectivity/metrics/phaselagindex.h
+++ b/libraries/connectivity/metrics/phaselagindex.h
@@ -86,6 +86,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -118,10 +119,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network phaseLagIndex(const QList<Eigen::MatrixXd> &matDataList,
-                                 const Eigen::MatrixX3f& matVert,
-                                 int iNfft=-1,
-                                 const QString &sWindowType="hanning");
+    static Network phaseLagIndex(const ConnectivitySettings& connectivitySettings);
 
     //==========================================================================================================
     /**

--- a/libraries/connectivity/metrics/phaselagindex.h
+++ b/libraries/connectivity/metrics/phaselagindex.h
@@ -116,7 +116,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network phaseLagIndex(const ConnectivitySettings& connectivitySettings);
+    static Network calculate(const ConnectivitySettings& connectivitySettings);
 
     //==========================================================================================================
     /**
@@ -129,10 +129,10 @@ public:
     *
     * @return                   The PLI value.
     */
-    static void computePLI(QVector<Eigen::MatrixXd>& vecPLI,
-                           const QList<Eigen::MatrixXd> &matDataList,
-                           int iNfft,
-                           const QString &sWindowType);
+    static void calculate(QVector<Eigen::MatrixXd>& vecPLI,
+                          const QList<Eigen::MatrixXd> &matDataList,
+                          int iNfft,
+                          const QString &sWindowType);
 
 protected:
     //=========================================================================================================

--- a/libraries/connectivity/metrics/phaselagindex.h
+++ b/libraries/connectivity/metrics/phaselagindex.h
@@ -126,6 +126,7 @@ protected:
     * Computes the PLI values. This function gets called in parallel.
     *
     * @param[in] inputData              The input data.
+    * @param[out]vecPairCsdSum          The sum of all CSD matrices for each trial.
     * @param[out]vecPairCsdImagSignSum  The sum of all imag sign CSD matrices for each trial.
     * @param[in] mutex                  The mutex used to safely access vecPairCsdSum.
     * @param[in] iNRows                 The number of rows.
@@ -134,6 +135,7 @@ protected:
     * @param[in] tapers                 The taper information.
     */
     static void compute(ConnectivityTrialData& inputData,
+                        QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
                         QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagSignSum,
                         QMutex& mutex,
                         int iNRows,

--- a/libraries/connectivity/metrics/phaselockingvalue.cpp
+++ b/libraries/connectivity/metrics/phaselockingvalue.cpp
@@ -98,9 +98,9 @@ PhaseLockingValue::PhaseLockingValue()
 
 Network PhaseLockingValue::calculate(ConnectivitySettings& connectivitySettings)
 {
-    QElapsedTimer timer;
-    qint64 iTime = 0;
-    timer.start();
+//    QElapsedTimer timer;
+//    qint64 iTime = 0;
+//    timer.start();
 
     Network finalNetwork("Phase Locking Value");
 
@@ -155,26 +155,26 @@ Network PhaseLockingValue::calculate(ConnectivitySettings& connectivitySettings)
                 tapers);
     };
 
-    iTime = timer.elapsed();
-    qDebug() << "PhaseLockingValue::calculate timer - Preparation:" << iTime;
-    timer.restart();
+//    iTime = timer.elapsed();
+//    qDebug() << "PhaseLockingValue::calculate timer - Preparation:" << iTime;
+//    timer.restart();
 
     // Compute PLV in parallel for all trials
     QFuture<void> result = QtConcurrent::map(connectivitySettings.getTrialData(),
                                              computeLambda);
     result.waitForFinished();
 
-    iTime = timer.elapsed();
-    qDebug() << "PhaseLockingValue::calculate timer - Compute PLV per trial:" << iTime;
-    timer.restart();
+//    iTime = timer.elapsed();
+//    qDebug() << "PhaseLockingValue::calculate timer - Compute PLV per trial:" << iTime;
+//    timer.restart();
 
     // Compute PLV
     computePLV(connectivitySettings,
                finalNetwork);
 
-    iTime = timer.elapsed();
-    qDebug() << "PhaseLockingValue::PhaseLagIndex timer - Compute PLV, Network creation:" << iTime;
-    timer.restart();
+//    iTime = timer.elapsed();
+//    qDebug() << "PhaseLockingValue::PhaseLagIndex timer - Compute PLV, Network creation:" << iTime;
+//    timer.restart();
 
     return finalNetwork;
 }

--- a/libraries/connectivity/metrics/phaselockingvalue.cpp
+++ b/libraries/connectivity/metrics/phaselockingvalue.cpp
@@ -159,7 +159,7 @@ Network PhaseLockingValue::calculate(ConnectivitySettings& connectivitySettings)
     //    qDebug() << "PhaseLockingValue::calculate timer - Preparation:" << iTime;
     //    timer.restart();
 
-    // Compute DSWPLV in parallel for all trials
+    // Compute PLV in parallel for all trials
     QFuture<void> result = QtConcurrent::map(connectivitySettings.m_dataList,
                                              computeLambda);
     result.waitForFinished();

--- a/libraries/connectivity/metrics/phaselockingvalue.cpp
+++ b/libraries/connectivity/metrics/phaselockingvalue.cpp
@@ -96,7 +96,7 @@ PhaseLockingValue::PhaseLockingValue()
 
 //*******************************************************************************************************
 
-Network PhaseLockingValue::phaseLockingValue(const ConnectivitySettings& connectivitySettings)
+Network PhaseLockingValue::calculate(const ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -128,7 +128,7 @@ Network PhaseLockingValue::phaseLockingValue(const ConnectivitySettings& connect
 //    timer.restart();
 
     //Calculate all-to-all coherence matrix over epochs
-    QVector<MatrixXd> vecPLV = PhaseLockingValue::computePLV(connectivitySettings.m_matDataList,
+    QVector<MatrixXd> vecPLV = PhaseLockingValue::calculate(connectivitySettings.m_matDataList,
                                                              connectivitySettings.m_iNfft,
                                                              connectivitySettings.m_sWindowType);
 
@@ -163,9 +163,9 @@ Network PhaseLockingValue::phaseLockingValue(const ConnectivitySettings& connect
 
 //*************************************************************************************************************
 
-QVector<MatrixXd> PhaseLockingValue::computePLV(const QList<MatrixXd> &matDataList,
-                                                int iNfft,
-                                                const QString &sWindowType)
+QVector<MatrixXd> PhaseLockingValue::calculate(const QList<MatrixXd> &matDataList,
+                                               int iNfft,
+                                               const QString &sWindowType)
 {
     #ifdef EIGEN_FFTW_DEFAULT
         fftw_make_planner_thread_safe();

--- a/libraries/connectivity/metrics/phaselockingvalue.cpp
+++ b/libraries/connectivity/metrics/phaselockingvalue.cpp
@@ -114,6 +114,8 @@ Network PhaseLockingValue::calculate(const ConnectivitySettings& connectivitySet
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
+        rowVert = RowVectorXf::Zero(3);
+
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
             rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
             rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);

--- a/libraries/connectivity/metrics/phaselockingvalue.cpp
+++ b/libraries/connectivity/metrics/phaselockingvalue.cpp
@@ -132,6 +132,9 @@ Network PhaseLockingValue::calculate(ConnectivitySettings& connectivitySettings)
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
+    if(iNfft > iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/phaselockingvalue.cpp
+++ b/libraries/connectivity/metrics/phaselockingvalue.cpp
@@ -132,9 +132,6 @@ Network PhaseLockingValue::calculate(ConnectivitySettings& connectivitySettings)
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
-    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/phaselockingvalue.cpp
+++ b/libraries/connectivity/metrics/phaselockingvalue.cpp
@@ -96,7 +96,7 @@ PhaseLockingValue::PhaseLockingValue()
 
 //*******************************************************************************************************
 
-Network PhaseLockingValue::calculate(const ConnectivitySettings& connectivitySettings)
+Network PhaseLockingValue::calculate(ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -104,16 +104,20 @@ Network PhaseLockingValue::calculate(const ConnectivitySettings& connectivitySet
 
     Network finalNetwork("Phase Locking Value");
 
-    if(connectivitySettings.m_matDataList.empty()) {
-        qDebug() << "PhaseLockingValue::phaseLockingValue - Input data is empty";
+    if(connectivitySettings.m_dataList.empty()) {
+        qDebug() << "PhaseLockingValue::calculate - Input data is empty";
         return finalNetwork;
     }
 
+    #ifdef EIGEN_FFTW_DEFAULT
+        fftw_make_planner_thread_safe();
+    #endif
+
     //Create nodes
-    int rows = connectivitySettings.m_matDataList.first().rows();
+    int iNRows = connectivitySettings.m_dataList.first().matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
-    for(int i = 0; i < rows; ++i) {
+    for(int i = 0; i < iNRows; ++i) {
         rowVert = RowVectorXf::Zero(3);
 
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
@@ -125,38 +129,50 @@ Network PhaseLockingValue::calculate(const ConnectivitySettings& connectivitySet
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
     }
 
-//    iTime = timer.elapsed();
-//    qDebug() << "PhaseLockingValue::phaseLockingValue timer - Preparation:" << iTime;
-//    timer.restart();
-
-    //Calculate all-to-all coherence matrix over epochs
-    QVector<MatrixXd> vecPLV = PhaseLockingValue::calculate(connectivitySettings.m_matDataList,
-                                                             connectivitySettings.m_iNfft,
-                                                             connectivitySettings.m_sWindowType);
-
-//    iTime = timer.elapsed();
-//    qDebug() << "PhaseLockingValue::phaseLockingValue timer - Actual computation:" << iTime;
-//    timer.restart();
-
-    //Add edges to network
-    QSharedPointer<NetworkEdge> pEdge;
-    MatrixXd matWeight;
-    int j;
-
-    for(int i = 0; i < vecPLV.length(); ++i) {
-        for(j = i; j < connectivitySettings.m_matDataList.at(0).rows(); ++j) {
-            matWeight = vecPLV.at(i).row(j).transpose();
-
-            pEdge = QSharedPointer<NetworkEdge>(new NetworkEdge(i, j, matWeight));
-
-            finalNetwork.getNodeAt(i)->append(pEdge);
-            finalNetwork.getNodeAt(j)->append(pEdge);
-            finalNetwork.append(pEdge);
-        }
+    // Check that iNfft >= signal length
+    int iSignalLength = connectivitySettings.m_dataList.at(0).matData.cols();
+    int iNfft = connectivitySettings.m_iNfft;
+    if (iNfft < iSignalLength) {
+        iNfft = iSignalLength;
     }
 
+    // Generate tapers
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.m_sWindowType);
+
+    // Initialize
+    int iNFreqs = int(floor(iNfft / 2.0)) + 1;
+
+    QMutex mutex;
+
+    std::function<void(ConnectivityTrialData&)> computeLambda = [&](ConnectivityTrialData& inputData) {
+        compute(inputData,
+                connectivitySettings.data.vecPairCsdNormalizedSum,
+                mutex,
+                iNRows,
+                iNFreqs,
+                iNfft,
+                tapers);
+    };
+
+    //    iTime = timer.elapsed();
+    //    qDebug() << "PhaseLockingValue::calculate timer - Preparation:" << iTime;
+    //    timer.restart();
+
+    // Compute DSWPLV in parallel for all trials
+    QFuture<void> result = QtConcurrent::map(connectivitySettings.m_dataList,
+                                             computeLambda);
+    result.waitForFinished();
+
 //    iTime = timer.elapsed();
-//    qDebug() << "PhaseLockingValue::phaseLockingValue timer - Network creation:" << iTime;
+//    qDebug() << "PhaseLockingValue::calculate timer - Compute PLV per trial:" << iTime;
+//    timer.restart();
+
+    // Compute PLV
+    computePLV(connectivitySettings,
+               finalNetwork);
+
+//    iTime = timer.elapsed();
+//    qDebug() << "PhaseLockingValue::PhaseLagIndex timer - Compute PLV, Network creation:" << iTime;
 //    timer.restart();
 
     return finalNetwork;
@@ -165,142 +181,122 @@ Network PhaseLockingValue::calculate(const ConnectivitySettings& connectivitySet
 
 //*************************************************************************************************************
 
-QVector<MatrixXd> PhaseLockingValue::calculate(const QList<MatrixXd> &matDataList,
-                                               int iNfft,
-                                               const QString &sWindowType)
+void PhaseLockingValue::compute(ConnectivityTrialData& inputData,
+                                QVector<QPair<int,MatrixXcd> >& vecPairCsdNormalizedSum,
+                                QMutex& mutex,
+                                int iNRows,
+                                int iNFreqs,
+                                int iNfft,
+                                const QPair<MatrixXd, VectorXd>& tapers)
 {
-    #ifdef EIGEN_FFTW_DEFAULT
-        fftw_make_planner_thread_safe();
-    #endif
-
-    if(matDataList.isEmpty()) {
-        return QVector<MatrixXd>();
+    if(inputData.vecPairCsdNormalized.size() == iNRows) {
+        //qDebug() << "PhaseLockingValue::compute - vecPairCsdNormalized was already computed for this trial.";
+        return;
     }
-
-    // Check that iNfft >= signal length
-    int iSignalLength = matDataList.at(0).cols();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
-    }
-
-    // Generate tapers
-    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
-
-    int iNRows = matDataList.at(0).rows();
-    int iNFreqs = int(floor(iNfft / 2.0)) + 1;
-
-//    // Sequential
-//    AbstractMetricResultData finalResult;
-
-//    for (int i = 0; i < lData.length(); ++i) {
-//        reduce(finalResult, compute(lData.at(i)));
-//    }
-
-    // Parallel
-    std::function<QVector<MatrixXcd>(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
-        return compute(matInputData,
-                       iNRows,
-                       iNFreqs,
-                       iNfft,
-                       tapers);
-    };
-
-    QFuture<QVector<MatrixXcd> > result = QtConcurrent::mappedReduced(matDataList,
-                                                                      computeLambda,
-                                                                      reduce);
-    result.waitForFinished();
-
-    QVector<MatrixXcd> finalResult = result.result();
-
-    QVector<MatrixXd> vecPLV;
-    for (int i = 0; i < finalResult.size(); ++i) {
-        vecPLV.append(finalResult.at(i).cwiseAbs() / matDataList.length());
-    }
-
-    return vecPLV;
-}
-
-
-//*************************************************************************************************************
-
-QVector<MatrixXcd> PhaseLockingValue::compute(const MatrixXd& matInputData,
-                                              int iNRows,
-                                              int iNFreqs,
-                                              int iNfft,
-                                              const QPair<MatrixXd, VectorXd>& tapers)
-{
-    // Initialize vecCsdAvg
-    QVector<MatrixXcd> vecCsdAvg;
-
-    // Subtract mean, generate tapered spectra and CSD
-    // This code was copied and changed modified Utils/Spectra since we do not want to call the function due to time loss.
-    RowVectorXd vecInputFFT, rowData;
-    RowVectorXcd vecTmpFreq;
-
-    MatrixXcd matTapSpectrum(tapers.first.rows(), iNFreqs);
-
-    QVector<Eigen::MatrixXcd> vecTapSpectra;
 
     int i,j;
 
-    FFT<double> fft;
-    fft.SetFlag(fft.HalfSpectrum);
+    // Calculate tapered spectra if not available already
+    // This code was copied and changed modified Utils/Spectra since we do not want to call the function due to time loss.
+    if(inputData.vecTapSpectra.size() != iNRows) {
+        inputData.vecTapSpectra.clear();
 
-    for (i = 0; i < iNRows; ++i) {
-        // Substract mean
-        rowData.array() = matInputData.row(i).array() - matInputData.row(i).mean();
+        RowVectorXd vecInputFFT, rowData;
+        RowVectorXcd vecTmpFreq;
 
-        // FFT for freq domain returning the half spectrum and multiply taper weights
-        for(j = 0; j < tapers.first.rows(); j++) {
-            vecInputFFT = rowData.cwiseProduct(tapers.first.row(j));
-            fft.fwd(vecTmpFreq, vecInputFFT, iNfft);
-            matTapSpectrum.row(j) = vecTmpFreq * tapers.second(j);
+        MatrixXcd matTapSpectrum(tapers.first.rows(), iNFreqs);
+
+        QVector<Eigen::MatrixXcd> vecTapSpectra;
+
+        FFT<double> fft;
+        fft.SetFlag(fft.HalfSpectrum);
+
+        for (i = 0; i < iNRows; ++i) {
+            // Substract mean
+            rowData.array() = inputData.matData.row(i).array() - inputData.matData.row(i).mean();
+
+            // Calculate tapered spectra if not available already
+            for(j = 0; j < tapers.first.rows(); j++) {
+                vecInputFFT = rowData.cwiseProduct(tapers.first.row(j));
+                // FFT for freq domain returning the half spectrum and multiply taper weights
+                fft.fwd(vecTmpFreq, vecInputFFT, iNfft);
+                matTapSpectrum.row(j) = vecTmpFreq * tapers.second(j);
+            }
+
+            inputData.vecTapSpectra.append(matTapSpectrum);
         }
-
-        vecTapSpectra.append(matTapSpectrum);
     }
 
     // Compute CSD
-    bool bNfftEven = false;
-    if (iNfft % 2 == 0){
-        bNfftEven = true;
-    }
-
-    double denomCSD = sqrt(tapers.second.cwiseAbs2().sum()) * sqrt(tapers.second.cwiseAbs2().sum()) / 2.0;
-
     MatrixXcd matCsd = MatrixXcd(iNRows, iNFreqs);
 
-    for (i = 0; i < iNRows; ++i) {
-        for (j = i; j < iNRows; ++j) {
-            // Compute CSD (average over tapers if necessary)
-            matCsd.row(j) = vecTapSpectra.at(i).cwiseProduct(vecTapSpectra.at(j).conjugate()).colwise().sum() / denomCSD;
+    if(inputData.vecPairCsd.size() != iNRows) {
+        inputData.vecPairCsd.clear();
 
-            // Divide first and last element by 2 due to half spectrum
-            matCsd.row(j)(0) /= 2.0;
-            if(bNfftEven) {
-                matCsd.row(j).tail(1) /= 2.0;
-            }
+        bool bNfftEven = false;
+        if (iNfft % 2 == 0){
+            bNfftEven = true;
         }
 
-        vecCsdAvg.append(matCsd.cwiseQuotient(matCsd.cwiseAbs()));
+        double denomCSD = sqrt(tapers.second.cwiseAbs2().sum()) * sqrt(tapers.second.cwiseAbs2().sum()) / 2.0;
+
+        for (i = 0; i < iNRows; ++i) {
+            for (j = i; j < iNRows; ++j) {
+                // Compute CSD (average over tapers if necessary)
+                matCsd.row(j) = inputData.vecTapSpectra.at(i).cwiseProduct(inputData.vecTapSpectra.at(j).conjugate()).colwise().sum() / denomCSD;
+
+                // Divide first and last element by 2 due to half spectrum
+                matCsd.row(j)(0) /= 2.0;
+                if(bNfftEven) {
+                    matCsd.row(j).tail(1) /= 2.0;
+                }
+            }
+
+            inputData.vecPairCsd.append(QPair<int,MatrixXcd>(i,matCsd));
+            inputData.vecPairCsdNormalized.append(QPair<int,MatrixXcd>(i,matCsd.cwiseQuotient(matCsd.cwiseAbs())));
+        }
+    } else {
+        for (i = 0; i < iNRows; ++i) {
+            inputData.vecPairCsdNormalized.append(QPair<int,MatrixXcd>(i,inputData.vecPairCsd.at(i).second.cwiseQuotient(inputData.vecPairCsd.at(i).second.cwiseAbs())));
+        }
     }
 
-    return vecCsdAvg;
+    mutex.lock();
+
+    if(vecPairCsdNormalizedSum.isEmpty()) {
+        vecPairCsdNormalizedSum = inputData.vecPairCsdNormalized;
+    } else {
+        for (int j = 0; j < vecPairCsdNormalizedSum.size(); ++j) {
+            vecPairCsdNormalizedSum[j].second += inputData.vecPairCsdNormalized.at(j).second;
+        }
+    }
+
+    mutex.unlock();
 }
 
 
 //*************************************************************************************************************
 
-void PhaseLockingValue::reduce(QVector<MatrixXcd>& finalData,
-                               const QVector<MatrixXcd>& resultData)
+void PhaseLockingValue::computePLV(ConnectivitySettings &connectivitySettings,
+                                   Network& finalNetwork)
 {
-    // Sum over epoch
-    if(finalData.isEmpty()) {
-        finalData = resultData;
-    } else {
-        for (int j = 0; j < finalData.size(); ++j) {
-            finalData[j] += resultData.at(j);
+    // Compute final PLV and create Network
+    MatrixXd matNom;
+    MatrixXd matWeight;
+    QSharedPointer<NetworkEdge> pEdge;
+    int j;
+
+    for (int i = 0; i < connectivitySettings.m_dataList.first().matData.rows(); ++i) {
+        matNom = connectivitySettings.data.vecPairCsdNormalizedSum.at(i).second.cwiseAbs() / connectivitySettings.size();
+
+        for(j = i; j < connectivitySettings.m_dataList.at(0).matData.rows(); ++j) {
+            matWeight = matNom.row(j).transpose();
+
+            pEdge = QSharedPointer<NetworkEdge>(new NetworkEdge(i, j, matWeight));
+
+            finalNetwork.getNodeAt(i)->append(pEdge);
+            finalNetwork.getNodeAt(j)->append(pEdge);
+            finalNetwork.append(pEdge);
         }
     }
 }
-

--- a/libraries/connectivity/metrics/phaselockingvalue.h
+++ b/libraries/connectivity/metrics/phaselockingvalue.h
@@ -125,16 +125,18 @@ protected:
     /**
     * Computes the PLV values. This function gets called in parallel.
     *
-    * @param[in] inputData          The input data.
-    * @param[out]vecPairCsdSum      The sum of all CSD matrices for each trial.
-    * @param[in] mutex              The mutex used to safely access vecPairCsdSum.
-    * @param[in] iNRows             The number of rows.
-    * @param[in] iNFreqs            The number of frequenciy bins.
-    * @param[in] iNfft              The FFT length.
-    * @param[in] tapers             The taper information.
+    * @param[in] inputData                  The input data.
+    * @param[out]vecPairCsdSum              The sum of all CSD matrices for each trial.
+    * @param[out]vecPairCsdNormalizedSum    The sum of all normalized CSD matrices for each trial.
+    * @param[in] mutex                      The mutex used to safely access vecPairCsdSum.
+    * @param[in] iNRows                     The number of rows.
+    * @param[in] iNFreqs                    The number of frequenciy bins.
+    * @param[in] iNfft                      The FFT length.
+    * @param[in] tapers                     The taper information.
     */
     static void compute(ConnectivityTrialData& inputData,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
+                        QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdNormalizedSum,
                         QMutex& mutex,
                         int iNRows,
                         int iNFreqs,

--- a/libraries/connectivity/metrics/phaselockingvalue.h
+++ b/libraries/connectivity/metrics/phaselockingvalue.h
@@ -116,7 +116,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network phaseLockingValue(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(const ConnectivitySettings &connectivitySettings);
 
     //==========================================================================================================
     /**
@@ -128,9 +128,9 @@ public:
     *
     * @return                   The PLV value.
     */
-    static QVector<Eigen::MatrixXd> computePLV(const QList<Eigen::MatrixXd> &matDataList,
-                                               int iNfft,
-                                               const QString &sWindowType);
+    static QVector<Eigen::MatrixXd> calculate(const QList<Eigen::MatrixXd> &matDataList,
+                                              int iNfft,
+                                              const QString &sWindowType);
 protected:
     //=========================================================================================================
     /**

--- a/libraries/connectivity/metrics/phaselockingvalue.h
+++ b/libraries/connectivity/metrics/phaselockingvalue.h
@@ -86,6 +86,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -118,10 +119,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network phaseLockingValue(const QList<Eigen::MatrixXd> &matDataList,
-                                     const Eigen::MatrixX3f& matVert,
-                                     int iNfft=-1,
-                                     const QString &sWindowType="hanning");
+    static Network phaseLockingValue(const ConnectivitySettings &connectivitySettings);
 
     //==========================================================================================================
     /**

--- a/libraries/connectivity/metrics/phaselockingvalue.h
+++ b/libraries/connectivity/metrics/phaselockingvalue.h
@@ -56,6 +56,7 @@
 //=============================================================================================================
 
 #include <QSharedPointer>
+#include <QMutex>
 
 
 //*************************************************************************************************************
@@ -87,6 +88,7 @@ namespace CONNECTIVITYLIB {
 
 class Network;
 class ConnectivitySettings;
+class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -116,49 +118,38 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network calculate(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(ConnectivitySettings &connectivitySettings);
 
-    //==========================================================================================================
-    /**
-    * Calculates the actual phase locking value between two data vectors.
-    *
-    * @param[in] matDataList    The input data.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
-    *
-    * @return                   The PLV value.
-    */
-    static QVector<Eigen::MatrixXd> calculate(const QList<Eigen::MatrixXd> &matDataList,
-                                              int iNfft,
-                                              const QString &sWindowType);
 protected:
     //=========================================================================================================
     /**
     * Computes the PLV values. This function gets called in parallel.
     *
-    * @param[in] matInputData           The input data.
-    * @param[in] iNRows                 The number of rows.
-    * @param[in] iNFreqs                The number of frequenciy bins.
-    * @param[in] iNfft                  The FFT length.
-    * @param[in] tapers                 The taper information.
-    *
-    * @return            The coherency result in form of AbstractMetricResultData.
+    * @param[in] inputData          The input data.
+    * @param[out]vecPairCsdSum      The sum of all CSD matrices for each trial.
+    * @param[in] mutex              The mutex used to safely access vecPairCsdSum.
+    * @param[in] iNRows             The number of rows.
+    * @param[in] iNFreqs            The number of frequenciy bins.
+    * @param[in] iNfft              The FFT length.
+    * @param[in] tapers             The taper information.
     */
-    static QVector<Eigen::MatrixXcd> compute(const Eigen::MatrixXd& matInputData,
-                                             int iNRows,
-                                             int iNFreqs,
-                                             int iNfft,
-                                             const QPair<Eigen::MatrixXd, Eigen::VectorXd>& tapers);
+    static void compute(ConnectivityTrialData& inputData,
+                        QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
+                        QMutex& mutex,
+                        int iNRows,
+                        int iNFreqs,
+                        int iNfft,
+                        const QPair<Eigen::MatrixXd, Eigen::VectorXd>& tapers);
 
     //=========================================================================================================
     /**
-    * Reduces the PLV computation to a final result. This function gets called in parallel.
+    * Reduces the PLV computation to a final result.
     *
-    * @param[out] finalData    The final data.
-    * @param[in]  resultData   The resulting data from the computation step.
+    * @param[out] connectivitySettings   The input data.
+    * @param[in]  finalNetwork           The final network.
     */
-    static void reduce(QVector<Eigen::MatrixXcd>& finalData,
-                       const QVector<Eigen::MatrixXcd>& resultData);
+    static void computePLV(ConnectivitySettings &connectivitySettings,
+                           Network& finalNetwork);
 };
 
 

--- a/libraries/connectivity/metrics/phaselockingvalue.h
+++ b/libraries/connectivity/metrics/phaselockingvalue.h
@@ -112,10 +112,7 @@ public:
     /**
     * Calculates the phase locking value between the rows of the data matrix.
     *
-    * @param[in] matDataList    The input data.
-    * @param[in] matVert        The vertices of each network node.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[in] connectivitySettings   The input data and parameters.
     *
     * @return                   The connectivity information in form of a network structure.
     */

--- a/libraries/connectivity/metrics/phaselockingvalue.h
+++ b/libraries/connectivity/metrics/phaselockingvalue.h
@@ -2,13 +2,14 @@
 /**
 * @file     phaselockingvalue.h
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -48,6 +49,7 @@
 #include "../connectivity_global.h"
 
 #include "abstractmetric.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -87,8 +89,6 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
-class ConnectivitySettings;
-class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -134,7 +134,7 @@ protected:
     * @param[in] iNfft                      The FFT length.
     * @param[in] tapers                     The taper information.
     */
-    static void compute(ConnectivityTrialData& inputData,
+    static void compute(ConnectivitySettings::IntermediateTrialData& inputData,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdNormalizedSum,
                         QMutex& mutex,

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
@@ -2,13 +2,14 @@
 /**
 * @file     unbiasedsquaredUnbiasedSquaredPhaseLagIndex.cpp
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -46,7 +47,6 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
-#include "../connectivitysettings.h"
 
 #include <utils/spectral.h>
 
@@ -104,7 +104,7 @@ Network UnbiasedSquaredPhaseLagIndex::calculate(ConnectivitySettings& connectivi
 
     Network finalNetwork("Unbiased Squared Phase Lag Index");
 
-    if(connectivitySettings.m_dataList.empty()) {
+    if(connectivitySettings.isEmpty()) {
         qDebug() << "UnbiasedSquaredPhaseLagIndex::calculate - Input data is empty";
         return finalNetwork;
     }
@@ -114,41 +114,41 @@ Network UnbiasedSquaredPhaseLagIndex::calculate(ConnectivitySettings& connectivi
     #endif
 
     //Create nodes
-    int rows = connectivitySettings.m_dataList.first().matData.rows();
+    int rows = connectivitySettings.at(0).matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
         rowVert = RowVectorXf::Zero(3);
 
-        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
-            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
-            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
-            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
+        if(connectivitySettings.getNodePositions().rows() != 0 && i < connectivitySettings.getNodePositions().rows()) {
+            rowVert(0) = connectivitySettings.getNodePositions().row(i)(0);
+            rowVert(1) = connectivitySettings.getNodePositions().row(i)(1);
+            rowVert(2) = connectivitySettings.getNodePositions().row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
     }
 
     // Check that iNfft >= signal length
-    int iSignalLength = connectivitySettings.m_dataList.at(0).matData.cols();
-    int iNfft = connectivitySettings.m_iNfft;
+    int iSignalLength = connectivitySettings.at(0).matData.cols();
+    int iNfft = connectivitySettings.getNumberFFT();
     if (iNfft < iSignalLength) {
         iNfft = iSignalLength;
     }
 
     // Generate tapers
-    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.m_sWindowType);
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());
 
     // Initialize
-    int iNRows = connectivitySettings.m_dataList.at(0).matData.rows();
+    int iNRows = connectivitySettings.at(0).matData.rows();
     int iNFreqs = int(floor(iNfft / 2.0)) + 1;
 
     QMutex mutex;
 
-    std::function<void(ConnectivityTrialData&)> computeLambda = [&](ConnectivityTrialData& inputData) {
+    std::function<void(ConnectivitySettings::IntermediateTrialData&)> computeLambda = [&](ConnectivitySettings::IntermediateTrialData& inputData) {
         compute(inputData,
-                connectivitySettings.data.vecPairCsdSum,
-                connectivitySettings.data.vecPairCsdImagSignSum,
+                connectivitySettings.getIntermediateSumData().vecPairCsdSum,
+                connectivitySettings.getIntermediateSumData().vecPairCsdImagSignSum,
                 mutex,
                 iNRows,
                 iNFreqs,
@@ -161,7 +161,7 @@ Network UnbiasedSquaredPhaseLagIndex::calculate(ConnectivitySettings& connectivi
 //    timer.restart();
 
     // Compute DSWPLV in parallel for all trials
-    QFuture<void> result = QtConcurrent::map(connectivitySettings.m_dataList,
+    QFuture<void> result = QtConcurrent::map(connectivitySettings.getTrialData(),
                                              computeLambda);
     result.waitForFinished();
 
@@ -183,7 +183,7 @@ Network UnbiasedSquaredPhaseLagIndex::calculate(ConnectivitySettings& connectivi
 
 //*************************************************************************************************************
 
-void UnbiasedSquaredPhaseLagIndex::compute(ConnectivityTrialData& inputData,
+void UnbiasedSquaredPhaseLagIndex::compute(ConnectivitySettings::IntermediateTrialData& inputData,
                                            QVector<QPair<int,MatrixXcd> >& vecPairCsdSum,
                                            QVector<QPair<int,MatrixXd> >& vecPairCsdImagSignSum,
                                            QMutex& mutex,
@@ -306,8 +306,8 @@ void UnbiasedSquaredPhaseLagIndex::computeUSPLI(ConnectivitySettings &connectivi
     int j;
     double dNTrials = double(connectivitySettings.size() - 1.0);
 
-    for (int i = 0; i < connectivitySettings.data.vecPairCsdImagSignSum.size(); ++i) {
-        matNom = connectivitySettings.data.vecPairCsdImagSignSum.at(i).second.cwiseAbs() / connectivitySettings.size();
+    for (int i = 0; i < connectivitySettings.getIntermediateSumData().vecPairCsdImagSignSum.size(); ++i) {
+        matNom = connectivitySettings.getIntermediateSumData().vecPairCsdImagSignSum.at(i).second.cwiseAbs() / connectivitySettings.size();
         matNom = (connectivitySettings.size() * matNom.array().square() - 1.0) / dNTrials;
 
         for(j = i; j < matNom.rows(); ++j) {

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
@@ -105,6 +105,8 @@ Network UnbiasedSquaredPhaseLagIndex::calculate(const ConnectivitySettings& conn
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
+        rowVert = RowVectorXf::Zero(3);
+
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
             rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
             rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
@@ -44,6 +44,7 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -90,27 +91,24 @@ UnbiasedSquaredPhaseLagIndex::UnbiasedSquaredPhaseLagIndex()
 
 //*******************************************************************************************************
 
-Network UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(const QList<MatrixXd> &matDataList,
-                                                                   const MatrixX3f& matVert,
-                                                                   int iNfft,
-                                                                   const QString &sWindowType)
+Network UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(const ConnectivitySettings& connectivitySettings)
 {
     Network finalNetwork("Unbiased Squared Phase Lag Index");
 
-    if(matDataList.empty()) {
+    if(connectivitySettings.m_matDataList.empty()) {
         qDebug() << "UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex - Input data is empty";
         return finalNetwork;
     }
 
     //Create nodes
-    int rows = matDataList.first().rows();
+    int rows = connectivitySettings.m_matDataList.first().rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
-        if(matVert.rows() != 0 && i < matVert.rows()) {
-            rowVert(0) = matVert.row(i)(0);
-            rowVert(1) = matVert.row(i)(1);
-            rowVert(2) = matVert.row(i)(2);
+        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
+            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
+            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
+            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
@@ -119,9 +117,9 @@ Network UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(const QList<M
     //Calculate all-to-all coherence matrix over epochs
     QVector<MatrixXd> vecUnbiasedSquaredPLI;
     UnbiasedSquaredPhaseLagIndex::computeUnbiasedSquaredPLI(vecUnbiasedSquaredPLI,
-                                                            matDataList,
-                                                            iNfft,
-                                                            sWindowType);
+                                                            connectivitySettings.m_matDataList,
+                                                            connectivitySettings.m_iNfft,
+                                                            connectivitySettings.m_sWindowType);
 
     //Add edges to network
     QSharedPointer<NetworkEdge> pEdge;
@@ -129,7 +127,7 @@ Network UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(const QList<M
     int j;
 
     for(int i = 0; i < vecUnbiasedSquaredPLI.length(); ++i) {
-        for(j = i; j < matDataList.at(0).rows(); ++j) {
+        for(j = i; j < connectivitySettings.m_matDataList.at(0).rows(); ++j) {
             matWeight = vecUnbiasedSquaredPLI.at(i).row(j).transpose();
 
             pEdge = QSharedPointer<NetworkEdge>(new NetworkEdge(i, j, matWeight));

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
@@ -132,9 +132,6 @@ Network UnbiasedSquaredPhaseLagIndex::calculate(ConnectivitySettings& connectivi
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
-    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
@@ -132,6 +132,9 @@ Network UnbiasedSquaredPhaseLagIndex::calculate(ConnectivitySettings& connectivi
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
+    if(iNfft > iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.cpp
@@ -91,7 +91,7 @@ UnbiasedSquaredPhaseLagIndex::UnbiasedSquaredPhaseLagIndex()
 
 //*******************************************************************************************************
 
-Network UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(const ConnectivitySettings& connectivitySettings)
+Network UnbiasedSquaredPhaseLagIndex::calculate(const ConnectivitySettings& connectivitySettings)
 {
     Network finalNetwork("Unbiased Squared Phase Lag Index");
 
@@ -116,10 +116,10 @@ Network UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(const Connect
 
     //Calculate all-to-all coherence matrix over epochs
     QVector<MatrixXd> vecUnbiasedSquaredPLI;
-    UnbiasedSquaredPhaseLagIndex::computeUnbiasedSquaredPLI(vecUnbiasedSquaredPLI,
-                                                            connectivitySettings.m_matDataList,
-                                                            connectivitySettings.m_iNfft,
-                                                            connectivitySettings.m_sWindowType);
+    UnbiasedSquaredPhaseLagIndex::calculate(vecUnbiasedSquaredPLI,
+                                            connectivitySettings.m_matDataList,
+                                            connectivitySettings.m_iNfft,
+                                            connectivitySettings.m_sWindowType);
 
     //Add edges to network
     QSharedPointer<NetworkEdge> pEdge;
@@ -144,19 +144,19 @@ Network UnbiasedSquaredPhaseLagIndex::unbiasedSquaredPhaseLagIndex(const Connect
 
 //*************************************************************************************************************
 
-void UnbiasedSquaredPhaseLagIndex::computeUnbiasedSquaredPLI(QVector<MatrixXd>& vecUnbiasedSquaredPLI,
-                                                             const QList<MatrixXd> &matDataList,
-                                                             int iNfft,
-                                                             const QString &sWindowType)
+void UnbiasedSquaredPhaseLagIndex::calculate(QVector<MatrixXd>& vecUnbiasedSquaredPLI,
+                                             const QList<MatrixXd> &matDataList,
+                                             int iNfft,
+                                             const QString &sWindowType)
 {
     int iNRows = matDataList.at(0).rows();
     int iNTrials = matDataList.length();
 
     // Compute standard PLI
-    PhaseLagIndex::computePLI(vecUnbiasedSquaredPLI,
-                              matDataList,
-                              iNfft,
-                              sWindowType);
+    PhaseLagIndex::calculate(vecUnbiasedSquaredPLI,
+                             matDataList,
+                             iNfft,
+                             sWindowType);
 
     // Compute unbiased estimator according to Vinck et al., NeuroImage 55, pp. 1548-65, 2011
     for (int j = 0; j < iNRows; ++j) {

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
@@ -112,10 +112,7 @@ public:
     /**
     * Calculates the phase lag index between the rows of the data matrix.
     *
-    * @param[in] matDataList    The input data.
-    * @param[in] matVert        The vertices of each network node.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[in] connectivitySettings   The input data and parameters.
     *
     * @return                   The connectivity information in form of a network structure.
     */

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
@@ -86,6 +86,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -118,9 +119,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network unbiasedSquaredPhaseLagIndex(const QList<Eigen::MatrixXd> &matDataList,
-                                                const Eigen::MatrixX3f& matVert,
-                                                int iNfft=-1, const QString &sWindowType="hanning");
+    static Network unbiasedSquaredPhaseLagIndex(const ConnectivitySettings &connectivitySettings);
 
     //==========================================================================================================
     /**

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
@@ -9,7 +9,7 @@
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -49,6 +49,7 @@
 #include "../connectivity_global.h"
 
 #include "abstractmetric.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -88,8 +89,6 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
-class ConnectivitySettings;
-class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -135,7 +134,7 @@ protected:
     * @param[in] iNfft                  The FFT length.
     * @param[in] tapers                 The taper information.
     */
-    static void compute(ConnectivityTrialData& inputData,
+    static void compute(ConnectivitySettings::IntermediateTrialData& inputData,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
                         QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagSignSum,
                         QMutex& mutex,

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
@@ -2,6 +2,7 @@
 /**
 * @file     unbiasedsquaredphaselagindex.h
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
@@ -116,7 +116,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network unbiasedSquaredPhaseLagIndex(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(const ConnectivitySettings &connectivitySettings);
 
     //==========================================================================================================
     /**
@@ -129,10 +129,10 @@ public:
     *
     * @return                   The PLI value.
     */
-    static void computeUnbiasedSquaredPLI(QVector<Eigen::MatrixXd>& vecUnbiasedSquaredPLI,
-                                          const QList<Eigen::MatrixXd> &matDataList,
-                                          int iNfft,
-                                          const QString &sWindowType);
+    static void calculate(QVector<Eigen::MatrixXd>& vecUnbiasedSquaredPLI,
+                          const QList<Eigen::MatrixXd> &matDataList,
+                          int iNfft,
+                          const QString &sWindowType);
 };
 
 

--- a/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
+++ b/libraries/connectivity/metrics/unbiasedsquaredphaselagindex.h
@@ -126,6 +126,7 @@ protected:
     * Computes the PLI values. This function gets called in parallel.
     *
     * @param[in] inputData              The input data.
+    * @param[out]vecPairCsdSum          The sum of all CSD matrices for each trial.
     * @param[out]vecPairCsdImagSignSum  The sum of all imag sign CSD matrices for each trial.
     * @param[in] mutex                  The mutex used to safely access vecPairCsdSum.
     * @param[in] iNRows                 The number of rows.
@@ -134,6 +135,7 @@ protected:
     * @param[in] tapers                 The taper information.
     */
     static void compute(ConnectivityTrialData& inputData,
+                        QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
                         QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagSignSum,
                         QMutex& mutex,
                         int iNRows,

--- a/libraries/connectivity/metrics/weightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/weightedphaselagindex.cpp
@@ -96,21 +96,25 @@ WeightedPhaseLagIndex::WeightedPhaseLagIndex()
 
 //*******************************************************************************************************
 
-Network WeightedPhaseLagIndex::calculate(const ConnectivitySettings& connectivitySettings)
+Network WeightedPhaseLagIndex::calculate(ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
 //    timer.start();
 
-    Network finalNetwork("Weighted Phase Lag Index");
+    Network finalNetwork("Phase Lag Index");
 
-    if(connectivitySettings.m_matDataList.empty()) {
-        qDebug() << "WeightedPhaseLagIndex::weightedPhaseLagIndex - Input data is empty";
+    if(connectivitySettings.m_dataList.empty()) {
+        qDebug() << "WeightedPhaseLagIndex::calculate - Input data is empty";
         return finalNetwork;
     }
 
+    #ifdef EIGEN_FFTW_DEFAULT
+        fftw_make_planner_thread_safe();
+    #endif
+
     //Create nodes
-    int rows = connectivitySettings.m_matDataList.first().rows();
+    int rows = connectivitySettings.m_dataList.first().matData.rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
@@ -125,40 +129,51 @@ Network WeightedPhaseLagIndex::calculate(const ConnectivitySettings& connectivit
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
     }
 
-//    iTime = timer.elapsed();
-//    qDebug() << "WeightedPhaseLagIndex::weightedPhaseLagIndex timer - Preparation:" << iTime;
-//    timer.restart();
-
-    //Calculate all-to-all coherence matrix over epochs
-    QVector<MatrixXd> vecWPLI;
-    WeightedPhaseLagIndex::calculate(vecWPLI,
-                                     connectivitySettings.m_matDataList,
-                                     connectivitySettings.m_iNfft,
-                                     connectivitySettings.m_sWindowType);
-
-//    iTime = timer.elapsed();
-//    qDebug() << "WeightedPhaseLagIndex::weightedPhaseLagIndex timer - Actual computation:" << iTime;
-//    timer.restart();
-
-    //Add edges to network
-    QSharedPointer<NetworkEdge> pEdge;
-    MatrixXd matWeight;
-    int j;
-
-    for(int i = 0; i < vecWPLI.length(); ++i) {
-        for(j = i; j < connectivitySettings.m_matDataList.at(0).rows(); ++j) {
-            matWeight = vecWPLI.at(i).row(j).transpose();
-
-            pEdge = QSharedPointer<NetworkEdge>(new NetworkEdge(i, j, matWeight));
-
-            finalNetwork.getNodeAt(i)->append(pEdge);
-            finalNetwork.getNodeAt(j)->append(pEdge);
-            finalNetwork.append(pEdge);
-        }
+    // Check that iNfft >= signal length
+    int iSignalLength = connectivitySettings.m_dataList.at(0).matData.cols();
+    int iNfft = connectivitySettings.m_iNfft;
+    if (iNfft < iSignalLength) {
+        iNfft = iSignalLength;
     }
 
+    // Generate tapers
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.m_sWindowType);
+
+    // Initialize
+    int iNRows = connectivitySettings.m_dataList.at(0).matData.rows();
+    int iNFreqs = int(floor(iNfft / 2.0)) + 1;
+
+    QMutex mutex;
+
+    std::function<void(ConnectivityTrialData&)> computeLambda = [&](ConnectivityTrialData& inputData) {
+        compute(inputData,
+                connectivitySettings.data.vecPairCsdSum,
+                mutex,
+                iNRows,
+                iNFreqs,
+                iNfft,
+                tapers);
+    };
+
+    //    iTime = timer.elapsed();
+    //    qDebug() << "WeightedPhaseLagIndex::calculate timer - Preparation:" << iTime;
+    //    timer.restart();
+
+    // Compute DSWPLV in parallel for all trials
+    QFuture<void> result = QtConcurrent::map(connectivitySettings.m_dataList,
+                                             computeLambda);
+    result.waitForFinished();
+
 //    iTime = timer.elapsed();
-//    qDebug() << "WeightedPhaseLagIndex::weightedPhaseLagIndex timer - Final network structure creation:" << iTime;
+//    qDebug() << "WeightedPhaseLagIndex::calculate timer - Compute WPLI per trial:" << iTime;
+//    timer.restart();
+
+    // Compute WPLI
+    computeWPLI(connectivitySettings,
+               finalNetwork);
+
+//    iTime = timer.elapsed();
+//    qDebug() << "WeightedPhaseLagIndex::calculate timer - Compute WPLI, Network creation:" << iTime;
 //    timer.restart();
 
     return finalNetwork;
@@ -167,96 +182,52 @@ Network WeightedPhaseLagIndex::calculate(const ConnectivitySettings& connectivit
 
 //*************************************************************************************************************
 
-void WeightedPhaseLagIndex::calculate(QVector<MatrixXd>& vecWPLI,
-                                      const QList<MatrixXd> &matDataList,
-                                      int iNfft,
-                                      const QString &sWindowType)
+void WeightedPhaseLagIndex::compute(ConnectivityTrialData& inputData,
+                            QVector<QPair<int,MatrixXcd> >& vecPairCsdSum,
+                            QMutex& mutex,
+                            int iNRows,
+                            int iNFreqs,
+                            int iNfft,
+                            const QPair<MatrixXd, VectorXd>& tapers)
 {
-    #ifdef EIGEN_FFTW_DEFAULT
-        fftw_make_planner_thread_safe();
-    #endif
-
-    // Check that iNfft >= signal length
-    int iSignalLength = matDataList.at(0).cols();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
+    if(inputData.vecPairCsd.size() == iNRows) {
+        //qDebug() << "WeightedPhaseLagIndex::compute - vecPairCsd was already computed for this trial.";
+        return;
     }
-
-    // Generate tapers
-    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, sWindowType);
-
-    // Initialize
-    int iNRows = matDataList.at(0).rows();
-    int iNFreqs = int(floor(iNfft / 2.0)) + 1;
-
-    //    // Sequential
-    //    AbstractMetricResultData finalResult;
-
-    //    for (int i = 0; i < matDataList.length(); ++i) {
-    //        reduce(finalResult, computeLambda(matDataList.at(i)));
-    //    }
-
-    std::function<AbstractMetricResultData(const MatrixXd&)> computeLambda = [&](const MatrixXd& matInputData) {
-        return compute(matInputData,
-                       iNRows,
-                       iNFreqs,
-                       iNfft,
-                       tapers);
-    };
-
-    // Parallel
-    QFuture<AbstractMetricResultData> result = QtConcurrent::mappedReduced(matDataList,
-                                                                           computeLambda,
-                                                                           reduce);
-    result.waitForFinished();
-
-    AbstractMetricResultData finalResult = result.result();
-
-    MatrixXd matDenom;
-
-    for (int i = 0; i < iNRows; ++i) {
-        matDenom = finalResult.vecCsdAbsAvgImag.at(i);
-        matDenom = (matDenom.array() == 0.).select(INFINITY, matDenom);
-
-        vecWPLI.append(finalResult.vecCsdAvgImag.at(i).cwiseAbs().cwiseQuotient(matDenom));
-    }
-}
-
-
-//*************************************************************************************************************
-
-AbstractMetricResultData WeightedPhaseLagIndex::compute(const MatrixXd& matInputData,
-                                                        int iNRows,
-                                                        int iNFreqs,
-                                                        int iNfft,
-                                                        const QPair<MatrixXd, VectorXd>& tapers)
-{
-    // Subtract mean, generate tapered spectra and CSD
-    // This code was copied and changed modified Utils/Spectra since we do not want to call the function due to time loss.
-    RowVectorXd vecInputFFT, rowData;
-    RowVectorXcd vecTmpFreq;
-
-    MatrixXcd matTapSpectrum(tapers.first.rows(), iNFreqs);
-
-    QVector<Eigen::MatrixXcd> vecTapSpectra;
 
     int i,j;
 
-    FFT<double> fft;
-    fft.SetFlag(fft.HalfSpectrum);
+    inputData.vecPairCsd.clear();
 
-    for (i = 0; i < iNRows; ++i) {
-        // Substract mean
-        rowData.array() = matInputData.row(i).array() - matInputData.row(i).mean();
+    // Calculate tapered spectra if not available already
+    // This code was copied and changed modified Utils/Spectra since we do not want to call the function due to time loss.
+    if(inputData.vecTapSpectra.size() != iNRows) {
+        inputData.vecTapSpectra.clear();
 
-        // FFT for freq domain returning the half spectrum and multiply taper weights
-        for(j = 0; j < tapers.first.rows(); j++) {
-            vecInputFFT = rowData.cwiseProduct(tapers.first.row(j));
-            fft.fwd(vecTmpFreq, vecInputFFT, iNfft);
-            matTapSpectrum.row(j) = vecTmpFreq * tapers.second(j);
+        RowVectorXd vecInputFFT, rowData;
+        RowVectorXcd vecTmpFreq;
+
+        MatrixXcd matTapSpectrum(tapers.first.rows(), iNFreqs);
+
+        QVector<Eigen::MatrixXcd> vecTapSpectra;
+
+        FFT<double> fft;
+        fft.SetFlag(fft.HalfSpectrum);
+
+        for (i = 0; i < iNRows; ++i) {
+            // Substract mean
+            rowData.array() = inputData.matData.row(i).array() - inputData.matData.row(i).mean();
+
+            // Calculate tapered spectra if not available already
+            for(j = 0; j < tapers.first.rows(); j++) {
+                vecInputFFT = rowData.cwiseProduct(tapers.first.row(j));
+                // FFT for freq domain returning the half spectrum and multiply taper weights
+                fft.fwd(vecTmpFreq, vecInputFFT, iNfft);
+                matTapSpectrum.row(j) = vecTmpFreq * tapers.second(j);
+            }
+
+            inputData.vecTapSpectra.append(matTapSpectrum);
         }
-
-        vecTapSpectra.append(matTapSpectrum);
     }
 
     // Compute CSD
@@ -267,14 +238,12 @@ AbstractMetricResultData WeightedPhaseLagIndex::compute(const MatrixXd& matInput
 
     double denomCSD = sqrt(tapers.second.cwiseAbs2().sum()) * sqrt(tapers.second.cwiseAbs2().sum()) / 2.0;
 
-    MatrixXd matCsd(iNRows, iNFreqs);
-
-    AbstractMetricResultData resultData;
+    MatrixXcd matCsd = MatrixXcd(iNRows, iNFreqs);
 
     for (i = 0; i < iNRows; ++i) {
         for (j = i; j < iNRows; ++j) {
             // Compute CSD (average over tapers if necessary)
-            matCsd.row(j) = vecTapSpectra.at(i).cwiseProduct(vecTapSpectra.at(j).conjugate()).colwise().sum().imag() / denomCSD;
+            matCsd.row(j) = inputData.vecTapSpectra.at(i).cwiseProduct(inputData.vecTapSpectra.at(j).conjugate()).colwise().sum() / denomCSD;
 
             // Divide first and last element by 2 due to half spectrum
             matCsd.row(j)(0) /= 2.0;
@@ -283,43 +252,51 @@ AbstractMetricResultData WeightedPhaseLagIndex::compute(const MatrixXd& matInput
             }
         }
 
-        resultData.vecCsdAvgImag.append(matCsd);
-        resultData.vecCsdAbsAvgImag.append(matCsd.cwiseAbs());
+        inputData.vecPairCsd.append(QPair<int,MatrixXcd>(i,matCsd));
     }
 
-    return resultData;
+    mutex.lock();
+
+    if(vecPairCsdSum.isEmpty()) {
+        vecPairCsdSum = inputData.vecPairCsd;
+    } else {
+        for (int j = 0; j < vecPairCsdSum.size(); ++j) {
+            vecPairCsdSum[j].second += inputData.vecPairCsd.at(j).second;
+        }
+    }
+
+    mutex.unlock();
 }
 
 
 //*************************************************************************************************************
 
-void WeightedPhaseLagIndex::reduce(AbstractMetricResultData& finalData,
-                                   const AbstractMetricResultData& resultData)
+void WeightedPhaseLagIndex::computeWPLI(ConnectivitySettings &connectivitySettings,
+                                        Network& finalNetwork)
 {
-    // Sum over epoch
-    if(finalData.vecCsdAvgImag.isEmpty()) {
-        finalData.vecCsdAvgImag = resultData.vecCsdAvgImag;
-    } else {
-        for (int j = 0; j < finalData.vecCsdAvgImag.size(); ++j) {
-            finalData.vecCsdAvgImag[j] += resultData.vecCsdAvgImag.at(j);
-        }
-    }
+    // Compute final WPLI and create Network
+    MatrixXd matDenom, matNom;
+    MatrixXd matWeight;
+    QSharedPointer<NetworkEdge> pEdge;
+    int j;
 
-    if(finalData.vecSquaredCsdAvgImag.isEmpty()) {
-        finalData.vecSquaredCsdAvgImag = resultData.vecSquaredCsdAvgImag;
-    } else {
-        for (int j = 0; j < finalData.vecSquaredCsdAvgImag.size(); ++j) {
-            finalData.vecSquaredCsdAvgImag[j] += resultData.vecSquaredCsdAvgImag.at(j);
-        }
-    }
+    for (int i = 0; i < connectivitySettings.data.vecPairCsdSum.size(); ++i) {
+        matDenom = connectivitySettings.data.vecPairCsdSum.at(i).second.imag().cwiseAbs();
+        matDenom = (matDenom.array() == 0.).select(INFINITY, matDenom);
 
-    if(finalData.vecCsdAbsAvgImag.isEmpty()) {
-        finalData.vecCsdAbsAvgImag = resultData.vecCsdAbsAvgImag;
-    } else {
-        for (int j = 0; j < finalData.vecCsdAbsAvgImag.size(); ++j) {
-            finalData.vecCsdAbsAvgImag[j] += resultData.vecCsdAbsAvgImag.at(j);
+        matNom = connectivitySettings.data.vecPairCsdSum.at(i).second.imag().cwiseAbs();
+
+        matNom = matNom.cwiseQuotient(matDenom);
+
+        for(j = i; j < matNom.rows(); ++j) {
+            matWeight = matNom.row(j).transpose();
+
+            pEdge = QSharedPointer<NetworkEdge>(new NetworkEdge(i, j, matWeight));
+
+            finalNetwork.getNodeAt(i)->append(pEdge);
+            finalNetwork.getNodeAt(j)->append(pEdge);
+            finalNetwork.append(pEdge);
         }
     }
 }
-
 

--- a/libraries/connectivity/metrics/weightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/weightedphaselagindex.cpp
@@ -46,6 +46,7 @@
 #include "network/networknode.h"
 #include "network/networkedge.h"
 #include "network/network.h"
+#include "../connectivitysettings.h"
 
 #include <utils/spectral.h>
 
@@ -95,10 +96,7 @@ WeightedPhaseLagIndex::WeightedPhaseLagIndex()
 
 //*******************************************************************************************************
 
-Network WeightedPhaseLagIndex::weightedPhaseLagIndex(const QList<MatrixXd> &matDataList,
-                                                     const MatrixX3f& matVert,
-                                                     int iNfft,
-                                                     const QString &sWindowType)
+Network WeightedPhaseLagIndex::weightedPhaseLagIndex(const ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -106,20 +104,20 @@ Network WeightedPhaseLagIndex::weightedPhaseLagIndex(const QList<MatrixXd> &matD
 
     Network finalNetwork("Weighted Phase Lag Index");
 
-    if(matDataList.empty()) {
+    if(connectivitySettings.m_matDataList.empty()) {
         qDebug() << "WeightedPhaseLagIndex::weightedPhaseLagIndex - Input data is empty";
         return finalNetwork;
     }
 
     //Create nodes
-    int rows = matDataList.first().rows();
+    int rows = connectivitySettings.m_matDataList.first().rows();
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
-        if(matVert.rows() != 0 && i < matVert.rows()) {
-            rowVert(0) = matVert.row(i)(0);
-            rowVert(1) = matVert.row(i)(1);
-            rowVert(2) = matVert.row(i)(2);
+        if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
+            rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
+            rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);
+            rowVert(2) = connectivitySettings.m_matNodePositions.row(i)(2);
         }
 
         finalNetwork.append(NetworkNode::SPtr(new NetworkNode(i, rowVert)));
@@ -132,9 +130,9 @@ Network WeightedPhaseLagIndex::weightedPhaseLagIndex(const QList<MatrixXd> &matD
     //Calculate all-to-all coherence matrix over epochs
     QVector<MatrixXd> vecWPLI;
     WeightedPhaseLagIndex::computeWPLI(vecWPLI,
-                                       matDataList,
-                                       iNfft,
-                                       sWindowType);
+                                       connectivitySettings.m_matDataList,
+                                       connectivitySettings.m_iNfft,
+                                       connectivitySettings.m_sWindowType);
 
 //    iTime = timer.elapsed();
 //    qDebug() << "WeightedPhaseLagIndex::weightedPhaseLagIndex timer - Actual computation:" << iTime;
@@ -146,7 +144,7 @@ Network WeightedPhaseLagIndex::weightedPhaseLagIndex(const QList<MatrixXd> &matD
     int j;
 
     for(int i = 0; i < vecWPLI.length(); ++i) {
-        for(j = i; j < matDataList.at(0).rows(); ++j) {
+        for(j = i; j < connectivitySettings.m_matDataList.at(0).rows(); ++j) {
             matWeight = vecWPLI.at(i).row(j).transpose();
 
             pEdge = QSharedPointer<NetworkEdge>(new NetworkEdge(i, j, matWeight));

--- a/libraries/connectivity/metrics/weightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/weightedphaselagindex.cpp
@@ -96,7 +96,7 @@ WeightedPhaseLagIndex::WeightedPhaseLagIndex()
 
 //*******************************************************************************************************
 
-Network WeightedPhaseLagIndex::weightedPhaseLagIndex(const ConnectivitySettings& connectivitySettings)
+Network WeightedPhaseLagIndex::calculate(const ConnectivitySettings& connectivitySettings)
 {
 //    QElapsedTimer timer;
 //    qint64 iTime = 0;
@@ -129,10 +129,10 @@ Network WeightedPhaseLagIndex::weightedPhaseLagIndex(const ConnectivitySettings&
 
     //Calculate all-to-all coherence matrix over epochs
     QVector<MatrixXd> vecWPLI;
-    WeightedPhaseLagIndex::computeWPLI(vecWPLI,
-                                       connectivitySettings.m_matDataList,
-                                       connectivitySettings.m_iNfft,
-                                       connectivitySettings.m_sWindowType);
+    WeightedPhaseLagIndex::calculate(vecWPLI,
+                                     connectivitySettings.m_matDataList,
+                                     connectivitySettings.m_iNfft,
+                                     connectivitySettings.m_sWindowType);
 
 //    iTime = timer.elapsed();
 //    qDebug() << "WeightedPhaseLagIndex::weightedPhaseLagIndex timer - Actual computation:" << iTime;
@@ -165,10 +165,10 @@ Network WeightedPhaseLagIndex::weightedPhaseLagIndex(const ConnectivitySettings&
 
 //*************************************************************************************************************
 
-void WeightedPhaseLagIndex::computeWPLI(QVector<MatrixXd>& vecWPLI,
-                                        const QList<MatrixXd> &matDataList,
-                                        int iNfft,
-                                        const QString &sWindowType)
+void WeightedPhaseLagIndex::calculate(QVector<MatrixXd>& vecWPLI,
+                                      const QList<MatrixXd> &matDataList,
+                                      int iNfft,
+                                      const QString &sWindowType)
 {
     #ifdef EIGEN_FFTW_DEFAULT
         fftw_make_planner_thread_safe();

--- a/libraries/connectivity/metrics/weightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/weightedphaselagindex.cpp
@@ -114,6 +114,8 @@ Network WeightedPhaseLagIndex::calculate(const ConnectivitySettings& connectivit
     RowVectorXf rowVert = RowVectorXf::Zero(3);
 
     for(int i = 0; i < rows; ++i) {
+        rowVert = RowVectorXf::Zero(3);
+
         if(connectivitySettings.m_matNodePositions.rows() != 0 && i < connectivitySettings.m_matNodePositions.rows()) {
             rowVert(0) = connectivitySettings.m_matNodePositions.row(i)(0);
             rowVert(1) = connectivitySettings.m_matNodePositions.row(i)(1);

--- a/libraries/connectivity/metrics/weightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/weightedphaselagindex.cpp
@@ -132,6 +132,9 @@ Network WeightedPhaseLagIndex::calculate(ConnectivitySettings& connectivitySetti
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
+    if(iNfft > iSignalLength) {
+        iNfft = iSignalLength;
+    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/weightedphaselagindex.cpp
+++ b/libraries/connectivity/metrics/weightedphaselagindex.cpp
@@ -132,9 +132,6 @@ Network WeightedPhaseLagIndex::calculate(ConnectivitySettings& connectivitySetti
     // Check that iNfft >= signal length
     int iSignalLength = connectivitySettings.at(0).matData.cols();
     int iNfft = connectivitySettings.getNumberFFT();
-    if (iNfft < iSignalLength) {
-        iNfft = iSignalLength;
-    }
 
     // Generate tapers
     QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iSignalLength, connectivitySettings.getWindowType());

--- a/libraries/connectivity/metrics/weightedphaselagindex.h
+++ b/libraries/connectivity/metrics/weightedphaselagindex.h
@@ -112,10 +112,7 @@ public:
     /**
     * Calculates the weighted phase lag index between the rows of the data matrix.
     *
-    * @param[in] matDataList    The input data.
-    * @param[in] matVert        The vertices of each network node.
-    * @param[in] iNfft          The FFT length.
-    * @param[in] sWindowType    The type of the window function used to compute tapered spectra.
+    * @param[in] connectivitySettings   The input data and parameters.
     *
     * @return                   The connectivity information in form of a network structure.
     */

--- a/libraries/connectivity/metrics/weightedphaselagindex.h
+++ b/libraries/connectivity/metrics/weightedphaselagindex.h
@@ -2,6 +2,7 @@
 /**
 * @file     weightedphaselagindex.h
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     April, 2018

--- a/libraries/connectivity/metrics/weightedphaselagindex.h
+++ b/libraries/connectivity/metrics/weightedphaselagindex.h
@@ -86,6 +86,7 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
+class ConnectivitySettings;
 
 
 //=============================================================================================================
@@ -118,10 +119,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network weightedPhaseLagIndex(const QList<Eigen::MatrixXd> &matDataList,
-                                         const Eigen::MatrixX3f& matVert,
-                                         int iNfft=-1,
-                                         const QString &sWindowType="hanning");
+    static Network weightedPhaseLagIndex(const ConnectivitySettings &connectivitySettings);
 
     //==========================================================================================================
     /**

--- a/libraries/connectivity/metrics/weightedphaselagindex.h
+++ b/libraries/connectivity/metrics/weightedphaselagindex.h
@@ -116,7 +116,7 @@ public:
     *
     * @return                   The connectivity information in form of a network structure.
     */
-    static Network weightedPhaseLagIndex(const ConnectivitySettings &connectivitySettings);
+    static Network calculate(const ConnectivitySettings &connectivitySettings);
 
     //==========================================================================================================
     /**
@@ -129,10 +129,10 @@ public:
     *
     * @return                   The WPLI value.
     */
-    static void computeWPLI(QVector<Eigen::MatrixXd>& vecWPLI,
-                            const QList<Eigen::MatrixXd> &matDataList,
-                            int iNfft,
-                            const QString &sWindowType);
+    static void calculate(QVector<Eigen::MatrixXd>& vecWPLI,
+                          const QList<Eigen::MatrixXd> &matDataList,
+                          int iNfft,
+                          const QString &sWindowType);
 
 protected:
     //=========================================================================================================

--- a/libraries/connectivity/metrics/weightedphaselagindex.h
+++ b/libraries/connectivity/metrics/weightedphaselagindex.h
@@ -9,7 +9,7 @@
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -49,6 +49,7 @@
 #include "../connectivity_global.h"
 
 #include "abstractmetric.h"
+#include "../connectivitysettings.h"
 
 
 //*************************************************************************************************************
@@ -88,8 +89,6 @@ namespace CONNECTIVITYLIB {
 //=============================================================================================================
 
 class Network;
-class ConnectivitySettings;
-class ConnectivityTrialData;
 
 
 //=============================================================================================================
@@ -135,7 +134,7 @@ protected:
     * @param[in] iNfft                  The FFT length.
     * @param[in] tapers                 The taper information.
     */
-    static void compute(ConnectivityTrialData& inputData,
+    static void compute(ConnectivitySettings::IntermediateTrialData& inputData,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
                         QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagAbsSum,
                         QMutex& mutex,

--- a/libraries/connectivity/metrics/weightedphaselagindex.h
+++ b/libraries/connectivity/metrics/weightedphaselagindex.h
@@ -125,16 +125,18 @@ protected:
     /**
     * Computes the WPLI values. This function gets called in parallel.
     *
-    * @param[in] inputData          The input data.
-    * @param[out]vecPairCsdSum      The sum of all CSD matrices for each trial.
-    * @param[in] mutex              The mutex used to safely access vecPairCsdSum.
-    * @param[in] iNRows             The number of rows.
-    * @param[in] iNFreqs            The number of frequenciy bins.
-    * @param[in] iNfft              The FFT length.
-    * @param[in] tapers             The taper information.
+    * @param[in] inputData              The input data.
+    * @param[out]vecPairCsdSum          The sum of all CSD matrices for each trial.
+    * @param[out]vecPairCsdImagAbsSum   The sum of all imag abs CSD matrices for each trial.
+    * @param[in] mutex                  The mutex used to safely access vecPairCsdSum.
+    * @param[in] iNRows                 The number of rows.
+    * @param[in] iNFreqs                The number of frequenciy bins.
+    * @param[in] iNfft                  The FFT length.
+    * @param[in] tapers                 The taper information.
     */
     static void compute(ConnectivityTrialData& inputData,
                         QVector<QPair<int,Eigen::MatrixXcd> >& vecPairCsdSum,
+                        QVector<QPair<int,Eigen::MatrixXd> >& vecPairCsdImagAbsSum,
                         QMutex& mutex,
                         int iNRows,
                         int iNFreqs,

--- a/libraries/disp/viewers/scalingview.cpp
+++ b/libraries/disp/viewers/scalingview.cpp
@@ -363,6 +363,8 @@ void ScalingView::onUpdateSpinBoxScaling(double value)
             m_qMapChScaling.insert(it.key(), it.value()->value() * scaleValue);
 //        qDebug()<<"m_pRTMSAW->m_qMapChScaling[it.key()]" << m_pRTMSAW->m_qMapChScaling[it.key()];
     }
+
+    emit scalingChanged(m_qMapChScaling);
 }
 
 

--- a/libraries/disp/viewers/triggerdetectionview.cpp
+++ b/libraries/disp/viewers/triggerdetectionview.cpp
@@ -285,6 +285,7 @@ void TriggerDetectionView::onRealTimeTriggerColorTypeChanged(const QString &valu
 void TriggerDetectionView::onResetTriggerNumbers()
 {
     ui->m_label_numberDetectedTriggers->setText(QString("0"));
+    ui->m_comboBox_triggerColorType->clear();
 
     emit resetTriggerCounter();
 

--- a/libraries/disp3D/engine/model/data3Dtreedelegate.cpp
+++ b/libraries/disp3D/engine/model/data3Dtreedelegate.cpp
@@ -108,7 +108,7 @@ QWidget *Data3DTreeDelegate::createEditor(QWidget* parent, const QStyleOptionVie
         }
 
         case MetaTreeItemTypes::SurfaceColorSulci: {
-            QColorDialog *pColorDialog = new QColorDialog();
+            QColorDialog *pColorDialog = new QColorDialog(parent);
             connect(pColorDialog, &QColorDialog::currentColorChanged,
                     this, &Data3DTreeDelegate::onEditorEdited);
             pColorDialog->setWindowTitle("Select Sulci Color");
@@ -128,7 +128,8 @@ QWidget *Data3DTreeDelegate::createEditor(QWidget* parent, const QStyleOptionVie
         }
 
         case MetaTreeItemTypes::DataThreshold: {
-            Spline* pSpline = new Spline("Set Threshold", 0);
+            Spline* pSpline = new Spline("Set Threshold", parent);
+            pSpline->setWindowFlags(Qt::Window);
             connect(pSpline, static_cast<void (Spline::*)(double, double, double)>(&Spline::borderChanged),
                     this, &Data3DTreeDelegate::onEditorEdited);
 
@@ -154,7 +155,7 @@ QWidget *Data3DTreeDelegate::createEditor(QWidget* parent, const QStyleOptionVie
         }
 
         case MetaTreeItemTypes::Color: {
-            QColorDialog *pColorDialog = new QColorDialog();
+            QColorDialog *pColorDialog = new QColorDialog(parent);
             connect(pColorDialog, &QColorDialog::currentColorChanged,
                     this, &Data3DTreeDelegate::onEditorEdited);
             pColorDialog->setWindowTitle("Select Color");
@@ -261,7 +262,8 @@ QWidget *Data3DTreeDelegate::createEditor(QWidget* parent, const QStyleOptionVie
             QModelIndex indexParent = pData3DTreeModel->indexFromItem(pParentItem);
             MatrixXd matRTData = index.model()->data(indexParent, Data3DTreeModelItemRoles::Data).value<MatrixXd>();
 
-            ImageSc* pPlotLA = new ImageSc(matRTData);
+            ImageSc* pPlotLA = new ImageSc(matRTData, parent);
+            pPlotLA->setWindowFlags(Qt::Window);
             pPlotLA->show();
             //return pPlotLA;
         }

--- a/libraries/disp3D/engine/model/data3Dtreemodel.cpp
+++ b/libraries/disp3D/engine/model/data3Dtreemodel.cpp
@@ -215,8 +215,8 @@ FsSurfaceTreeItem* Data3DTreeModel::addSurface(const QString& subject,
 //*************************************************************************************************************
 
 QList<SourceSpaceTreeItem*> Data3DTreeModel::addSourceSpace(const QString& sSubject,
-                                                     const QString& sMeasurementSetName,
-                                                     const MNESourceSpace& sourceSpace)
+                                                            const QString& sMeasurementSetName,
+                                                            const MNESourceSpace& sourceSpace)
 {
     QList<SourceSpaceTreeItem*> pReturnItem;
 
@@ -242,8 +242,8 @@ QList<SourceSpaceTreeItem*> Data3DTreeModel::addSourceSpace(const QString& sSubj
 //*************************************************************************************************************
 
 QList<SourceSpaceTreeItem*> Data3DTreeModel::addForwardSolution(const QString& sSubject,
-                                                         const QString& sMeasurementSetName,
-                                                         const MNEForwardSolution& forwardSolution)
+                                                                const QString& sMeasurementSetName,
+                                                                const MNEForwardSolution& forwardSolution)
 {
     return this->addSourceSpace(sSubject, sMeasurementSetName, forwardSolution.src);
 }

--- a/libraries/disp3D/engine/model/items/network/networktreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/network/networktreeitem.cpp
@@ -339,21 +339,23 @@ void NetworkTreeItem::plotEdges(const Network &tNetworkData)
 
             if(startPos != endPos) {
                 dWeight = pNetworkEdge->getWeight();
-                diff = endPos - startPos;
-                edgePos = endPos - diff/2;
+                if(dWeight != 0.0) {
+                    diff = endPos - startPos;
+                    edgePos = endPos - diff/2;
 
-                QMatrix4x4 tempTransform;
-                tempTransform.translate(edgePos);
-                tempTransform.rotate(QQuaternion::rotationTo(QVector3D(0,1,0), diff.normalized()).normalized());
-                tempTransform.scale(1.0,diff.length(),1.0);
+                    QMatrix4x4 tempTransform;
+                    tempTransform.translate(edgePos);
+                    tempTransform.rotate(QQuaternion::rotationTo(QVector3D(0,1,0), diff.normalized()).normalized());
+                    tempTransform.scale(1.0,diff.length(),1.0);
 
-                vTransformsEdges.push_back(tempTransform);
+                    vTransformsEdges.push_back(tempTransform);
 
-                // Normalize colors
-                if(dMaxWeight != 0.0f) {
-                    vColorsEdges.push_back(QColor(ColorMap::valueToJet(dWeight/dMaxWeight)));
-                } else {
-                    vColorsEdges.push_back(QColor(ColorMap::valueToJet(0.0f)));
+                    // Normalize colors
+                    if(dMaxWeight != 0.0f) {
+                        vColorsEdges.push_back(QColor(ColorMap::valueToJet(dWeight/dMaxWeight)));
+                    } else {
+                        vColorsEdges.push_back(QColor(ColorMap::valueToJet(0.0f)));
+                    }
                 }
             }
         }

--- a/libraries/disp3D/engine/model/items/sourcedata/mneestimatetreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/sourcedata/mneestimatetreeitem.cpp
@@ -426,7 +426,8 @@ void MneEstimateTreeItem::addData(const MNESourceEstimate& tSourceEstimate)
     data.setValue(tSourceEstimate.data);
     this->setData(data, Data3DTreeModelItemRoles::Data);
 
-    if(m_pRtSourceDataController) {
+    // Only draw activation if item is checked
+    if(m_pRtSourceDataController && this->checkState() == Qt::Checked) {
         m_pRtSourceDataController->addData(tSourceEstimate.data);
     }
 }

--- a/libraries/libraries.pro
+++ b/libraries/libraries.pro
@@ -9,7 +9,7 @@
 #
 # @section  LICENSE
 #
-# Copyright (C) 2012, Christoph Dinh, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
+# Copyright (C) 2012, Christoph Dinh, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 # the following conditions are met:

--- a/libraries/libraries.pro
+++ b/libraries/libraries.pro
@@ -9,7 +9,7 @@
 #
 # @section  LICENSE
 #
-# Copyright (C) 2012, Christoph Dinh, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+# Copyright (C) 2012, Christoph Dinh, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 # the following conditions are met:

--- a/libraries/mne/mne_epoch_data_list.cpp
+++ b/libraries/mne/mne_epoch_data_list.cpp
@@ -373,7 +373,9 @@ void MNEEpochDataList::checkChVariance(ArtifactRejectionData& inputData)
 
     double dMedian = temp.norm() / temp.cols();
 
+    // Remove offset
     temp = temp.array() - dMedian;
+
     temp.array().square();
 
 //    qDebug() << "MNEEpochDataList::checkChVariance - dMedian" << abs(dMedian);
@@ -395,6 +397,7 @@ void MNEEpochDataList::checkChThreshold(ArtifactRejectionData& inputData)
 {
     RowVectorXd temp = inputData.data;
 
+    // Remove offset
     temp = temp.array() - temp(0);
 
     double min = temp.minCoeff();

--- a/libraries/mne/mne_epoch_data_list.cpp
+++ b/libraries/mne/mne_epoch_data_list.cpp
@@ -50,6 +50,7 @@
 
 #include <QPointer>
 #include <QtConcurrent>
+#include <QDebug>
 
 
 //*************************************************************************************************************
@@ -273,7 +274,7 @@ void MNEEpochDataList::pick_channels(const RowVectorXi& sel)
 
 //*************************************************************************************************************
 
-bool MNEEpochDataList::checkForArtifact(MatrixXd& data,
+bool MNEEpochDataList::checkForArtifact(const MatrixXd& data,
                                         const FiffInfo& pFiffInfo,
                                         double dThreshold,
                                         const QString& sCheckType,
@@ -327,7 +328,7 @@ bool MNEEpochDataList::checkForArtifact(MatrixXd& data,
     }
 
     if(lchData.isEmpty()) {
-        qDebug() << "MNEEpochDataList::checkForArtifact - No channels found to scan for artifacts. Returning.";
+        qDebug() << "MNEEpochDataList::checkForArtifact - No channels found to scan for artifacts. Do not reject. Returning.";
 
         return bReject;
     }
@@ -335,7 +336,7 @@ bool MNEEpochDataList::checkForArtifact(MatrixXd& data,
 //    qDebug() << "MNEEpochDataList::checkForArtifact - lchData.size()" << lchData.size();
 //    qDebug() << "MNEEpochDataList::checkForArtifact - iChType" << iChType;
 
-    if(sCheckType.contains("threshold", Qt::CaseInsensitive)) {
+    if(sCheckType.contains("threshold", Qt::CaseInsensitive) && !lchData.isEmpty()) {
         //Start the concurrent processing
         QFuture<void> future = QtConcurrent::map(lchData, checkChThreshold);
         future.waitForFinished();
@@ -347,7 +348,7 @@ bool MNEEpochDataList::checkForArtifact(MatrixXd& data,
                 break;
             }
         }
-    } else if(sCheckType.contains("variance", Qt::CaseInsensitive)) {
+    } else if(sCheckType.contains("variance", Qt::CaseInsensitive) && !lchData.isEmpty()) {
         //Start the concurrent processing
         QFuture<void> future = QtConcurrent::map(lchData, checkChVariance);
         future.waitForFinished();

--- a/libraries/mne/mne_epoch_data_list.h
+++ b/libraries/mne/mne_epoch_data_list.h
@@ -163,7 +163,7 @@ public:
     *
     * @return   Whether a threshold artifact was detected.
     */
-    static bool checkForArtifact(Eigen::MatrixXd& data,
+    static bool checkForArtifact(const Eigen::MatrixXd& data,
                                  const FIFFLIB::FiffInfo& pFiffInfo,
                                  double dThreshold,
                                  const QString& sCheckType = QString("threshold"),

--- a/libraries/mne/mne_forwardsolution.cpp
+++ b/libraries/mne/mne_forwardsolution.cpp
@@ -178,7 +178,12 @@ void MNEForwardSolution::clear()
 
 //*************************************************************************************************************
 
-MNEForwardSolution MNEForwardSolution::cluster_forward_solution(const AnnotationSet &p_AnnotationSet, qint32 p_iClusterSize, MatrixXd& p_D, const FiffCov &p_pNoise_cov, const FiffInfo &p_pInfo, QString p_sMethod) const
+MNEForwardSolution MNEForwardSolution::cluster_forward_solution(const AnnotationSet &p_AnnotationSet,
+                                                                qint32 p_iClusterSize,
+                                                                MatrixXd& p_D,
+                                                                const FiffCov &p_pNoise_cov,
+                                                                const FiffInfo &p_pInfo,
+                                                                QString p_sMethod) const
 {
     printf("Cluster forward solution using %s.\n", p_sMethod.toUtf8().constData());
 

--- a/libraries/mne/mne_forwardsolution.h
+++ b/libraries/mne/mne_forwardsolution.h
@@ -260,7 +260,12 @@ public:
     *
     * @return clustered MNE forward solution
     */
-    MNEForwardSolution cluster_forward_solution(const AnnotationSet &p_AnnotationSet, qint32 p_iClusterSize, MatrixXd& p_D = defaultD, const FiffCov &p_pNoise_cov = defaultCov, const FiffInfo &p_pInfo = defaultInfo, QString p_sMethod = "cityblock") const;
+    MNEForwardSolution cluster_forward_solution(const AnnotationSet &p_AnnotationSet,
+                                                qint32 p_iClusterSize,
+                                                MatrixXd& p_D = defaultD,
+                                                const FiffCov &p_pNoise_cov = defaultCov,
+                                                const FiffInfo &p_pInfo = defaultInfo,
+                                                QString p_sMethod = "cityblock") const;
 
     //=========================================================================================================
     /**
@@ -286,7 +291,13 @@ public:
     *
     * @return the depth prior
     */
-    static FiffCov compute_depth_prior(const MatrixXd &Gain, const FiffInfo &gain_info, bool is_fixed_ori, double exp = 0.8, double limit = 10.0, const MatrixXd &patch_areas = defaultConstMatrixXd, bool limit_depth_chs = false);
+    static FiffCov compute_depth_prior(const MatrixXd &Gain,
+                                       const FiffInfo &gain_info,
+                                       bool is_fixed_ori,
+                                       double exp = 0.8,
+                                       double limit = 10.0,
+                                       const MatrixXd &patch_areas = defaultConstMatrixXd,
+                                       bool limit_depth_chs = false);
 
     //=========================================================================================================
     /**

--- a/libraries/rtprocessing/rtconnectivity.cpp
+++ b/libraries/rtprocessing/rtconnectivity.cpp
@@ -95,8 +95,8 @@ void RtConnectivityWorker::doWork(const ConnectivitySettings &connectivitySettin
     qDebug()<<"----------------------------------------";
     qDebug()<<"----------------------------------------";
     qDebug()<<"------RtConnectivityWorker::doWork()";
-    qDebug()<<"------Method:"<<connectivitySettings.m_sConnectivityMethods.first();
-    qDebug()<<"------Data dim:"<<connectivitySettings.m_dataList.first().matData.rows() << "x" << connectivitySettings.m_dataList.first().matData.cols();
+    qDebug()<<"------Method:"<<connectivitySettings.getConnectivityMethods().first();
+    qDebug()<<"------Data dim:"<<connectivitySettings.at(0).matData.rows() << "x" << connectivitySettings.at(0).matData.cols();
     qDebug()<<"------Number trials:"<< connectivitySettings.size();
     qDebug()<<"------Total time:"<<iTime << "ms";
     qDebug()<<"----------------------------------------";

--- a/libraries/rtprocessing/rtconnectivity.cpp
+++ b/libraries/rtprocessing/rtconnectivity.cpp
@@ -86,8 +86,7 @@ void RtConnectivityWorker::doWork(const ConnectivitySettings &connectivitySettin
     qint64 iTime = 0;
     time.start();
 
-    Connectivity tConnectivity(connectivitySettings);
-    Network finalNetwork = tConnectivity.calculateConnectivity();
+    Network finalNetwork = Connectivity::calculate(connectivitySettings);
 
     iTime = time.elapsed();
 

--- a/libraries/rtprocessing/rtconnectivity.cpp
+++ b/libraries/rtprocessing/rtconnectivity.cpp
@@ -98,7 +98,7 @@ void RtConnectivityWorker::doWork(const ConnectivitySettings &connectivitySettin
     qDebug()<<"------RtConnectivityWorker::doWork()";
     qDebug()<<"------Method:"<<connectivitySettings.m_sConnectivityMethods.first();
     qDebug()<<"------Data dim:"<<connectivitySettings.m_dataList.first().matData.rows() << "x" << connectivitySettings.m_dataList.first().matData.cols();
-    qDebug()<<"------Number trials:"<< connectivitySettings.m_dataList.size();
+    qDebug()<<"------Number trials:"<< connectivitySettings.size();
     qDebug()<<"------Total time:"<<iTime << "ms";
     qDebug()<<"----------------------------------------";
     qDebug()<<"----------------------------------------";

--- a/libraries/rtprocessing/rtconnectivity.cpp
+++ b/libraries/rtprocessing/rtconnectivity.cpp
@@ -92,7 +92,6 @@ void RtConnectivityWorker::doWork(const ConnectivitySettings &connectivitySettin
 
     iTime = time.elapsed();
 
-    emit resultReady(finalNetwork, connectivitySettingsTemp);
     qDebug()<<"----------------------------------------";
     qDebug()<<"----------------------------------------";
     qDebug()<<"------RtConnectivityWorker::doWork()";
@@ -102,6 +101,8 @@ void RtConnectivityWorker::doWork(const ConnectivitySettings &connectivitySettin
     qDebug()<<"------Total time:"<<iTime << "ms";
     qDebug()<<"----------------------------------------";
     qDebug()<<"----------------------------------------";
+
+    emit resultReady(finalNetwork, connectivitySettingsTemp);
 }
 
 

--- a/libraries/rtprocessing/rtconnectivity.cpp
+++ b/libraries/rtprocessing/rtconnectivity.cpp
@@ -82,21 +82,23 @@ void RtConnectivityWorker::doWork(const ConnectivitySettings &connectivitySettin
         return;
     }
 
+    ConnectivitySettings connectivitySettingsTemp = connectivitySettings;
+
     QElapsedTimer time;
     qint64 iTime = 0;
     time.start();
 
-    Network finalNetwork = Connectivity::calculate(connectivitySettings);
+    Network finalNetwork = Connectivity::calculate(connectivitySettingsTemp);
 
     iTime = time.elapsed();
 
-    emit resultReady(finalNetwork);
+    emit resultReady(finalNetwork, connectivitySettingsTemp);
     qDebug()<<"----------------------------------------";
     qDebug()<<"----------------------------------------";
     qDebug()<<"------RtConnectivityWorker::doWork()";
     qDebug()<<"------Method:"<<connectivitySettings.m_sConnectivityMethods.first();
-    qDebug()<<"------Data dim:"<<connectivitySettings.m_matDataList.first().rows() << "x"<<connectivitySettings.m_matDataList.first().cols();
-    qDebug()<<"------Number trials:"<< connectivitySettings.m_matDataList.size();
+    qDebug()<<"------Data dim:"<<connectivitySettings.m_dataList.first().matData.rows() << "x" << connectivitySettings.m_dataList.first().matData.cols();
+    qDebug()<<"------Number trials:"<< connectivitySettings.m_dataList.size();
     qDebug()<<"------Total time:"<<iTime << "ms";
     qDebug()<<"----------------------------------------";
     qDebug()<<"----------------------------------------";
@@ -121,7 +123,7 @@ RtConnectivity::RtConnectivity(QObject *parent)
             worker, &RtConnectivityWorker::doWork);
 
     connect(worker, &RtConnectivityWorker::resultReady,
-            this, &RtConnectivity::handleResults);
+            this, &RtConnectivity::newConnectivityResultAvailable);
 
     m_workerThread.start();
 }
@@ -145,14 +147,6 @@ void RtConnectivity::append(const ConnectivitySettings& connectivitySettings)
 
 //*************************************************************************************************************
 
-void RtConnectivity::handleResults(const Network& connectivityResult)
-{
-    emit newConnectivityResultAvailable(connectivityResult);
-}
-
-
-//*************************************************************************************************************
-
 void RtConnectivity::restart()
 {
     stop();
@@ -167,7 +161,7 @@ void RtConnectivity::restart()
             worker, &RtConnectivityWorker::doWork);
 
     connect(worker, &RtConnectivityWorker::resultReady,
-            this, &RtConnectivity::handleResults);
+            this, &RtConnectivity::newConnectivityResultAvailable);
 
     m_workerThread.start();
 }

--- a/libraries/rtprocessing/rtconnectivity.h
+++ b/libraries/rtprocessing/rtconnectivity.h
@@ -111,7 +111,7 @@ public:
     void doWork(const CONNECTIVITYLIB::ConnectivitySettings& connectivitySettings);
 
 signals:
-    void resultReady(const CONNECTIVITYLIB::Network& connectivityResult);
+    void resultReady(const CONNECTIVITYLIB::Network& connectivityResult, const CONNECTIVITYLIB::ConnectivitySettings& connectivitySettings);
 };
 
 //=============================================================================================================
@@ -163,16 +163,10 @@ public:
     void stop();
 
 protected:
-    //=========================================================================================================
-    /**
-    * Handles the result
-    */
-    void handleResults(const CONNECTIVITYLIB::Network& connectivityResult);
-
     QThread             m_workerThread;         /**< The worker thread. */
 
 signals:
-    void newConnectivityResultAvailable(const CONNECTIVITYLIB::Network& connectivityResult);
+    void newConnectivityResultAvailable(const CONNECTIVITYLIB::Network& connectivityResult, const CONNECTIVITYLIB::ConnectivitySettings& connectivitySettings);
 
     void operate(const CONNECTIVITYLIB::ConnectivitySettings& connectivitySettings);
 };

--- a/libraries/utils/spectral.cpp
+++ b/libraries/utils/spectral.cpp
@@ -2,13 +2,14 @@
 /**
 * @file     spectral.cpp
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     March, 2018
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:

--- a/libraries/utils/spectral.h
+++ b/libraries/utils/spectral.h
@@ -2,13 +2,14 @@
 /**
 * @file     spectral.h
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     March, 2018
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -219,5 +219,5 @@ isEmpty( MNE_INSTALL_INCLUDE_DIR ) {
 
 
 # FFTW dir
-FFTW_DIR_LIBS = $$shell_path(C:\fftw-3.3.5-dll64)
-FFTW_DIR_INCLUDE = $$shell_path(C:\fftw-3.3.5-dll64)
+FFTW_DIR_LIBS = $$shell_path(/cluster/fusion/lesch/Programs/fftw-3.3.8/lib)
+FFTW_DIR_INCLUDE = $$shell_path(/cluster/fusion/lesch/Programs/fftw-3.3.8/include)

--- a/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
+++ b/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
@@ -361,9 +361,6 @@ void TestSpectralConnectivity::compareConnectivity()
 
     printf(">>>>>>>>>>>>>>>>>>>>>>>>> Compare Spectral Connectivities >>>>>>>>>>>>>>>>>>>>>>>>>\n");
 
-    qDebug() << "TestSpectralConnectivity::compareConnectivity - m_ConnectivityOutput" << m_ConnectivityOutput;
-    qDebug() << "TestSpectralConnectivity::compareConnectivity - m_RefConnectivityOutput" << m_RefConnectivityOutput;
-
     //*********************************************************************************************************
     // Compare connectivity estimate
     //*********************************************************************************************************

--- a/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
+++ b/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
@@ -2,6 +2,7 @@
 /**
 * @file     test_spectral_connectivity.cpp
 * @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+*           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
 * @date     May, 2018

--- a/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
+++ b/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
@@ -9,7 +9,7 @@
 *
 * @section  LICENSE
 *
-* Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+* Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 * the following conditions are met:
@@ -365,7 +365,7 @@ void TestSpectralConnectivity::compareConnectivity()
     qDebug() << "TestSpectralConnectivity::compareConnectivity - m_RefConnectivityOutput" << m_RefConnectivityOutput;
 
     //*********************************************************************************************************
-    // Compare connectivity estimate for each frequency bin
+    // Compare connectivity estimate
     //*********************************************************************************************************
 
     QCOMPARE(m_ConnectivityOutput, m_RefConnectivityOutput);

--- a/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
+++ b/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
@@ -131,8 +131,8 @@ void TestSpectralConnectivity::initTestCase()
     //*********************************************************************************************************
 
     QList<MatrixXd> matDataList = readConnectivityData();
-    m_connectivitySettings.m_iNfft = matDataList.at(0).cols();
-    m_connectivitySettings.m_sWindowType = "hanning";
+    m_connectivitySettings.setNumberFFT(matDataList.at(0).cols());
+    m_connectivitySettings.setWindowType("hanning");
     m_connectivitySettings.append(matDataList);
 }
 

--- a/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
+++ b/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
@@ -94,13 +94,13 @@ public:
 
 private slots:
     void initTestCase();
-    void spectralConnectivityCoherence();
-    void spectralConnectivityImagCoherence();
     void spectralConnectivityPLV();
     void spectralConnectivityPLI();
     void spectralConnectivityPLI2();
     void spectralConnectivityWPLI();
     void spectralConnectivityWPLI2();
+    void spectralConnectivityCoherence();
+    void spectralConnectivityImagCoherence();
     void cleanupTestCase();
 
 private:
@@ -359,6 +359,9 @@ void TestSpectralConnectivity::compareConnectivity()
     //*********************************************************************************************************
 
     printf(">>>>>>>>>>>>>>>>>>>>>>>>> Compare Spectral Connectivities >>>>>>>>>>>>>>>>>>>>>>>>>\n");
+
+    qDebug() << "TestSpectralConnectivity::compareConnectivity - m_ConnectivityOutput" << m_ConnectivityOutput;
+    qDebug() << "TestSpectralConnectivity::compareConnectivity - m_RefConnectivityOutput" << m_RefConnectivityOutput;
 
     //*********************************************************************************************************
     // Compare connectivity estimate for each frequency bin

--- a/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
+++ b/testframes/test_spectral_connectivity/test_spectral_connectivity.cpp
@@ -179,9 +179,9 @@ void TestSpectralConnectivity::spectralConnectivityImagCoherence()
     // Compute Connectivity
     //*********************************************************************************************************
 
-    QVector<MatrixXd> vecImagCoh = ImagCoherence::computeImagCoherence(matDataList,
-                                                                       iNfft,
-                                                                       sWindowType);
+    QVector<MatrixXd> vecImagCoh = ImagCoherence::calculate(matDataList,
+                                                            iNfft,
+                                                            sWindowType);
     m_ConnectivityOutput = vecImagCoh.at(0).row(1);
 
     //*********************************************************************************************************
@@ -217,7 +217,7 @@ void TestSpectralConnectivity::spectralConnectivityPLV()
     // Compute Connectivity
     //*********************************************************************************************************
 
-    QVector<MatrixXd> PLV = PhaseLockingValue::computePLV(matDataList, iNfft, sWindowType);
+    QVector<MatrixXd> PLV = PhaseLockingValue::calculate(matDataList, iNfft, sWindowType);
     m_ConnectivityOutput = PLV.at(0).row(1);
 
     //*********************************************************************************************************
@@ -254,10 +254,10 @@ void TestSpectralConnectivity::spectralConnectivityPLI()
     //*********************************************************************************************************
 
     QVector<MatrixXd> PLI;
-    PhaseLagIndex::computePLI(PLI,
-                              matDataList,
-                              iNfft,
-                              sWindowType);
+    PhaseLagIndex::calculate(PLI,
+                             matDataList,
+                             iNfft,
+                             sWindowType);
     m_ConnectivityOutput = PLI.at(0).row(1);
 
     //*********************************************************************************************************
@@ -294,10 +294,10 @@ void TestSpectralConnectivity::spectralConnectivityPLI2()
     //*********************************************************************************************************
 
     QVector<MatrixXd> PLI2;
-    UnbiasedSquaredPhaseLagIndex::computeUnbiasedSquaredPLI(PLI2,
-                                                            matDataList,
-                                                            iNfft,
-                                                            sWindowType);
+    UnbiasedSquaredPhaseLagIndex::calculate(PLI2,
+                                            matDataList,
+                                            iNfft,
+                                            sWindowType);
     m_ConnectivityOutput = PLI2.at(0).row(1);
 
     //*********************************************************************************************************
@@ -334,10 +334,10 @@ void TestSpectralConnectivity::spectralConnectivityWPLI()
     //*********************************************************************************************************
 
     QVector<MatrixXd> WPLI;
-    WeightedPhaseLagIndex::computeWPLI(WPLI,
-                                       matDataList,
-                                       iNfft,
-                                       sWindowType);
+    WeightedPhaseLagIndex::calculate(WPLI,
+                                     matDataList,
+                                     iNfft,
+                                     sWindowType);
     m_ConnectivityOutput = WPLI.at(0).row(1);
 
     //*********************************************************************************************************
@@ -374,10 +374,10 @@ void TestSpectralConnectivity::spectralConnectivityWPLI2()
     //*********************************************************************************************************
 
     QVector<MatrixXd> WPLI2;
-    DebiasedSquaredWeightedPhaseLagIndex::computeDebiasedSquaredWPLI(WPLI2,
-                                                                     matDataList,
-                                                                     iNfft,
-                                                                     sWindowType);
+    DebiasedSquaredWeightedPhaseLagIndex::calculate(WPLI2,
+                                                    matDataList,
+                                                    iNfft,
+                                                    sWindowType);
     m_ConnectivityOutput = WPLI2.at(0).row(1);
 
     //*********************************************************************************************************

--- a/testframes/test_spectral_connectivity/test_spectral_connectivity.pro
+++ b/testframes/test_spectral_connectivity/test_spectral_connectivity.pro
@@ -2,13 +2,14 @@
 #
 # @file     test_spectral_connectivity.pro
 # @author   Daniel Strohmeier <daniel.strohmeier@tu-ilmenau.de>;
+#           Lorenz Esch <lorenz.esch@mgh.harvard.edu>;
 #           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 # @version  1.0
 # @date     May, 2018
 #
 # @section  LICENSE
 #
-# Copyright (C) 2018, Daniel Strohmeier and Matti Hamalainen. All rights reserved.
+# Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch and Matti Hamalainen. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 # the following conditions are met:


### PR DESCRIPTION
- Store intermediate data which can be used while computing a new functional connectivity estimate as soon as a new trial is added. This greatly speeds up computation during real-time scenarios and when changing between similar metrics.
- Fix bug where tree items were added twice during real-time connectivity visualization.
- Change trigger detection threshold in BabyMEG