### PR TITLE
fix lib name for rtcmusic plugin

### DIFF
--- a/applications/mne_scan/plugins/rtcmusic/rtcmusic.pro
+++ b/applications/mne_scan/plugins/rtcmusic/rtcmusic.pro
@@ -66,7 +66,7 @@ CONFIG(debug, debug|release) {
             -lMNE$${MNE_LIB_VERSION}Mned \
             -lMNE$${MNE_LIB_VERSION}Fwdd \
             -lMNE$${MNE_LIB_VERSION}Inversed \
-            -lMNE$${MNE_LIB_VERSION}Connectivity \
+            -lMNE$${MNE_LIB_VERSION}Connectivityd \
             -lscMeasd \
             -lscDispd \
             -lscSharedd


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

Fix typo in debug lib name for rtcmusic plugin