### PR TITLE
Remove white spaces from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@
 *.qm
 
 # Bin folder with exceptions
-/lib/   
-/bin/              
+/lib/
+/bin/
 
 # Applications folder
 /applications/mne_analyze/extensions/deepcntknets/bio


### PR DESCRIPTION
Removed some white spaces from .gitignore which prevented the bin and lib folder to be excluded under Linux.