### PR TITLE
Rename ChannelDataview to RtFiffRawView.

### DIFF
--- a/applications/mne_scan/libs/scDisp/realtimeevokedsetwidget.cpp
+++ b/applications/mne_scan/libs/scDisp/realtimeevokedsetwidget.cpp
@@ -52,7 +52,7 @@
 #include <disp/viewers/projectorsview.h>
 #include <disp/viewers/compensatorview.h>
 #include <disp/viewers/modalityselectionview.h>
-#include <disp/viewers/channeldatasettingsview.h>
+#include <disp/viewers/fiffrawviewsettings.h>
 #include <disp/viewers/averageselectionview.h>
 #include <disp/viewers/averagingsettingsview.h>
 
@@ -345,17 +345,17 @@ void RealTimeEvokedSetWidget::init()
         }
 
         // Quick control channel data settings
-        ChannelDataSettingsView* pChannelDataSettingsView = new ChannelDataSettingsView(QString("RTESW/%1").arg(t_sRTESName));
+        FiffRawViewSettings* pChannelDataSettingsView = new FiffRawViewSettings(QString("RTESW/%1").arg(t_sRTESName));
         pChannelDataSettingsView->setWidgetList(QStringList() << "screenshot" << "backgroundColor");
         m_pQuickControlView->addGroupBoxWithTabs(pChannelDataSettingsView, "Other", "View");
 
-        connect(pChannelDataSettingsView, &ChannelDataSettingsView::backgroundColorChanged,
+        connect(pChannelDataSettingsView, &FiffRawViewSettings::backgroundColorChanged,
                 m_pAverageLayoutView.data(), &AverageLayoutView::setBackgroundColor);
 
-        connect(pChannelDataSettingsView, &ChannelDataSettingsView::backgroundColorChanged,
+        connect(pChannelDataSettingsView, &FiffRawViewSettings::backgroundColorChanged,
                 m_pButterflyView.data(), &ButterflyView::setBackgroundColor);
 
-        connect(pChannelDataSettingsView, &ChannelDataSettingsView::makeScreenshot,
+        connect(pChannelDataSettingsView, &FiffRawViewSettings::makeScreenshot,
                 this, &RealTimeEvokedSetWidget::onMakeScreenshot);
 
         m_pAverageLayoutView->setBackgroundColor(pChannelDataSettingsView->getBackgroundColor());

--- a/applications/mne_scan/libs/scDisp/realtimemultisamplearraywidget.cpp
+++ b/applications/mne_scan/libs/scDisp/realtimemultisamplearraywidget.cpp
@@ -45,13 +45,13 @@
 #include <disp/viewers/filterdesignview.h>
 #include <disp/viewers/channelselectionview.h>
 #include <disp/viewers/helpers/channelinfomodel.h>
-#include <disp/viewers/channeldataview.h>
+#include <disp/viewers/rtfiffrawview.h>
 #include <disp/viewers/scalingview.h>
 #include <disp/viewers/projectorsview.h>
 #include <disp/viewers/filtersettingsview.h>
 #include <disp/viewers/compensatorview.h>
 #include <disp/viewers/spharasettingsview.h>
-#include <disp/viewers/channeldatasettingsview.h>
+#include <disp/viewers/fiffrawviewsettings.h>
 #include <disp/viewers/triggerdetectionview.h>
 
 #include <scMeas/realtimemultisamplearray.h>
@@ -121,7 +121,7 @@ RealTimeMultiSampleArrayWidget::RealTimeMultiSampleArrayWidget(QSharedPointer<Re
     m_pActionQuickControl->setVisible(true);
 
     //Create table view and set layout
-    m_pChannelDataView = new ChannelDataView(QString("RTMSAW/%1").arg(m_pRTMSA->getName()),
+    m_pChannelDataView = new RtFiffRawView(QString("RTMSAW/%1").arg(m_pRTMSA->getName()),
                                              this);
     m_pChannelDataView->hide();
 
@@ -206,9 +206,9 @@ void RealTimeMultiSampleArrayWidget::init()
                 m_pChannelSelectionView.data(), &ChannelSelectionView::setCurrentlyMappedFiffChannels);
 
         connect(m_pChannelSelectionView.data(), &ChannelSelectionView::showSelectedChannelsOnly,
-                m_pChannelDataView.data(), &ChannelDataView::showSelectedChannelsOnly);
+                m_pChannelDataView.data(), &RtFiffRawView::showSelectedChannelsOnly);
 
-        connect(m_pChannelDataView.data(), &ChannelDataView::channelMarkingChanged,
+        connect(m_pChannelDataView.data(), &RtFiffRawView::channelMarkingChanged,
                 m_pChannelSelectionView.data(), &ChannelSelectionView::updateBadChannels);
 
         m_pChannelInfoModel->layoutChanged(m_pChannelSelectionView->getLayoutMap());
@@ -223,7 +223,7 @@ void RealTimeMultiSampleArrayWidget::init()
             m_pQuickControlView->addGroupBox(pScalingView, "Scaling");
 
             connect(pScalingView, &ScalingView::scalingChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::setScalingMap);
+                    m_pChannelDataView.data(), &RtFiffRawView::setScalingMap);
 
             m_pChannelDataView->setScalingMap(pScalingView->getScaleMap());
         }
@@ -234,7 +234,7 @@ void RealTimeMultiSampleArrayWidget::init()
             m_pQuickControlView->addGroupBoxWithTabs(pProjectorsView, "Noise", "SSP");
 
             connect(pProjectorsView, &ProjectorsView::projSelectionChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::updateProjection);
+                    m_pChannelDataView.data(), &RtFiffRawView::updateProjection);
 
             pProjectorsView->setProjectors(m_pFiffInfo->projs);
         }
@@ -245,7 +245,7 @@ void RealTimeMultiSampleArrayWidget::init()
             m_pQuickControlView->addGroupBoxWithTabs(pCompensatorView, "Noise", "Comp");
 
             connect(pCompensatorView, &CompensatorView::compSelectionChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::updateCompensator);
+                    m_pChannelDataView.data(), &RtFiffRawView::updateCompensator);
 
             pCompensatorView->setCompensators(m_pFiffInfo->comps);
         }
@@ -256,13 +256,13 @@ void RealTimeMultiSampleArrayWidget::init()
             m_pQuickControlView->addGroupBoxWithTabs(pFilterSettingsView, "Noise", "Filter");
 
             connect(pFilterSettingsView->getFilterView().data(), &FilterDesignView::filterChannelTypeChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::setFilterChannelType);
+                    m_pChannelDataView.data(), &RtFiffRawView::setFilterChannelType);
 
             connect(pFilterSettingsView->getFilterView().data(), &FilterDesignView::filterChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::setFilter);
+                    m_pChannelDataView.data(), &RtFiffRawView::setFilter);
 
             connect(pFilterSettingsView, &FilterSettingsView::filterActivationChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::setFilterActive);
+                    m_pChannelDataView.data(), &RtFiffRawView::setFilterActive);
 
             m_pChannelDataView->setFilterActive(pFilterSettingsView->getFilterActive());
             m_pChannelDataView->setFilterChannelType(pFilterSettingsView->getFilterView()->getChannelType());
@@ -277,34 +277,34 @@ void RealTimeMultiSampleArrayWidget::init()
             m_pQuickControlView->addGroupBoxWithTabs(pSpharaSettingsView, "Noise", "SPHARA");
 
             connect(pSpharaSettingsView, &SpharaSettingsView::spharaActivationChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::updateSpharaActivation);
+                    m_pChannelDataView.data(), &RtFiffRawView::updateSpharaActivation);
 
             connect(pSpharaSettingsView, &SpharaSettingsView::spharaOptionsChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::updateSpharaOptions);
+                    m_pChannelDataView.data(), &RtFiffRawView::updateSpharaOptions);
         }
 
         // Quick control channel data settings
         if(slFlags.contains("view")) {
-            ChannelDataSettingsView* pChannelDataSettingsView = new ChannelDataSettingsView(QString("RTMSAW/%1").arg(sRTMSAWName));
+            FiffRawViewSettings* pChannelDataSettingsView = new FiffRawViewSettings(QString("RTMSAW/%1").arg(sRTMSAWName));
             pChannelDataSettingsView->setWidgetList();
             m_pQuickControlView->addGroupBoxWithTabs(pChannelDataSettingsView, "Other", "View");
 
-            connect(pChannelDataSettingsView, &ChannelDataSettingsView::signalColorChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::setSignalColor);
+            connect(pChannelDataSettingsView, &FiffRawViewSettings::signalColorChanged,
+                    m_pChannelDataView.data(), &RtFiffRawView::setSignalColor);
 
-            connect(pChannelDataSettingsView, &ChannelDataSettingsView::backgroundColorChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::setBackgroundColor);
+            connect(pChannelDataSettingsView, &FiffRawViewSettings::backgroundColorChanged,
+                    m_pChannelDataView.data(), &RtFiffRawView::setBackgroundColor);
 
-            connect(pChannelDataSettingsView, &ChannelDataSettingsView::zoomChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::setZoom);
+            connect(pChannelDataSettingsView, &FiffRawViewSettings::zoomChanged,
+                    m_pChannelDataView.data(), &RtFiffRawView::setZoom);
 
-            connect(pChannelDataSettingsView, &ChannelDataSettingsView::timeWindowChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::setWindowSize);
+            connect(pChannelDataSettingsView, &FiffRawViewSettings::timeWindowChanged,
+                    m_pChannelDataView.data(), &RtFiffRawView::setWindowSize);
 
-            connect(pChannelDataSettingsView, &ChannelDataSettingsView::distanceTimeSpacerChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::setDistanceTimeSpacer);
+            connect(pChannelDataSettingsView, &FiffRawViewSettings::distanceTimeSpacerChanged,
+                    m_pChannelDataView.data(), &RtFiffRawView::setDistanceTimeSpacer);
 
-            connect(pChannelDataSettingsView, &ChannelDataSettingsView::makeScreenshot,
+            connect(pChannelDataSettingsView, &FiffRawViewSettings::makeScreenshot,
                     this, &RealTimeMultiSampleArrayWidget::onMakeScreenshot);
 
             m_pChannelDataView->setZoom(pChannelDataSettingsView->getZoom());
@@ -320,12 +320,12 @@ void RealTimeMultiSampleArrayWidget::init()
             m_pQuickControlView->addGroupBoxWithTabs(pTriggerDetectionView, "Other", "Triggers");
 
             connect(pTriggerDetectionView, &TriggerDetectionView::triggerInfoChanged,
-                    m_pChannelDataView.data(), &ChannelDataView::triggerInfoChanged);
+                    m_pChannelDataView.data(), &RtFiffRawView::triggerInfoChanged);
 
             connect(pTriggerDetectionView, &TriggerDetectionView::resetTriggerCounter,
-                    m_pChannelDataView.data(), &ChannelDataView::resetTriggerCounter);
+                    m_pChannelDataView.data(), &RtFiffRawView::resetTriggerCounter);
 
-            connect(m_pChannelDataView.data(), &ChannelDataView::triggerDetected,
+            connect(m_pChannelDataView.data(), &RtFiffRawView::triggerDetected,
                     pTriggerDetectionView, &TriggerDetectionView::setNumberDetectedTriggersAndTypes);
 
             pTriggerDetectionView->init(m_pFiffInfo);

--- a/applications/mne_scan/libs/scDisp/realtimemultisamplearraywidget.h
+++ b/applications/mne_scan/libs/scDisp/realtimemultisamplearraywidget.h
@@ -73,7 +73,7 @@
 namespace DISPLIB {
     class ChannelSelectionView;
     class ChannelInfoModel;
-    class ChannelDataView;
+    class RtFiffRawView;
     class QuickControlView;
     class ChannelDataViewNew;
 }
@@ -176,7 +176,7 @@ private:
     QSharedPointer<DISPLIB::QuickControlView>               m_pQuickControlView;            /**< quick control widget. */
     QSharedPointer<DISPLIB::ChannelInfoModel>               m_pChannelInfoModel;            /**< channel info model. */
     QSharedPointer<DISPLIB::ChannelSelectionView>           m_pChannelSelectionView;        /**< ChannelSelectionView. */
-    QPointer<DISPLIB::ChannelDataView>                      m_pChannelDataView;             /**< the QTableView being part of the model/view framework of Qt. */
+    QPointer<DISPLIB::RtFiffRawView>                      m_pChannelDataView;             /**< the QTableView being part of the model/view framework of Qt. */
 
 
     QSharedPointer<FIFFLIB::FiffInfo>                       m_pFiffInfo;                    /**< FiffInfo, which is used insteadd of ListChInfo*/

--- a/libraries/disp/disp.pro
+++ b/libraries/disp/disp.pro
@@ -107,7 +107,6 @@ SOURCES += \
     viewers/spectrumview.cpp \
     viewers/modalityselectionview.cpp \
     viewers/butterflyview.cpp \
-    viewers/channeldataview.cpp \
     viewers/channelselectionview.cpp \
     viewers/spectrumsettingsview.cpp \
     viewers/scalingview.cpp \
@@ -115,7 +114,7 @@ SOURCES += \
     viewers/compensatorview.cpp \
     viewers/filtersettingsview.cpp \
     viewers/spharasettingsview.cpp \
-    viewers/channeldatasettingsview.cpp \
+    viewers/fiffrawviewsettings.cpp \
     viewers/averageselectionview.cpp \
     viewers/triggerdetectionview.cpp \
     viewers/quickcontrolview.cpp \
@@ -126,6 +125,9 @@ SOURCES += \
     viewers/control3dview.cpp \
     viewers/tfsettingsview.cpp \
     viewers/artifactsettingsview.cpp \
+    viewers/rtfiffrawview.cpp \
+    viewers/helpers/rtfiffrawviewmodel.cpp \
+    viewers/helpers/rtfiffrawviewdelegate.cpp \
     viewers/helpers/evokedsetmodel.cpp \
     viewers/helpers/layoutscene.cpp \
     viewers/helpers/averagescene.cpp \
@@ -138,8 +140,6 @@ SOURCES += \
     viewers/helpers/draggableframelesswidget.cpp \
     viewers/helpers/frequencyspectrumdelegate.cpp \
     viewers/helpers/frequencyspectrummodel.cpp \
-    viewers/helpers/channeldatamodel.cpp \
-    viewers/helpers/channeldatadelegate.cpp \
 
 HEADERS += \
     disp_global.h \
@@ -153,7 +153,6 @@ HEADERS += \
     viewers/spectrumview.h \
     viewers/modalityselectionview.h \
     viewers/butterflyview.h \
-    viewers/channeldataview.h \
     viewers/channelselectionview.h \
     viewers/spectrumsettingsview.h \
     viewers/scalingview.h \
@@ -161,7 +160,7 @@ HEADERS += \
     viewers/compensatorview.h \
     viewers/filtersettingsview.h \
     viewers/spharasettingsview.h \
-    viewers/channeldatasettingsview.h \
+    viewers/fiffrawviewsettings.h \
     viewers/averageselectionview.h \
     viewers/triggerdetectionview.h \
     viewers/quickcontrolview.h \
@@ -172,6 +171,9 @@ HEADERS += \
     viewers/control3dview.h \
     viewers/tfsettingsview.h \
     viewers/artifactsettingsview.h \
+    viewers/rtfiffrawview.h \
+    viewers/helpers/rtfiffrawviewdelegate.h \
+    viewers/helpers/rtfiffrawviewmodel.h \
     viewers/helpers/evokedsetmodel.h \
     viewers/helpers/layoutscene.h \
     viewers/helpers/averagescene.h \
@@ -184,8 +186,6 @@ HEADERS += \
     viewers/helpers/draggableframelesswidget.h \
     viewers/helpers/frequencyspectrumdelegate.h \
     viewers/helpers/frequencyspectrummodel.h \
-    viewers/helpers/channeldatamodel.h \
-    viewers/helpers/channeldatadelegate.h \
 
 qtHaveModule(charts) {
     SOURCES += \
@@ -225,7 +225,7 @@ FORMS += \
     viewers/formfiles/filterdesignview.ui \
     viewers/formfiles/channelselectionview.ui \
     viewers/formfiles/spharasettingsview.ui \
-    viewers/formfiles/channeldatasettingsview.ui \
+    viewers/formfiles/fiffrawviewsettings.ui \
     viewers/formfiles/triggerdetectionview.ui \
     viewers/formfiles/quickcontrolview.ui \
     viewers/formfiles/tfsettingsview.ui \

--- a/libraries/disp/viewers/fiffrawviewsettings.cpp
+++ b/libraries/disp/viewers/fiffrawviewsettings.cpp
@@ -1,6 +1,6 @@
 //=============================================================================================================
 /**
-* @file     channeldatasettingsview.cpp
+* @file     fiffrawviewsettings.cpp
 * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
@@ -29,7 +29,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 *
-* @brief    Definition of the ChannelDataSettingsView Class.
+* @brief    Definition of the FiffRawViewSettings Class.
 *
 */
 
@@ -38,9 +38,9 @@
 // INCLUDES
 //=============================================================================================================
 
-#include "channeldatasettingsview.h"
+#include "fiffrawviewsettings.h"
 
-#include "ui_channeldatasettingsview.h"
+#include "ui_fiffrawviewsettings.h"
 
 
 //*************************************************************************************************************
@@ -72,11 +72,11 @@ using namespace DISPLIB;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-ChannelDataSettingsView::ChannelDataSettingsView(const QString &sSettingsPath,
-                                                 QWidget *parent,
-                                                 Qt::WindowFlags f)
+FiffRawViewSettings::FiffRawViewSettings(const QString &sSettingsPath,
+                                         QWidget *parent,
+                                         Qt::WindowFlags f)
 : QWidget(parent, f)
-, ui(new Ui::ChannelDataSettingsViewWidget)
+, ui(new Ui::FiffRawViewSettingsWidget)
 , m_sSettingsPath(sSettingsPath)
 {
     ui->setupUi(this);
@@ -91,7 +91,7 @@ ChannelDataSettingsView::ChannelDataSettingsView(const QString &sSettingsPath,
 
 //*************************************************************************************************************
 
-ChannelDataSettingsView::~ChannelDataSettingsView()
+FiffRawViewSettings::~FiffRawViewSettings()
 {
     saveSettings(m_sSettingsPath);
 }
@@ -99,12 +99,12 @@ ChannelDataSettingsView::~ChannelDataSettingsView()
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::setWidgetList(const QStringList& lVisibleWidgets)
+void FiffRawViewSettings::setWidgetList(const QStringList& lVisibleWidgets)
 {
     if(lVisibleWidgets.contains("numberChannels", Qt::CaseInsensitive) || lVisibleWidgets.isEmpty()) {
         //Number of visible channels
         connect(ui->m_doubleSpinBox_numberVisibleChannels, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
-                this, &ChannelDataSettingsView::zoomChanged);
+                this, &FiffRawViewSettings::zoomChanged);
     } else {
         ui->m_doubleSpinBox_numberVisibleChannels->hide();
         ui->label_numberChannels->hide();
@@ -113,7 +113,7 @@ void ChannelDataSettingsView::setWidgetList(const QStringList& lVisibleWidgets)
     if(lVisibleWidgets.contains("windowSize", Qt::CaseInsensitive) || lVisibleWidgets.isEmpty()) {
         //Window size
         connect(ui->m_spinBox_windowSize, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
-                this, &ChannelDataSettingsView::timeWindowChanged);
+                this, &FiffRawViewSettings::timeWindowChanged);
     } else {
         ui->m_spinBox_windowSize->hide();
         ui->label_windowSize->hide();
@@ -122,7 +122,7 @@ void ChannelDataSettingsView::setWidgetList(const QStringList& lVisibleWidgets)
     if(lVisibleWidgets.contains("distanceSpacers", Qt::CaseInsensitive) || lVisibleWidgets.isEmpty()) {
         //Distance for timer spacer
         connect(ui->m_comboBox_distaceTimeSpacer, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-                this, &ChannelDataSettingsView::onDistanceTimeSpacerChanged);
+                this, &FiffRawViewSettings::onDistanceTimeSpacerChanged);
     } else {
         ui->m_comboBox_distaceTimeSpacer->hide();
         ui->label_timeSpacers->hide();
@@ -131,7 +131,7 @@ void ChannelDataSettingsView::setWidgetList(const QStringList& lVisibleWidgets)
     if(lVisibleWidgets.contains("backgroundColor", Qt::CaseInsensitive) || lVisibleWidgets.isEmpty()) {
         //Background Colors
         connect(ui->m_pushButton_backgroundColor, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked),
-                this, &ChannelDataSettingsView::onViewColorButtonClicked);
+                this, &FiffRawViewSettings::onViewColorButtonClicked);
     } else {
         ui->m_pushButton_backgroundColor->hide();
         ui->label_backgroundColor->hide();
@@ -140,7 +140,7 @@ void ChannelDataSettingsView::setWidgetList(const QStringList& lVisibleWidgets)
     if(lVisibleWidgets.contains("signalColor", Qt::CaseInsensitive) || lVisibleWidgets.isEmpty()) {
         //Signal Colors
         connect(ui->m_pushButton_signalColor, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked),
-                this, &ChannelDataSettingsView::onViewColorButtonClicked);
+                this, &FiffRawViewSettings::onViewColorButtonClicked);
     } else {
         ui->m_pushButton_signalColor->hide();
         ui->label_signalColor->hide();
@@ -149,7 +149,7 @@ void ChannelDataSettingsView::setWidgetList(const QStringList& lVisibleWidgets)
     if(lVisibleWidgets.contains("screenshot", Qt::CaseInsensitive) || lVisibleWidgets.isEmpty()) {
         //Signal Colors
         connect(ui->m_pushButton_makeScreenshot, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked),
-                this, &ChannelDataSettingsView::onMakeScreenshot);
+                this, &FiffRawViewSettings::onMakeScreenshot);
     } else {
         ui->m_pushButton_makeScreenshot->hide();
         ui->m_comboBox_imageType->hide();
@@ -161,7 +161,7 @@ void ChannelDataSettingsView::setWidgetList(const QStringList& lVisibleWidgets)
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::setWindowSize(int windowSize)
+void FiffRawViewSettings::setWindowSize(int windowSize)
 {
     ui->m_spinBox_windowSize->setValue(windowSize);
 
@@ -171,7 +171,7 @@ void ChannelDataSettingsView::setWindowSize(int windowSize)
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::setZoom(double zoomFactor)
+void FiffRawViewSettings::setZoom(double zoomFactor)
 {
     ui->m_doubleSpinBox_numberVisibleChannels->setValue(zoomFactor);
 
@@ -181,7 +181,7 @@ void ChannelDataSettingsView::setZoom(double zoomFactor)
 
 //*************************************************************************************************************
 
-int ChannelDataSettingsView::getDistanceTimeSpacer()
+int FiffRawViewSettings::getDistanceTimeSpacer()
 {
     return ui->m_comboBox_distaceTimeSpacer->currentText().toInt();
 }
@@ -189,7 +189,7 @@ int ChannelDataSettingsView::getDistanceTimeSpacer()
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::setDistanceTimeSpacer(int value)
+void FiffRawViewSettings::setDistanceTimeSpacer(int value)
 {
     ui->m_comboBox_distaceTimeSpacer->setCurrentText(QString::number(value));
 }
@@ -197,7 +197,7 @@ void ChannelDataSettingsView::setDistanceTimeSpacer(int value)
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::setBackgroundColor(const QColor& backgroundColor)
+void FiffRawViewSettings::setBackgroundColor(const QColor& backgroundColor)
 {
     ui->m_pushButton_backgroundColor->setStyleSheet(QString("background-color: rgb(%1, %2, %3);").arg(backgroundColor.red()).arg(backgroundColor.green()).arg(backgroundColor.blue()));
 
@@ -207,7 +207,7 @@ void ChannelDataSettingsView::setBackgroundColor(const QColor& backgroundColor)
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::setSignalColor(const QColor& signalColor)
+void FiffRawViewSettings::setSignalColor(const QColor& signalColor)
 {
     ui->m_pushButton_signalColor->setStyleSheet(QString("background-color: rgb(%1, %2, %3);").arg(signalColor.red()).arg(signalColor.green()).arg(signalColor.blue()));
 
@@ -217,7 +217,7 @@ void ChannelDataSettingsView::setSignalColor(const QColor& signalColor)
 
 //*************************************************************************************************************
 
-const QColor& ChannelDataSettingsView::getSignalColor()
+const QColor& FiffRawViewSettings::getSignalColor()
 {
     return m_colCurrentSignalColor;
 }
@@ -225,7 +225,7 @@ const QColor& ChannelDataSettingsView::getSignalColor()
 
 //*************************************************************************************************************
 
-const QColor& ChannelDataSettingsView::getBackgroundColor()
+const QColor& FiffRawViewSettings::getBackgroundColor()
 {
     return m_colCurrentBackgroundColor;
 }
@@ -233,7 +233,7 @@ const QColor& ChannelDataSettingsView::getBackgroundColor()
 
 //*************************************************************************************************************
 
-double ChannelDataSettingsView::getZoom()
+double FiffRawViewSettings::getZoom()
 {
     return ui->m_doubleSpinBox_numberVisibleChannels->value();
 }
@@ -241,7 +241,7 @@ double ChannelDataSettingsView::getZoom()
 
 //*************************************************************************************************************
 
-int ChannelDataSettingsView::getWindowSize()
+int FiffRawViewSettings::getWindowSize()
 {
     return ui->m_spinBox_windowSize->value();
 }
@@ -249,7 +249,7 @@ int ChannelDataSettingsView::getWindowSize()
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::saveSettings(const QString& settingsPath)
+void FiffRawViewSettings::saveSettings(const QString& settingsPath)
 {
     if(settingsPath.isEmpty()) {
         return;
@@ -267,7 +267,7 @@ void ChannelDataSettingsView::saveSettings(const QString& settingsPath)
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::loadSettings(const QString& settingsPath)
+void FiffRawViewSettings::loadSettings(const QString& settingsPath)
 {
     if(settingsPath.isEmpty()) {
         return;
@@ -286,7 +286,7 @@ void ChannelDataSettingsView::loadSettings(const QString& settingsPath)
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::onDistanceTimeSpacerChanged(qint32 value)
+void FiffRawViewSettings::onDistanceTimeSpacerChanged(qint32 value)
 {
     switch(value) {
         case 0:
@@ -314,7 +314,7 @@ void ChannelDataSettingsView::onDistanceTimeSpacerChanged(qint32 value)
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::onViewColorButtonClicked()
+void FiffRawViewSettings::onViewColorButtonClicked()
 {
     QColorDialog* pDialog = new QColorDialog(this);
 
@@ -351,7 +351,7 @@ void ChannelDataSettingsView::onViewColorButtonClicked()
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::onTimeWindowChanged(int value)
+void FiffRawViewSettings::onTimeWindowChanged(int value)
 {
     emit timeWindowChanged(value);
 
@@ -361,7 +361,7 @@ void ChannelDataSettingsView::onTimeWindowChanged(int value)
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::onZoomChanged(double value)
+void FiffRawViewSettings::onZoomChanged(double value)
 {
     emit zoomChanged(value);
 
@@ -371,7 +371,7 @@ void ChannelDataSettingsView::onZoomChanged(double value)
 
 //*************************************************************************************************************
 
-void ChannelDataSettingsView::onMakeScreenshot()
+void FiffRawViewSettings::onMakeScreenshot()
 {
     emit makeScreenshot(ui->m_comboBox_imageType->currentText());
 }

--- a/libraries/disp/viewers/fiffrawviewsettings.h
+++ b/libraries/disp/viewers/fiffrawviewsettings.h
@@ -1,6 +1,6 @@
 //=============================================================================================================
 /**
-* @file     channeldatasettingsview.h
+* @file     fiffrawviewsettings.h
 * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
@@ -29,12 +29,12 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 *
-* @brief    Declaration of the ChannelDataSettingsView Class.
+* @brief    Declaration of the FiffRawViewSettings Class.
 *
 */
 
-#ifndef CHANNELDATASETTINGSVIEW_H
-#define CHANNELDATASETTINGSVIEW_H
+#ifndef FIFFRAWVIEWSETTINGS_H
+#define FIFFRAWVIEWSETTINGS_H
 
 
 //*************************************************************************************************************
@@ -72,7 +72,7 @@
 //=============================================================================================================
 
 namespace Ui {
-    class ChannelDataSettingsViewWidget;
+    class FiffRawViewSettingsWidget;
 }
 
 
@@ -93,33 +93,33 @@ namespace DISPLIB
 
 //=============================================================================================================
 /**
-* DECLARE CLASS ChannelDataSettingsView
+* DECLARE CLASS FiffRawViewSettings
 *
-* @brief The ChannelDataSettingsView class provides a view to select different channel data view dependent settings
+* @brief The FiffRawViewSettings class provides a view to select different channel data view dependent settings
 */
-class DISPSHARED_EXPORT ChannelDataSettingsView : public QWidget
+class DISPSHARED_EXPORT FiffRawViewSettings : public QWidget
 {
     Q_OBJECT
 
 public:    
-    typedef QSharedPointer<ChannelDataSettingsView> SPtr;              /**< Shared pointer type for ChannelDataSettingsView. */
-    typedef QSharedPointer<const ChannelDataSettingsView> ConstSPtr;   /**< Const shared pointer type for ChannelDataSettingsView. */
+    typedef QSharedPointer<FiffRawViewSettings> SPtr;              /**< Shared pointer type for FiffRawViewSettings. */
+    typedef QSharedPointer<const FiffRawViewSettings> ConstSPtr;   /**< Const shared pointer type for FiffRawViewSettings. */
 
     //=========================================================================================================
     /**
-    * Constructs a ChannelDataSettingsView which is a child of parent.
+    * Constructs a FiffRawViewSettings which is a child of parent.
     *
     * @param [in] parent        parent of widget
     */
-    ChannelDataSettingsView(const QString& sSettingsPath = "",
+    FiffRawViewSettings(const QString& sSettingsPath = "",
                             QWidget *parent = 0,
                             Qt::WindowFlags f = Qt::Widget);
 
     //=========================================================================================================
     /**
-    * Destroys the ChannelDataSettingsView.
+    * Destroys the FiffRawViewSettings.
     */
-    ~ChannelDataSettingsView();
+    ~FiffRawViewSettings();
 
     //=========================================================================================================
     /**
@@ -259,7 +259,7 @@ protected:
     */
     void onMakeScreenshot();
 
-    Ui::ChannelDataSettingsViewWidget* ui;
+    Ui::FiffRawViewSettingsWidget* ui;
 
     QColor      m_colCurrentSignalColor;        /**< Current color of the signal. */
     QColor      m_colCurrentBackgroundColor;    /**< Current color of the background. */
@@ -308,4 +308,4 @@ signals:
 
 } // NAMESPACE
 
-#endif // CHANNELDATASETTINGSVIEW_H
+#endif // FIFFRAWVIEWSETTINGS_H

--- a/libraries/disp/viewers/formfiles/fiffrawviewsettings.ui
+++ b/libraries/disp/viewers/formfiles/fiffrawviewsettings.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ChannelDataSettingsViewWidget</class>
- <widget class="QWidget" name="ChannelDataSettingsViewWidget">
+ <class>FiffRawViewSettingsWidget</class>
+ <widget class="QWidget" name="FiffRawViewSettingsWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>286</width>
-    <height>179</height>
+    <width>317</width>
+    <height>202</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/libraries/disp/viewers/helpers/rtfiffrawviewdelegate.cpp
+++ b/libraries/disp/viewers/helpers/rtfiffrawviewdelegate.cpp
@@ -1,6 +1,6 @@
 //=============================================================================================================
 /**
-* @file     channeldatadelegate.cpp
+* @file     rtfiffrawviewdelegate.cpp
 * @author   Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
@@ -29,7 +29,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 *
-* @brief    Definition of the ChannelDataDelegate Class.
+* @brief    Definition of the RtFiffRawViewDelegate Class.
 *
 */
 
@@ -38,9 +38,9 @@
 // INCLUDES
 //=============================================================================================================
 
-#include "channeldatadelegate.h"
+#include "rtfiffrawviewdelegate.h"
 
-#include "channeldatamodel.h"
+#include "rtfiffrawviewmodel.h"
 
 
 //*************************************************************************************************************
@@ -70,7 +70,7 @@ using namespace DISPLIB;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-ChannelDataDelegate::ChannelDataDelegate(QObject *parent)
+RtFiffRawViewDelegate::RtFiffRawViewDelegate(QObject *parent)
 : QAbstractItemDelegate(parent)
 , m_dMaxValue(0.0)
 , m_dScaleY(0.0)
@@ -83,7 +83,7 @@ ChannelDataDelegate::ChannelDataDelegate(QObject *parent)
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::initPainterPaths(const QAbstractTableModel *model)
+void RtFiffRawViewDelegate::initPainterPaths(const QAbstractTableModel *model)
 {
     for(int i = 0; i<model->rowCount(); i++)
         m_painterPaths.append(QPainterPath());
@@ -123,7 +123,7 @@ void createPaths(const QModelIndex &index,
                  const QVector<float> &data,
                  const QVector<float> &lastData)
 {
-    const ChannelDataModel* t_pModel = static_cast<const ChannelDataModel*>(index.model());
+    const RtFiffRawViewModel* t_pModel = static_cast<const RtFiffRawViewModel*>(index.model());
 
     //get maximum range of respective channel type (range value in FiffChInfo does not seem to contain a reasonable value)
     qint32 kind = t_pModel->getKind(index.row());
@@ -263,7 +263,7 @@ void createPaths(const QModelIndex &index,
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+void RtFiffRawViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     float t_fPlotHeight = option.rect.height();
     painter->setRenderHint(QPainter::Antialiasing, true);
@@ -315,7 +315,7 @@ void ChannelDataDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
             QVariant variant = index.model()->data(index,Qt::DisplayRole);
             RowVectorPair data = variant.value<RowVectorPair>();
 
-            const ChannelDataModel* t_pModel = static_cast<const ChannelDataModel*>(index.model());
+            const RtFiffRawViewModel* t_pModel = static_cast<const RtFiffRawViewModel*>(index.model());
 
             if(data.second > 0) {
                 QPainterPath path(QPointF(option.rect.x(),option.rect.y()));
@@ -443,7 +443,7 @@ void ChannelDataDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
 
 //*************************************************************************************************************
 
-QSize ChannelDataDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
+QSize RtFiffRawViewDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     QSize size;
 
@@ -453,7 +453,7 @@ QSize ChannelDataDelegate::sizeHint(const QStyleOptionViewItem &option, const QM
         break;
     case 1:
         QList< QVector<float> > data = index.model()->data(index).value< QList<QVector<float> > >();
-//        qint32 nsamples = (static_cast<const ChannelDataModel*>(index.model()))->lastSample()-(static_cast<const ChannelDataModel*>(index.model()))->firstSample();
+//        qint32 nsamples = (static_cast<const RtFiffRawViewModel*>(index.model()))->lastSample()-(static_cast<const RtFiffRawViewModel*>(index.model()))->firstSample();
 
 //        size = QSize(nsamples*m_dDx,m_dPlotHeight);
         Q_UNUSED(option);
@@ -467,7 +467,7 @@ QSize ChannelDataDelegate::sizeHint(const QStyleOptionViewItem &option, const QM
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::markerMoved(QPoint position, int activeRow)
+void RtFiffRawViewDelegate::markerMoved(QPoint position, int activeRow)
 {
     m_markerPosition = position;
     m_iActiveRow = activeRow;
@@ -476,7 +476,7 @@ void ChannelDataDelegate::markerMoved(QPoint position, int activeRow)
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::setSignalColor(const QColor& signalColor)
+void RtFiffRawViewDelegate::setSignalColor(const QColor& signalColor)
 {
     m_penNormal.setColor(signalColor);
     m_penNormalBad.setColor(signalColor);
@@ -485,7 +485,7 @@ void ChannelDataDelegate::setSignalColor(const QColor& signalColor)
 
 //*************************************************************************************************************
 
-QColor ChannelDataDelegate::getSignalColor()
+QColor RtFiffRawViewDelegate::getSignalColor()
 {
     return m_penNormal.color();
 }
@@ -493,7 +493,7 @@ QColor ChannelDataDelegate::getSignalColor()
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::setUpperItemIndex(int iUpperItemIndex)
+void RtFiffRawViewDelegate::setUpperItemIndex(int iUpperItemIndex)
 {
     m_iUpperItemIndex = iUpperItemIndex;
 }
@@ -501,14 +501,14 @@ void ChannelDataDelegate::setUpperItemIndex(int iUpperItemIndex)
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::createPlotPath(const QModelIndex &index,
+void RtFiffRawViewDelegate::createPlotPath(const QModelIndex &index,
                                                       const QStyleOptionViewItem &option,
                                                       QPainterPath& path,
                                                       QPointF &ellipsePos,
                                                       QString &amplitude,
                                                       RowVectorPair &data) const
 {
-    const ChannelDataModel* t_pModel = static_cast<const ChannelDataModel*>(index.model());
+    const RtFiffRawViewModel* t_pModel = static_cast<const RtFiffRawViewModel*>(index.model());
 
     //get maximum range of respective channel type (range value in FiffChInfo does not seem to contain a reasonable value)
     qint32 kind = t_pModel->getKind(index.row());
@@ -626,9 +626,9 @@ void ChannelDataDelegate::createPlotPath(const QModelIndex &index,
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::createCurrentPositionMarkerPath(const QModelIndex &index, const QStyleOptionViewItem &option, QPainterPath& path) const
+void RtFiffRawViewDelegate::createCurrentPositionMarkerPath(const QModelIndex &index, const QStyleOptionViewItem &option, QPainterPath& path) const
 {
-    const ChannelDataModel* t_pModel = static_cast<const ChannelDataModel*>(index.model());
+    const RtFiffRawViewModel* t_pModel = static_cast<const RtFiffRawViewModel*>(index.model());
 
     float currentSampleIndex = option.rect.x()+t_pModel->getCurrentSampleIndex();
     float dDx = ((float)option.rect.width()) / t_pModel->getMaxSamples();
@@ -644,11 +644,11 @@ void ChannelDataDelegate::createCurrentPositionMarkerPath(const QModelIndex &ind
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::createGridPath(const QModelIndex &index, const QStyleOptionViewItem &option, QPainterPath& path, RowVectorPair &data) const
+void RtFiffRawViewDelegate::createGridPath(const QModelIndex &index, const QStyleOptionViewItem &option, QPainterPath& path, RowVectorPair &data) const
 {
     Q_UNUSED(data)
 
-    const ChannelDataModel* t_pModel = static_cast<const ChannelDataModel*>(index.model());
+    const RtFiffRawViewModel* t_pModel = static_cast<const RtFiffRawViewModel*>(index.model());
 
     if(t_pModel->numVLines() > 0)
     {
@@ -670,11 +670,11 @@ void ChannelDataDelegate::createGridPath(const QModelIndex &index, const QStyleO
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::createTimeSpacersPath(const QModelIndex &index, const QStyleOptionViewItem &option, QPainterPath& path, RowVectorPair &data) const
+void RtFiffRawViewDelegate::createTimeSpacersPath(const QModelIndex &index, const QStyleOptionViewItem &option, QPainterPath& path, RowVectorPair &data) const
 {
     Q_UNUSED(data)
 
-    const ChannelDataModel* t_pModel = static_cast<const ChannelDataModel*>(index.model());
+    const RtFiffRawViewModel* t_pModel = static_cast<const RtFiffRawViewModel*>(index.model());
 
     if(t_pModel->getNumberOfTimeSpacers() > 0)
     {
@@ -699,7 +699,7 @@ void ChannelDataDelegate::createTimeSpacersPath(const QModelIndex &index, const 
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::createTriggerPath(QPainter *painter,
+void RtFiffRawViewDelegate::createTriggerPath(QPainter *painter,
                                              const QModelIndex &index,
                                              const QStyleOptionViewItem &option,
                                              QPainterPath& path,
@@ -708,7 +708,7 @@ void ChannelDataDelegate::createTriggerPath(QPainter *painter,
     Q_UNUSED(data)
     Q_UNUSED(path)
 
-    const ChannelDataModel* t_pModel = static_cast<const ChannelDataModel*>(index.model());
+    const RtFiffRawViewModel* t_pModel = static_cast<const RtFiffRawViewModel*>(index.model());
 
     QList<QPair<int,double> > detectedTriggers = t_pModel->getDetectedTriggers();
     QList<QPair<int,double> > detectedTriggersOld = t_pModel->getDetectedTriggersOld();
@@ -765,11 +765,11 @@ void ChannelDataDelegate::createTriggerPath(QPainter *painter,
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::createTriggerThresholdPath(const QModelIndex &index, const QStyleOptionViewItem &option, QPainterPath& path, RowVectorPair &data, QPointF &textPosition) const
+void RtFiffRawViewDelegate::createTriggerThresholdPath(const QModelIndex &index, const QStyleOptionViewItem &option, QPainterPath& path, RowVectorPair &data, QPointF &textPosition) const
 {
     Q_UNUSED(data)
 
-    const ChannelDataModel* t_pModel = static_cast<const ChannelDataModel*>(index.model());
+    const RtFiffRawViewModel* t_pModel = static_cast<const RtFiffRawViewModel*>(index.model());
 
     //get maximum range of respective channel type (range value in FiffChInfo does not seem to contain a reasonable value)
     qint32 kind = t_pModel->getKind(index.row());
@@ -796,7 +796,7 @@ void ChannelDataDelegate::createTriggerThresholdPath(const QModelIndex &index, c
 
 //*************************************************************************************************************
 
-void ChannelDataDelegate::createMarkerPath(const QStyleOptionViewItem &option, QPainterPath& path) const
+void RtFiffRawViewDelegate::createMarkerPath(const QStyleOptionViewItem &option, QPainterPath& path) const
 {
     //horizontal lines
     float distance = m_markerPosition.x();

--- a/libraries/disp/viewers/helpers/rtfiffrawviewdelegate.h
+++ b/libraries/disp/viewers/helpers/rtfiffrawviewdelegate.h
@@ -1,6 +1,6 @@
 //=============================================================================================================
 /**
-* @file     channeldatadelegate.h
+* @file     rtfiffrawviewdelegate.h
 * @author   Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
@@ -29,12 +29,13 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 *
-* @brief    Declaration of the ChannelDataDelegate Class.
+* @brief    Declaration of the RtFiffRawViewDelegate Class.
 *
 */
 
-#ifndef CHANNELDATADELEGATE_H
-#define CHANNELDATADELEGATE_H
+#ifndef RTFIFFRAWVIEWDELEGATE_H
+#define RTFIFFRAWVIEWDELEGATE_H
+
 
 //*************************************************************************************************************
 //=============================================================================================================
@@ -90,16 +91,16 @@ typedef QPair<const double*,qint32> RowVectorPair;
 
 //=============================================================================================================
 /**
-* DECLARE CLASS ChannelDataDelegate
+* DECLARE CLASS RtFiffRawViewDelegate
 *
-* @brief The ChannelDataDelegate class represents a RTMSA delegate which creates the plot paths
+* @brief The RtFiffRawViewDelegate class represents a RTMSA delegate which creates the plot paths
 */
-class DISPSHARED_EXPORT ChannelDataDelegate : public QAbstractItemDelegate
+class DISPSHARED_EXPORT RtFiffRawViewDelegate : public QAbstractItemDelegate
 {
     Q_OBJECT
 public:
-    typedef QSharedPointer<ChannelDataDelegate> SPtr;              /**< Shared pointer type for ChannelDataDelegate. */
-    typedef QSharedPointer<const ChannelDataDelegate> ConstSPtr;   /**< Const shared pointer type for ChannelDataDelegate. */
+    typedef QSharedPointer<RtFiffRawViewDelegate> SPtr;              /**< Shared pointer type for RtFiffRawViewDelegate. */
+    typedef QSharedPointer<const RtFiffRawViewDelegate> ConstSPtr;   /**< Const shared pointer type for RtFiffRawViewDelegate. */
 
     //=========================================================================================================
     /**
@@ -107,7 +108,7 @@ public:
     *
     * @param[in] parent     Parent of the delegate
     */
-    ChannelDataDelegate(QObject *parent = 0);
+    RtFiffRawViewDelegate(QObject *parent = 0);
 
     //=========================================================================================================
     /**
@@ -283,4 +284,4 @@ private:
 
 } // NAMESPACE
 
-#endif // CHANNELDATADELEGATE_H
+#endif // RTFIFFRAWVIEWDELEGATE_H

--- a/libraries/disp/viewers/helpers/rtfiffrawviewmodel.cpp
+++ b/libraries/disp/viewers/helpers/rtfiffrawviewmodel.cpp
@@ -1,6 +1,6 @@
 //=============================================================================================================
 /**
-* @file     channeldatamodel.cpp
+* @file     rtfiffrawviewmodel.cpp
 * @author   Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
@@ -29,7 +29,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 *
-* @brief    Definition of the ChannelDataModel Class.
+* @brief    Definition of the RtFiffRawViewModel Class.
 *
 */
 
@@ -39,7 +39,7 @@
 // INCLUDES
 //=============================================================================================================
 
-#include "channeldatamodel.h"
+#include "rtfiffrawviewmodel.h"
 
 #include <fiff/fiff_types.h>
 #include <fiff/fiff_info.h>
@@ -83,7 +83,7 @@ using namespace Eigen;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-ChannelDataModel::ChannelDataModel(QObject *parent)
+RtFiffRawViewModel::RtFiffRawViewModel(QObject *parent)
 : QAbstractTableModel(parent)
 , m_bSpharaActivated(false)
 , m_bProjActivated(false)
@@ -113,7 +113,7 @@ ChannelDataModel::ChannelDataModel(QObject *parent)
 
 //*************************************************************************************************************
 //virtual functions
-int ChannelDataModel::rowCount(const QModelIndex & /*parent*/) const
+int RtFiffRawViewModel::rowCount(const QModelIndex & /*parent*/) const
 {
     if(!m_pFiffInfo->chs.isEmpty()) {
         return m_pFiffInfo->chs.size();
@@ -130,7 +130,7 @@ int ChannelDataModel::rowCount(const QModelIndex & /*parent*/) const
 
 //*************************************************************************************************************
 
-int ChannelDataModel::columnCount(const QModelIndex & /*parent*/) const
+int RtFiffRawViewModel::columnCount(const QModelIndex & /*parent*/) const
 {
     return 3;
 }
@@ -138,7 +138,7 @@ int ChannelDataModel::columnCount(const QModelIndex & /*parent*/) const
 
 //*************************************************************************************************************
 
-QVariant ChannelDataModel::data(const QModelIndex &index, int role) const
+QVariant RtFiffRawViewModel::data(const QModelIndex &index, int role) const
 {
     if(role != Qt::DisplayRole && role != Qt::BackgroundRole)
         return QVariant();
@@ -204,7 +204,7 @@ QVariant ChannelDataModel::data(const QModelIndex &index, int role) const
 
 //*************************************************************************************************************
 
-QVariant ChannelDataModel::headerData(int section, Qt::Orientation orientation, int role) const
+QVariant RtFiffRawViewModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     if(role != Qt::DisplayRole && role != Qt::TextAlignmentRole)
         return QVariant();
@@ -237,7 +237,7 @@ QVariant ChannelDataModel::headerData(int section, Qt::Orientation orientation, 
 
 //*************************************************************************************************************
 
-void ChannelDataModel::initSphara()
+void RtFiffRawViewModel::initSphara()
 {
     //Load SPHARA matrices for babymeg and vectorview
     IOUtils::read_eigen_matrix(m_matSpharaVVGradLoaded, QCoreApplication::applicationDirPath() + QString("/resources/mne_scan/plugins/noisereduction/SPHARA/Vectorview_SPHARA_InvEuclidean_Grad.txt"));
@@ -291,14 +291,14 @@ void ChannelDataModel::initSphara()
     //Create Sphara operator for the first time
     updateSpharaOptions("BabyMEG", 270, 105);
 
-    qDebug()<<"ChannelDataModel::initSphara - Read VectorView mag matrix "<<m_matSpharaVVMagLoaded.rows()<<m_matSpharaVVMagLoaded.cols()<<"and grad matrix"<<m_matSpharaVVGradLoaded.rows()<<m_matSpharaVVGradLoaded.cols();
-    qDebug()<<"ChannelDataModel::initSphara - Read BabyMEG inner layer matrix "<<m_matSpharaBabyMEGInnerLoaded.rows()<<m_matSpharaBabyMEGInnerLoaded.cols()<<"and outer layer matrix"<<m_matSpharaBabyMEGOuterLoaded.rows()<<m_matSpharaBabyMEGOuterLoaded.cols();
+    qDebug()<<"RtFiffRawViewModel::initSphara - Read VectorView mag matrix "<<m_matSpharaVVMagLoaded.rows()<<m_matSpharaVVMagLoaded.cols()<<"and grad matrix"<<m_matSpharaVVGradLoaded.rows()<<m_matSpharaVVGradLoaded.cols();
+    qDebug()<<"RtFiffRawViewModel::initSphara - Read BabyMEG inner layer matrix "<<m_matSpharaBabyMEGInnerLoaded.rows()<<m_matSpharaBabyMEGInnerLoaded.cols()<<"and outer layer matrix"<<m_matSpharaBabyMEGOuterLoaded.rows()<<m_matSpharaBabyMEGOuterLoaded.cols();
 }
 
 
 //*************************************************************************************************************
 
-void ChannelDataModel::setFiffInfo(QSharedPointer<FIFFLIB::FiffInfo> &p_pFiffInfo)
+void RtFiffRawViewModel::setFiffInfo(QSharedPointer<FIFFLIB::FiffInfo> &p_pFiffInfo)
 {
     if(p_pFiffInfo) {
         RowVectorXi sel;// = RowVectorXi(0,0);
@@ -376,7 +376,7 @@ void ChannelDataModel::setFiffInfo(QSharedPointer<FIFFLIB::FiffInfo> &p_pFiffInf
 
 //*************************************************************************************************************
 
-void ChannelDataModel::setSamplingInfo(float sps, int T, bool bSetZero)
+void RtFiffRawViewModel::setSamplingInfo(float sps, int T, bool bSetZero)
 {
     beginResetModel();
 
@@ -407,7 +407,7 @@ void ChannelDataModel::setSamplingInfo(float sps, int T, bool bSetZero)
 
 //*************************************************************************************************************
 
-MatrixXd ChannelDataModel::getLastBlock()
+MatrixXd RtFiffRawViewModel::getLastBlock()
 {
     if(!m_filterData.isEmpty() && m_bPerformFiltering) {
         return m_matDataFiltered.block(0, m_iCurrentSample-m_iCurrentBlockSize, m_matDataFiltered.rows(), m_iCurrentBlockSize);
@@ -419,7 +419,7 @@ MatrixXd ChannelDataModel::getLastBlock()
 
 //*************************************************************************************************************
 
-void ChannelDataModel::addData(const QList<MatrixXd> &data)
+void RtFiffRawViewModel::addData(const QList<MatrixXd> &data)
 {
     //SSP
     bool doProj = m_bProjActivated && m_matDataRaw.cols() > 0 && m_matDataRaw.rows() == m_matProj.cols() ? true : false;
@@ -574,7 +574,7 @@ void ChannelDataModel::addData(const QList<MatrixXd> &data)
 
 //*************************************************************************************************************
 
-fiff_int_t ChannelDataModel::getKind(qint32 row) const
+fiff_int_t RtFiffRawViewModel::getKind(qint32 row) const
 {
     if(row < m_qMapIdxRowSelection.size()) {
         qint32 chRow = m_qMapIdxRowSelection[row];
@@ -587,7 +587,7 @@ fiff_int_t ChannelDataModel::getKind(qint32 row) const
 
 //*************************************************************************************************************
 
-fiff_int_t ChannelDataModel::getUnit(qint32 row) const
+fiff_int_t RtFiffRawViewModel::getUnit(qint32 row) const
 {
     if(row < m_qMapIdxRowSelection.size()) {
         qint32 chRow = m_qMapIdxRowSelection[row];
@@ -600,7 +600,7 @@ fiff_int_t ChannelDataModel::getUnit(qint32 row) const
 
 //*************************************************************************************************************
 
-fiff_int_t ChannelDataModel::getCoil(qint32 row) const
+fiff_int_t RtFiffRawViewModel::getCoil(qint32 row) const
 {
     if(row < m_qMapIdxRowSelection.size()) {
         qint32 chRow = m_qMapIdxRowSelection[row];
@@ -613,7 +613,7 @@ fiff_int_t ChannelDataModel::getCoil(qint32 row) const
 
 //*************************************************************************************************************
 
-void ChannelDataModel::selectRows(const QList<qint32> &selection)
+void RtFiffRawViewModel::selectRows(const QList<qint32> &selection)
 {
     beginResetModel();
 
@@ -635,7 +635,7 @@ void ChannelDataModel::selectRows(const QList<qint32> &selection)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::hideRows(const QList<qint32> &selection)
+void RtFiffRawViewModel::hideRows(const QList<qint32> &selection)
 {
     beginResetModel();
 
@@ -653,7 +653,7 @@ void ChannelDataModel::hideRows(const QList<qint32> &selection)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::resetSelection()
+void RtFiffRawViewModel::resetSelection()
 {
     beginResetModel();
 
@@ -669,7 +669,7 @@ void ChannelDataModel::resetSelection()
 
 //*************************************************************************************************************
 
-void ChannelDataModel::toggleFreeze(const QModelIndex &)
+void RtFiffRawViewModel::toggleFreeze(const QModelIndex &)
 {
     m_bIsFreezed = !m_bIsFreezed;
 
@@ -693,7 +693,7 @@ void ChannelDataModel::toggleFreeze(const QModelIndex &)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::setScaling(const QMap< qint32,float >& p_qMapChScaling)
+void RtFiffRawViewModel::setScaling(const QMap< qint32,float >& p_qMapChScaling)
 {
     beginResetModel();
     m_qMapChScaling = p_qMapChScaling;
@@ -703,7 +703,7 @@ void ChannelDataModel::setScaling(const QMap< qint32,float >& p_qMapChScaling)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::updateProjection(const QList<FIFFLIB::FiffProj>& projs)
+void RtFiffRawViewModel::updateProjection(const QList<FIFFLIB::FiffProj>& projs)
 {
     //  Update the SSP projector
     if(m_pFiffInfo) {
@@ -720,7 +720,7 @@ void ChannelDataModel::updateProjection(const QList<FIFFLIB::FiffProj>& projs)
 
         this->m_pFiffInfo->make_projector(m_matProj);
 
-        qDebug() << "ChannelDataModel::updateProjection - New projection calculated.";
+        qDebug() << "RtFiffRawViewModel::updateProjection - New projection calculated.";
 
         //set columns of matrix to zero depending on bad channels indexes
         for(qint32 j = 0; j < m_vecBadIdcs.cols(); ++j) {
@@ -764,7 +764,7 @@ void ChannelDataModel::updateProjection(const QList<FIFFLIB::FiffProj>& projs)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::updateCompensator(int to)
+void RtFiffRawViewModel::updateCompensator(int to)
 {
     //  Update the compensator
     if(m_pFiffInfo) {
@@ -819,7 +819,7 @@ void ChannelDataModel::updateCompensator(int to)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::updateSpharaActivation(bool state)
+void RtFiffRawViewModel::updateSpharaActivation(bool state)
 {
     m_bSpharaActivated = state;
 }
@@ -827,10 +827,10 @@ void ChannelDataModel::updateSpharaActivation(bool state)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::updateSpharaOptions(const QString& sSytemType, int nBaseFctsFirst, int nBaseFctsSecond)
+void RtFiffRawViewModel::updateSpharaOptions(const QString& sSytemType, int nBaseFctsFirst, int nBaseFctsSecond)
 {
     if(m_pFiffInfo) {
-        qDebug()<<"ChannelDataModel::updateSpharaOptions - Creating SPHARA operator for"<<sSytemType;
+        qDebug()<<"RtFiffRawViewModel::updateSpharaOptions - Creating SPHARA operator for"<<sSytemType;
 
         MatrixXd matSpharaMultFirst = MatrixXd::Identity(m_pFiffInfo->chs.size(), m_pFiffInfo->chs.size());
         MatrixXd matSpharaMultSecond = MatrixXd::Identity(m_pFiffInfo->chs.size(), m_pFiffInfo->chs.size());
@@ -907,7 +907,7 @@ void ChannelDataModel::updateSpharaOptions(const QString& sSytemType, int nBaseF
 
 //*************************************************************************************************************
 
-void ChannelDataModel::setFilter(QList<FilterData> filterData)
+void RtFiffRawViewModel::setFilter(QList<FilterData> filterData)
 {
     m_filterData = filterData;
 
@@ -930,7 +930,7 @@ void ChannelDataModel::setFilter(QList<FilterData> filterData)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::setFilterActive(bool state)
+void RtFiffRawViewModel::setFilterActive(bool state)
 {
     m_bPerformFiltering = state;
 }
@@ -938,7 +938,7 @@ void ChannelDataModel::setFilterActive(bool state)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::setBackgroundColor(const QColor& color)
+void RtFiffRawViewModel::setBackgroundColor(const QColor& color)
 {
     m_colBackground = color;
 }
@@ -946,7 +946,7 @@ void ChannelDataModel::setBackgroundColor(const QColor& color)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::setFilterChannelType(QString channelType)
+void RtFiffRawViewModel::setFilterChannelType(QString channelType)
 {
     m_sFilterChannelType = channelType;
     m_filterChannelList = m_visibleChannelList;
@@ -986,7 +986,7 @@ void ChannelDataModel::setFilterChannelType(QString channelType)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::createFilterChannelList(QStringList channelNames)
+void RtFiffRawViewModel::createFilterChannelList(QStringList channelNames)
 {
     m_filterChannelList.clear();
     m_visibleChannelList = channelNames;
@@ -1028,7 +1028,7 @@ void ChannelDataModel::createFilterChannelList(QStringList channelNames)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::markChBad(QModelIndex ch, bool status)
+void RtFiffRawViewModel::markChBad(QModelIndex ch, bool status)
 {
     QList<FiffChInfo> chInfolist = m_pFiffInfo->chs;
 
@@ -1056,7 +1056,7 @@ void ChannelDataModel::markChBad(QModelIndex ch, bool status)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::triggerInfoChanged(const QMap<double, QColor>& colorMap, bool active, QString triggerCh, double threshold)
+void RtFiffRawViewModel::triggerInfoChanged(const QMap<double, QColor>& colorMap, bool active, QString triggerCh, double threshold)
 {
     m_qMapTriggerColor = colorMap;
     m_bTriggerDetectionActive = active;    
@@ -1084,7 +1084,7 @@ void ChannelDataModel::triggerInfoChanged(const QMap<double, QColor>& colorMap, 
 
 //*************************************************************************************************************
 
-void ChannelDataModel::distanceTimeSpacerChanged(int value)
+void RtFiffRawViewModel::distanceTimeSpacerChanged(int value)
 {
     if(value <= 0) {
         m_iDistanceTimerSpacer = 1000;
@@ -1096,7 +1096,7 @@ void ChannelDataModel::distanceTimeSpacerChanged(int value)
 
 //*************************************************************************************************************
 
-void ChannelDataModel::resetTriggerCounter()
+void RtFiffRawViewModel::resetTriggerCounter()
 {
     m_iDetectedTriggers = 0;
 }
@@ -1104,7 +1104,7 @@ void ChannelDataModel::resetTriggerCounter()
 
 //*************************************************************************************************************
 
-void ChannelDataModel::markChBad(QModelIndexList chlist, bool status)
+void RtFiffRawViewModel::markChBad(QModelIndexList chlist, bool status)
 {
     QList<FiffChInfo> chInfolist = m_pFiffInfo->chs;
 
@@ -1141,9 +1141,9 @@ void doFilterPerChannelRTMSA(QPair<QList<FilterData>,QPair<int,RowVectorXd> > &c
 
 //*************************************************************************************************************
 
-void ChannelDataModel::filterChannelsConcurrently()
+void RtFiffRawViewModel::filterChannelsConcurrently()
 {
-    //std::cout<<"START ChannelDataModel::filterChannelsConcurrently"<<std::endl;
+    //std::cout<<"START RtFiffRawViewModel::filterChannelsConcurrently"<<std::endl;
 
     if(m_filterData.isEmpty() || !m_bPerformFiltering) {
         return;
@@ -1207,15 +1207,15 @@ void ChannelDataModel::filterChannelsConcurrently()
         m_vecLastBlockFirstValuesFiltered = m_matDataFiltered.col(0);
     }
 
-    //std::cout<<"END ChannelDataModel::filterChannelsConcurrently"<<std::endl;
+    //std::cout<<"END RtFiffRawViewModel::filterChannelsConcurrently"<<std::endl;
 }
 
 
 //*************************************************************************************************************
 
-void ChannelDataModel::filterChannelsConcurrently(const MatrixXd &data, int iDataIndex)
+void RtFiffRawViewModel::filterChannelsConcurrently(const MatrixXd &data, int iDataIndex)
 {
-    //std::cout<<"START ChannelDataModel::filterChannelsConcurrently"<<std::endl;
+    //std::cout<<"START RtFiffRawViewModel::filterChannelsConcurrently"<<std::endl;
 
     if(iDataIndex >= m_matDataFiltered.cols() || data.cols() < m_iMaxFilterLength) {
         return;
@@ -1324,13 +1324,13 @@ void ChannelDataModel::filterChannelsConcurrently(const MatrixXd &data, int iDat
         m_matDataFiltered.row(notFilterChannelIndex.at(i)).segment(iDataIndex,data.row(notFilterChannelIndex.at(i)).cols()) = data.row(notFilterChannelIndex.at(i));
     }
 
-    //std::cout<<"END ChannelDataModel::filterChannelsConcurrently"<<std::endl;
+    //std::cout<<"END RtFiffRawViewModel::filterChannelsConcurrently"<<std::endl;
 }
 
 
 //*************************************************************************************************************
 
-void ChannelDataModel::clearModel()
+void RtFiffRawViewModel::clearModel()
 {
     beginResetModel();
 

--- a/libraries/disp/viewers/helpers/rtfiffrawviewmodel.h
+++ b/libraries/disp/viewers/helpers/rtfiffrawviewmodel.h
@@ -1,6 +1,6 @@
 //=============================================================================================================
 /**
-* @file     channeldatamodel.h
+* @file     rtfiffrawviewmodel.h
 * @author   Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
@@ -29,12 +29,12 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 *
-* @brief    Declaration of the ChannelDataModel Class.
+* @brief    Declaration of the RtFiffRawViewModel Class.
 *
 */
 
-#ifndef CHANNELDATAMODEL_H
-#define CHANNELDATAMODEL_H
+#ifndef RTFIFFRAWVIEWMODEL_H
+#define RTFIFFRAWVIEWMODEL_H
 
 
 //*************************************************************************************************************
@@ -108,16 +108,16 @@ typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> Matr
 
 //=============================================================================================================
 /**
-* DECLARE CLASS ChannelDataModel
+* DECLARE CLASS RtFiffRawViewModel
 *
-* @brief The ChannelDataModel class implements the data access model for a real-time multi sample array data stream
+* @brief The RtFiffRawViewModel class implements the data access model for a real-time multi sample array data stream
 */
-class DISPSHARED_EXPORT ChannelDataModel : public QAbstractTableModel
+class DISPSHARED_EXPORT RtFiffRawViewModel : public QAbstractTableModel
 {
     Q_OBJECT
 public:
-    typedef QSharedPointer<ChannelDataModel> SPtr;              /**< Shared pointer type for ChannelDataModel. */
-    typedef QSharedPointer<const ChannelDataModel> ConstSPtr;   /**< Const shared pointer type for ChannelDataModel. */
+    typedef QSharedPointer<RtFiffRawViewModel> SPtr;              /**< Shared pointer type for RtFiffRawViewModel. */
+    typedef QSharedPointer<const RtFiffRawViewModel> ConstSPtr;   /**< Const shared pointer type for RtFiffRawViewModel. */
 
     //=========================================================================================================
     /**
@@ -125,7 +125,7 @@ public:
     *
     * @param[in] parent     parent of the table model
     */
-    ChannelDataModel(QObject *parent = 0);
+    RtFiffRawViewModel(QObject *parent = 0);
 
     //=========================================================================================================
     /**
@@ -647,7 +647,7 @@ signals:
 // INLINE DEFINITIONS
 //=============================================================================================================
 
-inline qint32 ChannelDataModel::getMaxSamples() const
+inline qint32 RtFiffRawViewModel::getMaxSamples() const
 {
     return m_iMaxSamples;
 }
@@ -655,7 +655,7 @@ inline qint32 ChannelDataModel::getMaxSamples() const
 
 //*************************************************************************************************************
 
-inline qint32 ChannelDataModel::getCurrentSampleIndex() const
+inline qint32 RtFiffRawViewModel::getCurrentSampleIndex() const
 {
     if(m_bIsFreezed) {
         return m_iCurrentSampleFreeze;
@@ -671,7 +671,7 @@ inline qint32 ChannelDataModel::getCurrentSampleIndex() const
 
 //*************************************************************************************************************
 
-inline double ChannelDataModel::getLastBlockFirstValue(int row) const
+inline double RtFiffRawViewModel::getLastBlockFirstValue(int row) const
 {
     if(row>m_vecLastBlockFirstValuesFiltered.rows() || row>m_vecLastBlockFirstValuesRaw.rows())
         return 0;
@@ -685,7 +685,7 @@ inline double ChannelDataModel::getLastBlockFirstValue(int row) const
 
 //*************************************************************************************************************
 
-inline const QMap<qint32,qint32>& ChannelDataModel::getIdxSelMap() const
+inline const QMap<qint32,qint32>& RtFiffRawViewModel::getIdxSelMap() const
 {
     return m_qMapIdxRowSelection;
 }
@@ -693,7 +693,7 @@ inline const QMap<qint32,qint32>& ChannelDataModel::getIdxSelMap() const
 
 //*************************************************************************************************************
 
-inline qint32 ChannelDataModel::numVLines() const
+inline qint32 RtFiffRawViewModel::numVLines() const
 {
     return (m_iT - 1);
 }
@@ -701,7 +701,7 @@ inline qint32 ChannelDataModel::numVLines() const
 
 //*************************************************************************************************************
 
-inline bool ChannelDataModel::isFreezed() const
+inline bool RtFiffRawViewModel::isFreezed() const
 {
     return m_bIsFreezed;
 }
@@ -709,7 +709,7 @@ inline bool ChannelDataModel::isFreezed() const
 
 //*************************************************************************************************************
 
-inline const QMap< qint32,float >& ChannelDataModel::getScaling() const
+inline const QMap< qint32,float >& RtFiffRawViewModel::getScaling() const
 {
     return m_qMapChScaling;
 }
@@ -717,7 +717,7 @@ inline const QMap< qint32,float >& ChannelDataModel::getScaling() const
 
 //*************************************************************************************************************
 
-inline QMap<double, QColor> ChannelDataModel::getTriggerColor() const
+inline QMap<double, QColor> RtFiffRawViewModel::getTriggerColor() const
 {
     if(m_bTriggerDetectionActive) {
         return m_qMapTriggerColor;
@@ -730,7 +730,7 @@ inline QMap<double, QColor> ChannelDataModel::getTriggerColor() const
 
 //*************************************************************************************************************
 
-inline QList<QPair<int,double> >  ChannelDataModel::getDetectedTriggers() const
+inline QList<QPair<int,double> >  RtFiffRawViewModel::getDetectedTriggers() const
 {
     QList<QPair<int,double> > triggerIndices;
 
@@ -747,7 +747,7 @@ inline QList<QPair<int,double> >  ChannelDataModel::getDetectedTriggers() const
 
 //*************************************************************************************************************
 
-inline QList<QPair<int,double> > ChannelDataModel::getDetectedTriggersOld() const
+inline QList<QPair<int,double> > RtFiffRawViewModel::getDetectedTriggersOld() const
 {
     QList<QPair<int,double> > triggerIndices;
 
@@ -764,7 +764,7 @@ inline QList<QPair<int,double> > ChannelDataModel::getDetectedTriggersOld() cons
 
 //*************************************************************************************************************
 
-inline int ChannelDataModel::getNumberOfTimeSpacers() const
+inline int RtFiffRawViewModel::getNumberOfTimeSpacers() const
 {
     //qDebug()<<((m_iT*1000)/m_iDistanceTimerSpacer)-1;
     return ((1000)/m_iDistanceTimerSpacer)-1;
@@ -773,7 +773,7 @@ inline int ChannelDataModel::getNumberOfTimeSpacers() const
 
 //*************************************************************************************************************
 
-inline double ChannelDataModel::getTriggerThreshold() const
+inline double RtFiffRawViewModel::getTriggerThreshold() const
 {
     return m_dTriggerThreshold;
 }
@@ -781,7 +781,7 @@ inline double ChannelDataModel::getTriggerThreshold() const
 
 //*************************************************************************************************************
 
-inline QString ChannelDataModel::getTriggerName() const
+inline QString RtFiffRawViewModel::getTriggerName() const
 {
     return m_sCurrentTriggerCh;
 }
@@ -789,7 +789,7 @@ inline QString ChannelDataModel::getTriggerName() const
 
 //*************************************************************************************************************
 
-inline int ChannelDataModel::getCurrentTriggerIndex() const
+inline int RtFiffRawViewModel::getCurrentTriggerIndex() const
 {
     return m_iCurrentTriggerChIndex;
 }
@@ -797,7 +797,7 @@ inline int ChannelDataModel::getCurrentTriggerIndex() const
 
 //*************************************************************************************************************
 
-inline bool ChannelDataModel::triggerDetectionActive() const
+inline bool RtFiffRawViewModel::triggerDetectionActive() const
 {
     return m_bTriggerDetectionActive;
 }
@@ -805,7 +805,7 @@ inline bool ChannelDataModel::triggerDetectionActive() const
 
 //*************************************************************************************************************
 
-inline int ChannelDataModel::getCurrentOverlapAddDelay() const
+inline int RtFiffRawViewModel::getCurrentOverlapAddDelay() const
 {
     if(!m_filterData.isEmpty())
         return m_iMaxFilterLength/2;
@@ -821,4 +821,4 @@ inline int ChannelDataModel::getCurrentOverlapAddDelay() const
 Q_DECLARE_METATYPE(DISPLIB::RowVectorPair);
 #endif
 
-#endif // CHANNELDATAMODEL_H
+#endif // RTFIFFRAWVIEWMODEL_H

--- a/libraries/disp/viewers/rtfiffrawview.h
+++ b/libraries/disp/viewers/rtfiffrawview.h
@@ -1,6 +1,6 @@
 //=============================================================================================================
 /**
-* @file     channeldataview.h
+* @file     rtfiffrawview.h
 * @author   Lorenz Esch <lesc@mgh.harvard.edu>;
 *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>
 * @version  1.0
@@ -29,12 +29,12 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 *
-* @brief    Declaration of the ChannelDataView Class.
+* @brief    Declaration of the RtFiffRawView Class.
 *
 */
 
-#ifndef CHANNELDATAVIEW_H
-#define CHANNELDATAVIEW_H
+#ifndef RTFIFFRAWVIEW_H
+#define RTFIFFRAWVIEW_H
 
 
 //*************************************************************************************************************
@@ -95,43 +95,43 @@ namespace DISPLIB
 // DISPLIB FORWARD DECLARATIONS
 //=============================================================================================================
 
-class ChannelDataModel;
-class ChannelDataDelegate;
+class RtFiffRawViewModel;
+class RtFiffRawViewDelegate;
 
 
 //=============================================================================================================
 /**
-* DECLARE CLASS ChannelDataView
+* DECLARE CLASS RtFiffRawView
 *
-* @brief The ChannelDataView class provides a channel view display
+* @brief The RtFiffRawView class provides a real-time channel view display
 */
-class DISPSHARED_EXPORT ChannelDataView : public QWidget
+class DISPSHARED_EXPORT RtFiffRawView : public QWidget
 {    
     Q_OBJECT
 
 public:
-    typedef QSharedPointer<ChannelDataView> SPtr;              /**< Shared pointer type for ChannelDataView. */
-    typedef QSharedPointer<const ChannelDataView> ConstSPtr;   /**< Const shared pointer type for ChannelDataView. */
+    typedef QSharedPointer<RtFiffRawView> SPtr;              /**< Shared pointer type for RtFiffRawView. */
+    typedef QSharedPointer<const RtFiffRawView> ConstSPtr;   /**< Const shared pointer type for RtFiffRawView. */
 
     //=========================================================================================================
     /**
-    * Constructs a ChannelDataView which is a child of parent.
+    * Constructs a RtFiffRawView which is a child of parent.
     *
     * @param [in] parent    The parent of widget.
     */
-    ChannelDataView(const QString& sSettingsPath = "",
+    RtFiffRawView(const QString& sSettingsPath = "",
                     QWidget* parent = 0,
                     Qt::WindowFlags f = Qt::Widget);
 
     //=========================================================================================================
     /**
-    * Destroys the ChannelDataView.
+    * Destroys the RtFiffRawView.
     */
-    ~ChannelDataView();
+    ~RtFiffRawView();
 
     //=========================================================================================================
     /**
-    * Initilaizes the ChannelDataView based on a FiffInfo.
+    * Initilaizes the RtFiffRawView based on a FiffInfo.
     *
     * @param [in] info    The FiffInfo.
     */
@@ -427,8 +427,8 @@ protected:
     void markChBad();
 
     QPointer<QTableView>                        m_pTableView;                   /**< The QTableView being part of the model/view framework of Qt */
-    QPointer<DISPLIB::ChannelDataDelegate>      m_pDelegate;                    /**< The channel data delegate */
-    QPointer<DISPLIB::ChannelDataModel>         m_pModel;                       /**< The channel data model */
+    QPointer<DISPLIB::RtFiffRawViewDelegate>      m_pDelegate;                    /**< The channel data delegate */
+    QPointer<DISPLIB::RtFiffRawViewModel>         m_pModel;                       /**< The channel data model */
 
     QMap<qint32,float>                          m_qMapChScaling;                /**< Channel scaling values. */
 
@@ -469,4 +469,4 @@ signals:
 
 } // NAMESPACE
 
-#endif // CHANNELDATAVIEW_H
+#endif // RTFIFFRAWVIEW_H


### PR DESCRIPTION
Renaming was performed in order to ease the port of the new offline browser, implemented in mne_analyze, to the Disp library.