### PR TITLE
Move coverity build to ubuntu 16.04

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ScanLinux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v1


### PR DESCRIPTION
Move coverity build from ubuntu latest to 16.04 because of temporary install qt action bug jurplel/install-qt-action#19