### PR TITLE
[ENH] Docu upload

### DIFF
--- a/tools/travis/documentation/after_success.sh
+++ b/tools/travis/documentation/after_success.sh
@@ -6,24 +6,25 @@ cd doc
 doxygen mne-cpp_doxyfile
 
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
+	# Upload docu to gh-pages
     	git clone -b gh-pages --single-branch --no-checkout --depth 1 https://github.com/mne-tools/mne-cpp gh-pages
 	cd gh-pages
+
+	# Remove all files first
 	git rm * -r
-	git commit -a -m 'Delete all old docu files'
+	git commit --amend -a -m 'Update docu'
 
 	touch .nojekyll
 	
-	cd ..
-	cp -r html/* gh-pages
-	cp -r qt-creator_doc/mne-cpp.qch gh-pages
-
-	cd gh-pages
-
-	# Use git lfs for files over 100mb
-	git lfs track '*.qch'
+	cp -r ../html/* .
 
 	git add *
 	git add .nojekyll
-	git commit -a -m 'Add updated docu'
-	git push https://${GIT_TOKEN}@github.com/mne-tools/mne-cpp.git --all
+	git commit --amend -a -m 'Update docu'
+	git push -f https://${GIT_TOKEN}@github.com/mne-tools/mne-cpp.git --all
+
+	# Upload Qt Creator qch file to Azure
+	cd ../..
+
+        ./azcopy copy doc/qt-creator_doc/mne-cpp.qch "$REMOTE_AZURE_SERVERmne-cpp.qch?sv=2018-03-28&ss=b&srt=o&sp=w&se=2022-05-31T02:17:52Z&st=2019-05-30T18:17:52Z&spr=https&sig=$SAS"
 fi

--- a/tools/travis/documentation/before_install.sh
+++ b/tools/travis/documentation/before_install.sh
@@ -3,3 +3,6 @@
 # Update Repositories
 sudo add-apt-repository ppa:libreoffice/ppa -y
 sudo apt-get update -qq
+
+# Get azcopy
+wget https://aka.ms/downloadazcopy-v10-linux

--- a/tools/travis/documentation/install.sh
+++ b/tools/travis/documentation/install.sh
@@ -2,3 +2,7 @@
 
 # Install Doxygen
 sudo apt-get install -qq qttools5-dev-tools doxygen graphviz
+
+# Move azcopy so we can easily use it
+tar -xzvf downloadazcopy-v10-linux
+find . -type f -name 'azcopy' -exec mv -t ./ {} +

--- a/tools/travis/linux_release/before_install.sh
+++ b/tools/travis/linux_release/before_install.sh
@@ -8,7 +8,6 @@ sudo apt-get update -qq
 wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
 sudo chmod a+x linuxdeployqt-continuous-x86_64.AppImage
 
-
 # Get azcopy
 wget https://aka.ms/downloadazcopy-v10-linux
 


### PR DESCRIPTION
- Upload qch file to Azure instead of using git lfs. git lfs was a bit problematic because it can easily run out of quota. 
- Amend commits when updating docu. This way the git history does not grow with so many files being tracked.