### PR TITLE
Add wasm flag

### DIFF
--- a/applications/applications.pro
+++ b/applications/applications.pro
@@ -49,12 +49,23 @@ SUBDIRS += \
         mne_sample_set_downloader
 
         qtHaveModule(charts) {
-        SUBDIRS += \
-            mne_analyze \
-            mne_dipole_fit \
-            mne_launch \
-            mne_scan
+            SUBDIRS += \
+                mne_analyze \
+                mne_dipole_fit \
+                mne_launch \
+                mne_scan
         } else {
             message("applications.pro - The Qt Charts module is missing. Please install to build the complete set of MNE-CPP features.")
         }
+}
+
+# Overwrite SUBDIRS if wasm flag was defined
+contains(MNECPP_CONFIG, wasm) {
+    SUBDIRS = mne_browse
+
+    qtHaveModule(charts) {
+        #SUBDIRS += mne_analyze # needs qt3D which is not yet wasm supported
+    } else {
+        message("applications.pro - The Qt Charts module is missing. Please install to build the complete set of MNE-CPP features.")
+    }
 }

--- a/libraries/libraries.pro
+++ b/libraries/libraries.pro
@@ -67,6 +67,32 @@ SUBDIRS += \
     }
 }
 
+# Overwrite SUBDIRS if wasm flag was defined
+contains(MNECPP_CONFIG, wasm) {
+    SUBDIRS = \
+        utils \
+        fs \
+        fiff \
+        mne \
+        fwd \
+        inverse \
+        communication \
+
+    # Libraries which are not supported in the minimalVersion
+    !contains(MNECPP_CONFIG, minimalVersion) {
+        SUBDIRS += \
+            rtprocessing \
+            connectivity \
+            disp \
+
+        qtHaveModule(charts) {
+            # SUBDIRS += disp3D # needs qt3D which is not yet wasm supported
+        } else {
+            message("libraries.pro - The Qt Charts module is missing. Please install to build the disp3D library.")
+        }
+    }
+}
+
 # Specify library dependencies
 utils.depends =
 fs.depends = utils

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -128,16 +128,28 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2019 Authors of mne-cpp. All rights reser
 ## To build MNE-CPP Deep library based CNTK: qmake MNECPP_CONFIG+=buildDeep
 ## To build MNE-CPP with FFTW support in Eigen (make sure to specify FFTW_DIRs below): qmake MNECPP_CONFIG+=useFFTW
 ## To build MNE-CPP Disp library and MNE Browse with OpenGL support (default is with OpenGL support): qmake MNECPP_CONFIG+=dispOpenGL
+## To build MNE-CPP agaisnt wasm: qmake MNECPP_CONFIG+=wasm
 
 # Default flags
 MNECPP_CONFIG += dispOpenGL
 
-#Build minimalVersion for qt versions < 5.10.0
+# At least version 5.2.1
+!minQtVersion(5, 2, 1) {
+    message("Cannot build MNE-CPP with Qt version $${QT_VERSION}.")
+    error("Use at least Qt 5.2.1. Please note that you may only be able to build the minimal MNE-CPP version.")
+}
+
+# Build minimalVersion for qt versions < 5.10.0
 !minQtVersion(5, 10, 0) {
     message("Building minimal version of MNE-CPP due to Qt version $${QT_VERSION}.")
     MNECPP_CONFIG += minimalVersion
 }
 
+# Build static verion if wasm flag was set
+contains(MNECPP_CONFIG, wasm) {
+    message("The wasm flag was detected. Building static version of MNE-CPP.")
+    MNECPP_CONFIG += static
+}
 
 ########################################### DIRECTORY DEFINITIONS #############################################
 

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -128,7 +128,7 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2019 Authors of mne-cpp. All rights reser
 ## To build MNE-CPP Deep library based CNTK: qmake MNECPP_CONFIG+=buildDeep
 ## To build MNE-CPP with FFTW support in Eigen (make sure to specify FFTW_DIRs below): qmake MNECPP_CONFIG+=useFFTW
 ## To build MNE-CPP Disp library and MNE Browse with OpenGL support (default is with OpenGL support): qmake MNECPP_CONFIG+=dispOpenGL
-## To build MNE-CPP agaisnt wasm: qmake MNECPP_CONFIG+=wasm
+## To build MNE-CPP against wasm: qmake MNECPP_CONFIG+=wasm
 
 # Default flags
 MNECPP_CONFIG += dispOpenGL
@@ -145,7 +145,7 @@ MNECPP_CONFIG += dispOpenGL
     MNECPP_CONFIG += minimalVersion
 }
 
-# Build static verion if wasm flag was set
+# Build static version if wasm flag was defined
 contains(MNECPP_CONFIG, wasm) {
     message("The wasm flag was detected. Building static version of MNE-CPP.")
     MNECPP_CONFIG += static

--- a/mne-cpp.pro
+++ b/mne-cpp.pro
@@ -37,12 +37,6 @@ include(mne-cpp.pri)
 
 TEMPLATE = subdirs
 
-#At least version 5.2.1
-!minQtVersion(5, 2, 1) {
-    message("Cannot build MNE-CPP with Qt version $${QT_VERSION}.")
-    error("Use at least Qt 5.2.1. Please note that you may only be able to build the minimal MNE-CPP version.")
-}
-
 SUBDIRS += \
     libraries \
 
@@ -56,6 +50,13 @@ SUBDIRS += \
 
 !contains(MNECPP_CONFIG, noTests) {
     SUBDIRS += testframes
+}
+
+# Overwrite SUBDIRS if wasm flag was defined
+contains(MNECPP_CONFIG, wasm) {
+    SUBDIRS = \
+        libraries \
+        applications
 }
 
 # Specify library dependencies


### PR DESCRIPTION
- Add wasm flag to MNECPP_CONFIG
- If set configures MNE-CPP to be compatible with qt wasm
- Currently Qt3D is not supported to build against wasm see [here](https://forum.qt.io/topic/109166/wasm-support-for-qt3d/4). This means we cannot build disp3d when the wasm flag is set.

@juangpc This should ease building MNE-CPP against qt wasm.