### PR TITLE
[Fix] Small fixes in example wizard and FiffSimulator.cfg

### DIFF
--- a/resources/mne_rt_server_plugins/FiffSimulation.cfg
+++ b/resources/mne_rt_server_plugins/FiffSimulation.cfg
@@ -1,1 +1,1 @@
-simFile = ./MNE-sample-data/MEG/sample/sample_audvis_raw.fif
+simFile = <pathTo>/MNE-sample-data/MEG/sample/sample_audvis_raw.fif

--- a/tools/wizards/mnecpp/example/main.cpp
+++ b/tools/wizards/mnecpp/example/main.cpp
@@ -67,8 +67,8 @@
  */
 int main(int argc, char *argv[])
 {
-    qInstallMessageHandler(ApplicationLogger::CustomLogWriter);
-    QApplication a(argc, argv);
+    qInstallMessageHandler(UTILSLIB::ApplicationLogger::customLogWriter);
+    QCoreApplication a(argc, argv);
 
     // Command Line Parser
     QCommandLineParser parser;
@@ -82,9 +82,6 @@ int main(int argc, char *argv[])
     parser.process(a);
 
     // Add exampel code here
-
-    return a.exec();
-}
 
     return a.exec();
 }


### PR DESCRIPTION
Example wizard: 
- remove typo and add library
- remove return redundancy
- use QCoreApplication instead of QApplication to avoid error and:
> QCoreApplication - base class. Use it in command line applications.
QGuiApplication - base class + GUI capabilities. Use it in QML applications.
QApplication - base class + GUI + support for widgets. Use it in QtWidgets applications.

https://forum.qt.io/topic/94834/differences-between-qapplication-qguiappication-qcoreapplication-classes/3

FiffSimultor.cfg:
- use full path since it might be necessary on some operating systems (e.g. CentOs)
