### PR TITLE
solve test data paths

### DIFF
--- a/testframes/test_forward_solution/test_forward_solution.cpp
+++ b/testframes/test_forward_solution/test_forward_solution.cpp
@@ -130,7 +130,7 @@ void TestForwardSolution::computeForward()
     settings.transname.clear();
     settings.bemname = QDir::currentPath()+QCoreApplication::applicationDirPath() + "/MNE-sample-data/subjects/sample/bem/sample-5120-5120-5120-bem.fif";
     settings.mindist = 5.0f/1000.0f;
-    settings.solname = QDir::currentPath()+"./mne-cpp-test-data/Result/sample_audvis-meg-oct-6-fwd.fif";
+    settings.solname = QDir::currentPath()+"/mne-cpp-test-data/Result/sample_audvis-meg-oct-6-fwd.fif";
 
     settings.checkIntegrity();
 
@@ -176,7 +176,7 @@ void TestForwardSolution::compareForward()
 
     printf(">>>>>>>>>>>>>>>>>>>>>>>>> Compare Forward Solution >>>>>>>>>>>>>>>>>>>>>>>>>\n");
 
-    QString refFwdFileName(QDir::currentPath()+"./mne-cpp-test-data/Result/sample_audvis-meg-oct-6-fwd.fif");
+    QString refFwdFileName(QDir::currentPath()+"/mne-cpp-test-data/Result/sample_audvis-meg-oct-6-fwd.fif");
 
     //Load data
     QFile t_fileForwardSolution(refFwdFileName);


### PR DESCRIPTION
There's a (known(?)) problem with the app test_forward_solution.exe

Before, the app crashes when computing forward solution due to some path strings not well concatenated. This commit solves partially the problem, but the app is still crashing. 

As far as I understand, the forward solution is now computed (correctly?) and the app crash is now inside a call to mne_sourcespace.cpp while comparing the solution.

Feel free to delay the pull until I can figure this out.

Thanks
