### PR TITLE
Fix linux upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
 # 1.0.0
     - secure: YXurlzTjVZYR8t3W9K7rcFLCnpR7DerHQ15hgojGrCthKlkLuMy7maDrVx4Xq+KFuNmFzEZavla+GKdx5E+EhmZtaSx5OFfejfI1ya5WNTjwQgL5niQV4HoTCKNHZhwIovIEYkyLSaIPZbfccfXBRFegMrBQpVsSSBQoKZiUFfk=
     - secure: bQ7qDeGFDGiYIpudj50F+AXQkwi6HqBPmnrBEJ8DxAkYOy2evBxvACigUM+kx78LM1idOl+njye5HAtlLN8ZiQKikt9YSUXlxbX5es/wk0ABUZ/icWgsbiPU+ThHTNeP4mu33HW8o/vuoKARbaSjkOWn5RejGoiJKNDdnkgJTHw=
+# Azure Server
+    - secure: XwHew+l/Q6MTk9YElFBPgtuN/b6Ga8H9ka7rdR58y4huCQryNjYn2fH9E6+FRXuww/JDnX1/oAmYK2gp65rK07r2OX2YacXH2vi+29EmKUM/CB+E5x4nyTFbIV2OBH1llmLs//D4/EOzIVf5aTHl8Y47atihG1swWLXtVARS5CY=
+# Azure SAS
+    - secure: X+sDXtfcqT4DHDb/W8+7Rj/EyGLnpcN3FsPN0fsdM+uYEF80dd9j5/Ybd14294MeP1DNphW8mpFwjNkX6f9JKPNdPKEjFqgzrXm3q878tIGI3NgY7jQm+TLKZXyAXB5C1GDrj4hzh0PO1t0XzfcGAtnv1yyO4CdxDdvsmljbLyQ=
 
 matrix:
   fast_finish: true

--- a/tools/travis/linux_release/after_success.sh
+++ b/tools/travis/linux_release/after_success.sh
@@ -20,9 +20,9 @@ if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
     #Master
     if [[ $TRAVIS_BRANCH == 'master' ]]; then
         # upload artifacts
-        curl -u $MASTER_LOGIN:$MASTER_PASSWORD -T $archive_name ftp://$REMOTE_SERVER/ --connect-timeout 8 --retry 10 --retry-delay 3
+        ./azcopy copy $archive_name "$REMOTE_AZURE_SERVER$archive_name?sv=2018-03-28&ss=b&srt=o&sp=w&se=2022-05-31T02:17:52Z&st=2019-05-30T18:17:52Z&spr=https&sig=$SAS"
     elif [[ $TRAVIS_BRANCH == '1.0.0' ]]; then
         # upload artifacts
-        curl -u $ONEOO_LOGIN:$ONEOO_PASSWORD -T $archive_name ftp://$REMOTE_SERVER/ --connect-timeout 8 --retry 10 --retry-delay 3
+        ./azcopy copy $archive_name "$REMOTE_AZURE_SERVER$archive_name?sv=2018-03-28&ss=b&srt=o&sp=w&se=2022-05-31T02:17:52Z&st=2019-05-30T18:17:52Z&spr=https&sig=$SAS"
     fi
 fi

--- a/tools/travis/linux_release/before_install.sh
+++ b/tools/travis/linux_release/before_install.sh
@@ -3,3 +3,6 @@
 # Update Repositories
 sudo add-apt-repository ppa:beineri/opt-qt-5.10.1-trusty -y
 sudo apt-get update -qq
+
+# Get azcopy
+wget https://aka.ms/downloadazcopy-v10-linux

--- a/tools/travis/linux_release/install.sh
+++ b/tools/travis/linux_release/install.sh
@@ -5,3 +5,7 @@ sudo apt-get install -qq qt510base qt5103d qt510svg qt510serialport qt510charts-
 
 # Setup Qt environment
 source /opt/qt510/bin/qt510-env.sh
+
+# Move azcopy so we can easily use it
+tar -xzvf downloadazcopy-v10-linux
+find . -type f -name 'azcopy' -exec mv -t ./ {} +


### PR DESCRIPTION
Upload Linux pre-built binaries to Azure storage using azcopy. This also improves the download speed from our download website. We should consider uploading win and mac builts like this. 

The nature of the curl/ftp upload problem can be found [here](https://blog.travis-ci.com/2018-07-23-the-tale-of-ftp-at-travis-ci).