### PR TITLE
Add missing RPATH

### DIFF
--- a/applications/mne_analyze/extensions/deepcntk/deepcntk.pro
+++ b/applications/mne_analyze/extensions/deepcntk/deepcntk.pro
@@ -102,6 +102,10 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_analyze/extensions/dipolefit/dipolefit.pro
+++ b/applications/mne_analyze/extensions/dipolefit/dipolefit.pro
@@ -88,6 +88,10 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
 
 FORMS += \
     FormFiles/dipolefitcontrol.ui

--- a/applications/mne_analyze/extensions/invmne/invmne.pro
+++ b/applications/mne_analyze/extensions/invmne/invmne.pro
@@ -97,6 +97,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_analyze/extensions/music/music.pro
+++ b/applications/mne_analyze/extensions/music/music.pro
@@ -97,6 +97,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_analyze/extensions/stcbrowser/stcbrowser.pro
+++ b/applications/mne_analyze/extensions/stcbrowser/stcbrowser.pro
@@ -89,6 +89,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 FORMS += \
     FormFiles/stccontrol.ui
 

--- a/applications/mne_analyze/extensions/surfer/surfer.pro
+++ b/applications/mne_analyze/extensions/surfer/surfer.pro
@@ -103,6 +103,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_rt_server/plugins/fiffsimulator/fiffsimulator.pro
+++ b/applications/mne_rt_server/plugins/fiffsimulator/fiffsimulator.pro
@@ -92,6 +92,11 @@ UI_DIR = $${PWD}
 
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_rt_server/plugins/neuromag/neuromag.pro
+++ b/applications/mne_rt_server/plugins/neuromag/neuromag.pro
@@ -92,6 +92,11 @@ UI_DIR = $${PWD}
 
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/averaging/averaging.pro
+++ b/applications/mne_scan/plugins/averaging/averaging.pro
@@ -110,6 +110,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 RESOURCES += \
     averaging.qrc
 

--- a/applications/mne_scan/plugins/babymeg/babymeg.pro
+++ b/applications/mne_scan/plugins/babymeg/babymeg.pro
@@ -137,6 +137,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 contains(MNECPP_CONFIG, buildBasicMneScanVersion) {
     DEFINES += BUILD_BASIC_MNESCAN_VERSION
 }

--- a/applications/mne_scan/plugins/covariance/covariance.pro
+++ b/applications/mne_scan/plugins/covariance/covariance.pro
@@ -108,6 +108,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 RESOURCES += \
     covariance.qrc
 

--- a/applications/mne_scan/plugins/dummytoolbox/dummytoolbox.pro
+++ b/applications/mne_scan/plugins/dummytoolbox/dummytoolbox.pro
@@ -96,6 +96,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/ecgsimulator/ecgsimulator.pro
+++ b/applications/mne_scan/plugins/ecgsimulator/ecgsimulator.pro
@@ -111,6 +111,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/epidetect/epidetect.pro
+++ b/applications/mne_scan/plugins/epidetect/epidetect.pro
@@ -102,6 +102,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.pro
+++ b/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.pro
@@ -128,6 +128,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/lsladapter/lsladapter.pro
+++ b/applications/mne_scan/plugins/lsladapter/lsladapter.pro
@@ -126,11 +126,10 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
-###not sure about below:
-#RESOURCES += \
-#    brainamp.qrc
-
-#DISTFILES +=
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
 
 DISTFILES += \
     lsladapter.json

--- a/applications/mne_scan/plugins/mne/mne.pro
+++ b/applications/mne_scan/plugins/mne/mne.pro
@@ -112,6 +112,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/natus/natus.pro
+++ b/applications/mne_scan/plugins/natus/natus.pro
@@ -112,11 +112,10 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
-###not sure about below:
-#RESOURCES += \
-#    brainamp.qrc
-
-#DISTFILES +=
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
 
 DISTFILES += \
     natus.json

--- a/applications/mne_scan/plugins/neuromag/neuromag.pro
+++ b/applications/mne_scan/plugins/neuromag/neuromag.pro
@@ -120,6 +120,11 @@ RESOURCES += \
 OTHER_FILES += \
     neuromag.json
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Put generated form headers into the origin --> cause other src is pointing at them
 UI_DIR = $${PWD}
 

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.pro
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.pro
@@ -111,6 +111,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/noise/noise.pro
+++ b/applications/mne_scan/plugins/noise/noise.pro
@@ -104,6 +104,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/noisereduction/noisereduction.pro
+++ b/applications/mne_scan/plugins/noisereduction/noisereduction.pro
@@ -124,6 +124,11 @@ unix: QMAKE_CXXFLAGS += -Wno-attributes
 RESOURCES += \
     noisereduction.qrc
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/rapmusictoolbox/rapmusictoolbox.pro
+++ b/applications/mne_scan/plugins/rapmusictoolbox/rapmusictoolbox.pro
@@ -108,6 +108,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/reference/reference.pro
+++ b/applications/mne_scan/plugins/reference/reference.pro
@@ -104,7 +104,10 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
-DISTFILES +=
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
 
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {

--- a/applications/mne_scan/plugins/rthpi/rthpi.pro
+++ b/applications/mne_scan/plugins/rthpi/rthpi.pro
@@ -107,6 +107,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/rtsss/rtsss.pro
+++ b/applications/mne_scan/plugins/rtsss/rtsss.pro
@@ -106,6 +106,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/applications/mne_scan/plugins/ssvepbci/ssvepbci.pro
+++ b/applications/mne_scan/plugins/ssvepbci/ssvepbci.pro
@@ -134,7 +134,10 @@ UI_DIR = $${PWD}
 RESOURCES += \
         ssvepbci.qrc
 
-DISTFILES +=
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
 
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {

--- a/applications/mne_scan/plugins/triggercontrol/triggercontrol.pro
+++ b/applications/mne_scan/plugins/triggercontrol/triggercontrol.pro
@@ -99,6 +99,11 @@ unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 # suppress visibility warnings
 unix: QMAKE_CXXFLAGS += -Wno-attributes
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/examples/ex_make_layout/ex_make_layout.pro
+++ b/examples/ex_make_layout/ex_make_layout.pro
@@ -75,11 +75,6 @@ win32 {
     QMAKE_POST_LINK += $${DEPLOY_CMD}
 }
 
-win32 {
-    EXTRA_ARGS =
-    DEPLOY_CMD = $$winDeployAppArgs($${TARGET},$${TARGET_EXT},$${MNE_BINARY_DIR},$${LIBS},$${EXTRA_ARGS})
-    QMAKE_POST_LINK += $${DEPLOY_CMD}
-}
 unix:!macx {
     # === Unix ===
     QMAKE_RPATHDIR += $ORIGIN/../lib

--- a/testframes/test_codecov/test_codecov.pro
+++ b/testframes/test_codecov/test_codecov.pro
@@ -73,6 +73,11 @@ win32 {
 
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_dipole_fit/test_dipole_fit.pro
+++ b/testframes/test_dipole_fit/test_dipole_fit.pro
@@ -99,6 +99,11 @@ win32 {
     QMAKE_POST_LINK += $${DEPLOY_CMD}
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_fiff_cov/test_fiff_cov.pro
+++ b/testframes/test_fiff_cov/test_fiff_cov.pro
@@ -83,6 +83,11 @@ win32 {
     
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_fiff_digitizer/test_fiff_digitizer.pro
+++ b/testframes/test_fiff_digitizer/test_fiff_digitizer.pro
@@ -83,6 +83,11 @@ win32 {
     
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_fiff_mne_types_io/test_fiff_mne_types_io.pro
+++ b/testframes/test_fiff_mne_types_io/test_fiff_mne_types_io.pro
@@ -85,6 +85,11 @@ win32 {
     
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_fiff_rwr/test_fiff_rwr.pro
+++ b/testframes/test_fiff_rwr/test_fiff_rwr.pro
@@ -82,6 +82,11 @@ win32 {
     QMAKE_POST_LINK += $${DEPLOY_CMD}
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_forward_solution/test_forward_solution.pro
+++ b/testframes/test_forward_solution/test_forward_solution.pro
@@ -89,6 +89,11 @@ win32 {
     
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_geometryinfo/test_geometryinfo.pro
+++ b/testframes/test_geometryinfo/test_geometryinfo.pro
@@ -98,6 +98,11 @@ win32 {
     
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_interpolation/test_interpolation.pro
+++ b/testframes/test_interpolation/test_interpolation.pro
@@ -97,6 +97,11 @@ win32 {
     
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_mne_msh_display_surface_set/test_mne_msh_display_surface_set.pro
+++ b/testframes/test_mne_msh_display_surface_set/test_mne_msh_display_surface_set.pro
@@ -87,6 +87,11 @@ win32 {
     
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/testframes/test_spectral_connectivity/test_spectral_connectivity.pro
+++ b/testframes/test_spectral_connectivity/test_spectral_connectivity.pro
@@ -88,6 +88,11 @@ unix:!macx {
     QMAKE_RPATHDIR += $ORIGIN/../lib
 }
 
+unix:!macx {
+    # === Unix ===
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
 # Activate FFTW backend in Eigen
 contains(MNECPP_CONFIG, useFFTW) {
     DEFINES += EIGEN_FFTW_DEFAULT

--- a/tools/travis/linux_tests/after_success.sh
+++ b/tools/travis/linux_tests/after_success.sh
@@ -6,7 +6,6 @@ set -e
 git clone https://github.com/mne-tools/mne-cpp-test-data.git mne-cpp-test-data
 
 # Set Environment variable
-export LD_LIBRARY_PATH=$(pwd)/lib:$LD_LIBRARY_PATH
 MNECPP_ROOT=$(pwd)
 
 # Tests to run - TODO: find required tests automatically with grep

--- a/tools/travis/linux_tests/after_success.sh
+++ b/tools/travis/linux_tests/after_success.sh
@@ -6,6 +6,7 @@ set -e
 git clone https://github.com/mne-tools/mne-cpp-test-data.git mne-cpp-test-data
 
 # Set Environment variable
+export LD_LIBRARY_PATH=$(pwd)/lib:$LD_LIBRARY_PATH
 MNECPP_ROOT=$(pwd)
 
 # Tests to run - TODO: find required tests automatically with grep


### PR DESCRIPTION
Add QMAKE_RPATHDIR to MNE Scan plugins and MNE Analyze extensions as well as testframes. This will remove the necessity to set LD_LIBRARY_PATH to point to the mne-cpp lib folder on Linux. Avoiding LD_LIBRARY_PATH will make sure that no other application are linking against mne-cpp shipped qt libraries. The travis linux test script was changed to not use LD_LIBRARY_PATH. This PR fixes #297. 