### PR TITLE
[Fix] Custom Logger and small refactoring

### DIFF
--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -98,7 +98,7 @@ void write_pos(const float time, QSharedPointer<FIFFLIB::FiffInfo> info, Eigen::
         }
     }    
 
-    double error = std::accumulate(vGoF.begin(), vGoF.end(), .0) / vGoF.size();
+    // double error = std::accumulate(vGoF.begin(), vGoF.end(), .0) / vGoF.size();
     QQuaternion quatHPI = QQuaternion::fromRotationMatrix(rot);
 
     //qDebug() << "quatHPI.x() " << "quatHPI.y() " << "quatHPI.y() " << "trans x " << "trans y " << "trans z " << std::endl;
@@ -112,8 +112,8 @@ void write_pos(const float time, QSharedPointer<FIFFLIB::FiffInfo> info, Eigen::
     position(position.rows()-1,4) = info->dev_head_t.trans(0,3);
     position(position.rows()-1,5) = info->dev_head_t.trans(1,3);
     position(position.rows()-1,6) = info->dev_head_t.trans(2,3);
-    position(position.rows()-1,7) = 1-error;
-    position(position.rows()-1,8) = error;
+    position(position.rows()-1,7) = 0;
+    position(position.rows()-1,8) = 0;
     position(position.rows()-1,9) = 0;
 }
 

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -157,10 +157,7 @@ int main(int argc, char *argv[])
 
     // create time vector that specifies when to fit
     int N = ceil((last-first)/quantum);
-    RowVectorXf time(N);
-    for(int i = 0; i < N; i++){
-        time(i) = i * dT_sec;
-    }
+    RowVectorXf time = RowVectorXf::LinSpaced(N, 0, N-1) * dT_sec;
 
     // To fit at specific times outcommend the following block
 //    // Read Quaternion File

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -156,17 +156,18 @@ int main(int argc, char *argv[])
     fiff_int_t quantum = ceil(quantum_sec*pFiffInfo->sfreq);
 
     // create time vector that specifies when to fit
-//    int N = ceil((last-first)/quantum);
-//    RowVectorXf time(N);
-//    for(int i = 0; i < N; i++){
-//        time(i) = i * dT_sec;
-//    }
+    int N = ceil((last-first)/quantum);
+    RowVectorXf time(N);
+    for(int i = 0; i < N; i++){
+        time(i) = i * dT_sec;
+    }
 
-    // Read Quaternion File
-    Eigen::MatrixXd pos;
-    qInfo() << "Specify the path to your position file (.txt)";
-    UTILSLIB::IOUtils::read_eigen_matrix(pos, QCoreApplication::applicationDirPath() + "/mne-cpp-test-data/Result/ref_hpiFit_pos.txt");
-    RowVectorXd time = pos.col(0);
+    // To fit at specific times outcommend the following block
+//    // Read Quaternion File
+//    Eigen::MatrixXd pos;
+//    qInfo() << "Specify the path to your position file (.txt)";
+//    UTILSLIB::IOUtils::read_eigen_matrix(pos, QCoreApplication::applicationDirPath() + "/mne-cpp-test-data/Result/ref_hpiFit_pos.txt");
+//    RowVectorXd time = pos.col(0);
 
     MatrixXd position;       // Position matrix to save quaternions etc.
 

--- a/libraries/utils/generics/applicationlogger.cpp
+++ b/libraries/utils/generics/applicationlogger.cpp
@@ -104,8 +104,6 @@ void ApplicationLogger::customLogWriter(QtMsgType type,
         // Enable colored output for
         // Set output mode to handle virtual terminal sequences
         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-        DWORD dwMode = 0;
-        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     #endif
 
     switch (type) {

--- a/testframes/test_hpiFit/test_hpiFit.cpp
+++ b/testframes/test_hpiFit/test_hpiFit.cpp
@@ -111,7 +111,8 @@ TestFitHPI::TestFitHPI()
 
 //=============================================================================================================
 
-void write_pos(const float time, const int index, QSharedPointer<FIFFLIB::FiffInfo> info, Eigen::MatrixXd& position){
+void write_pos(const float time, const int index, QSharedPointer<FIFFLIB::FiffInfo> info, Eigen::MatrixXd& position)
+{
     // Write quaternions and time in position matrix. Format is the same as in maxfilter .pos files, but we only write quaternions and time. So column 7,8,9 are not used
     QMatrix3x3 rot;
 
@@ -143,7 +144,7 @@ void TestFitHPI::initTestCase()
     QFileInfo t_fileInInfo(t_fileIn);
     QDir().mkdir(t_fileInInfo.path());
 
-    printf(">>>>>>>>>>>>>>>>>>>>>>>>> Read and HPI fit  >>>>>>>>>>>>>>>>>>>>>>>>>\n");
+    printf(">>>>>>>>>>>>>>>>>>>>>>>>> Read Raw and HPI fit  >>>>>>>>>>>>>>>>>>>>>>>>>\n");
 
     // Setup for reading the raw data
     FiffRawData raw;
@@ -174,7 +175,7 @@ void TestFitHPI::initTestCase()
     FiffDigPointSet fittedPointSet;
     Eigen::MatrixXd matProjectors = Eigen::MatrixXd::Identity(pFiffInfo->chs.size(), pFiffInfo->chs.size());
     QString sHPIResourceDir = QCoreApplication::applicationDirPath() + "/HPIFittingDebug";
-    bool bDoDebug = false;
+    bool bDoDebug = true;
 
     for(int i = 0; i < ref_pos.rows(); i++) {
         from = first + ref_pos(i,0)*pFiffInfo->sfreq;


### PR DESCRIPTION
Fix #500 
- DWORD produced errors in Win7 and it is not used in Win10 either, so it is deleted. 
- test: minor changes
- example: use time vector instead of position file since this is the most likely usecase; Don't write error as gof in position file
