### PR TITLE
[ENH] Scaling and aligning average head to fiducials and hpi in HPI-View 

### DIFF
--- a/libraries/disp3D/viewers/formfiles/hpiview.ui
+++ b/libraries/disp3D/viewers/formfiles/hpiview.ui
@@ -260,7 +260,7 @@
            <number>500</number>
           </property>
           <property name="value">
-           <number>190</number>
+           <number>161</number>
           </property>
          </widget>
         </item>
@@ -360,7 +360,7 @@
            <number>500</number>
           </property>
           <property name="value">
-           <number>165</number>
+           <number>154</number>
           </property>
          </widget>
         </item>
@@ -400,7 +400,7 @@
            <number>500</number>
           </property>
           <property name="value">
-           <number>200</number>
+           <number>158</number>
           </property>
          </widget>
         </item>
@@ -443,7 +443,7 @@
            <number>500</number>
           </property>
           <property name="value">
-           <number>155</number>
+           <number>166</number>
           </property>
          </widget>
         </item>

--- a/libraries/disp3D/viewers/formfiles/hpiview.ui
+++ b/libraries/disp3D/viewers/formfiles/hpiview.ui
@@ -260,7 +260,7 @@
            <number>500</number>
           </property>
           <property name="value">
-           <number>161</number>
+           <number>190</number>
           </property>
          </widget>
         </item>
@@ -360,7 +360,7 @@
            <number>500</number>
           </property>
           <property name="value">
-           <number>154</number>
+           <number>165</number>
           </property>
          </widget>
         </item>
@@ -400,7 +400,7 @@
            <number>500</number>
           </property>
           <property name="value">
-           <number>158</number>
+           <number>200</number>
           </property>
          </widget>
         </item>
@@ -443,7 +443,7 @@
            <number>500</number>
           </property>
           <property name="value">
-           <number>166</number>
+           <number>155</number>
           </property>
          </widget>
         </item>

--- a/libraries/disp3D/viewers/formfiles/hpiview.ui
+++ b/libraries/disp3D/viewers/formfiles/hpiview.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>862</width>
-    <height>724</height>
+    <height>754</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -400,7 +400,7 @@
            <number>500</number>
           </property>
           <property name="value">
-           <number>220</number>
+           <number>200</number>
           </property>
          </widget>
         </item>

--- a/libraries/disp3D/viewers/hpiview.cpp
+++ b/libraries/disp3D/viewers/hpiview.cpp
@@ -377,7 +377,7 @@ QList<FiffDigPoint> HpiView::readPolhemusDig(const QString& fileName)
         m_vCoilFreqs << 155 << 165 << 190 << 220;
     }
 
-    //alignFiducials(fileName);
+    alignFiducials(fileName);
 
     return lDigPoints;
 }
@@ -406,7 +406,6 @@ void HpiView::alignFiducials(const QString& fileNameDigData)
     QFile t_fileDigDataReference(QCoreApplication::applicationDirPath() + "/resources/general/hpiAlignment/fsaverage-fiducials.fif");
     //FiffDigitizerData* t_digDataReference = new FiffDigitizerData(t_fileDigDataReference);
     QScopedPointer<FiffDigitizerData> t_digDataReference(new FiffDigitizerData(t_fileDigDataReference));
-
     MneSurfaceOrVolume::align_fiducials(t_digData,
                                         t_digDataReference.data(),
                                         surface,

--- a/libraries/disp3D/viewers/hpiview.cpp
+++ b/libraries/disp3D/viewers/hpiview.cpp
@@ -196,16 +196,6 @@ HpiView::HpiView(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo,
     BemTreeItem* pVVItem = m_pData3DModel->addBemData("Device", "VectorView", t_sensorVVSurfaceBEM);
     pVVItem->setCheckState(Qt::Unchecked);
 
-    QFile t_fileHeadKid(QCoreApplication::applicationDirPath() + "/MNE-sample-data/subjects/sample/bem/sample-head.fif");
-    MNEBem t_BemHeadKid(t_fileHeadKid);
-    m_pBemHeadKid = m_pData3DModel->addBemData("Head", "Child", t_BemHeadKid);
-    m_pBemHeadKid->setCheckState(Qt::Unchecked);
-
-    QFile t_fileHeadAdult(QCoreApplication::applicationDirPath() + "/MNE-sample-data/subjects/sample/bem/sample-head.fif");
-    MNEBem t_BemHeadAdult(t_fileHeadAdult);
-    m_pBemHeadAdult = m_pData3DModel->addBemData("Head", "Adult", t_BemHeadAdult);
-    m_pBemHeadAdult->setCheckState(Qt::Unchecked);
-
     QFile t_fileHeadAvr(QCoreApplication::applicationDirPath() + "/resources/general/hpiAlignment/fsaverage-head.fif");;
     MNEBem t_BemHeadAvr(t_fileHeadAvr);
     m_pBemHeadAvr = m_pData3DModel->addBemData("Head", "Average", t_BemHeadAvr);
@@ -215,7 +205,7 @@ HpiView::HpiView(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo,
     //this->setWindowFlags(this->windowFlags() | Qt::WindowStaysOnTopHint);
 
     //Init coil freqs
-    m_vCoilFreqs << 155 << 165 << 190 << 220;
+    m_vCoilFreqs << 155 << 165 << 190 << 200;
 
     //Init data
     m_matValue.resize(0,0);
@@ -389,116 +379,9 @@ QList<FiffDigPoint> HpiView::readPolhemusDig(const QString& fileName)
         m_vCoilFreqs << 155 << 165 << 190 << 200;
     }
 
-    // read fsaverage fiducials
-    QFile t_fileDigAvr(QCoreApplication::applicationDirPath() + "/resources/general/hpiAlignment/fsaverage-fiducials.fif");
-    FiffDigPointSet t_digAvr(t_fileDigAvr);
-
-    //t_digAvr.applyTransform(transAvr);
-    DigitizerSetTreeItem* pDigItem = m_pData3DModel->addDigitizerData("Head", "avr", t_digAvr);
-
-    // read mri-head transformation for average head
-    QFile file (QCoreApplication::applicationDirPath() + "/resources/general/hpiAlignment/fsaverage-trans.fif");
-    FiffCoordTrans transAvr(file);
-
-    // write fiducials to Eigen
-    Eigen::MatrixXf sLm(3,3);
-    Eigen::MatrixXf dLm(3,3);
-
-    for(int i = 0; i < t_digAvr.size(); i++){
-        if(t_digAvr[i].kind == FIFFV_POINT_CARDINAL/* || t_digAvr[i].kind ==  FIFFV_POINT_HPI*/){
-        sLm(i,0) = t_digAvr[i].r[0];
-        sLm(i,1) = t_digAvr[i].r[1];
-        sLm(i,2) = t_digAvr[i].r[2];
-        }
-    }
-
-    for(int i = 0; i < t_digSet.size(); i++){
-        if(t_digSet[i].kind == FIFFV_POINT_CARDINAL/* || t_digSet[i].kind ==  FIFFV_POINT_HPI*/) {
-            dLm(i,0) = t_digSet[i].r[0];
-            dLm(i,1) = t_digSet[i].r[1];
-            dLm(i,2) = t_digSet[i].r[2];
-        }
-    }
-
-    qDebug() << "sLm";
-    std::cout << sLm << std::endl;
-    qDebug() << "dLm";
-    std::cout << dLm << std::endl;
-
-//    RowVector3f vScale(3);
-
-//    vScale(0) = dLm.row(0).norm() / sLm.row(0).norm();
-//    vScale(1) = dLm.row(1).norm() / sLm.row(1).norm();
-//    vScale(2) = dLm.row(2).norm() / sLm.row(2).norm();
-
-//    qDebug() << "vScale: " ;
-//    std::cout << vScale << std::endl;
-
-//    float scale = vScale.mean();
-
-
-//    // compute transformation
-//    Matrix4f trans = computeTransformation(dLm, sLm);
-//    qDebug() << "trans";
-//    std::cout << trans << std::endl;
-//    MatrixXf temp = sLm;
-//    temp.conservativeResize(sLm.rows(),sLm.cols()+1);
-//    temp.block(0,3,3,1).setOnes();
-//    temp.transposeInPlace();
-//    MatrixXf tSLm = trans * temp;
-//    sLm = tSLm.block(0,0,3,3);
-
-//    // compute scaling
-//    float simplex_size = 2e-2;
-//    float sR;
-//    float dR;
-//    VectorXf sr0(3);
-//    VectorXf dr0(3);
-//    dr0 << 0,0,0;
-//    qDebug() << "a";
-//    Sphere::fit_sphere_to_points(dLm,simplex_size,dr0,dR);
-//    Sphere::fit_sphere_to_points(sLm,simplex_size,sr0,sR);
-//    qDebug("Tracked : (%.1f %.1f %.1f) mm R = %.1f mm\n",1000*dr0[0],1000*dr0[1],1000*dr0[2],1000*dR);
-//    qDebug("Average : (%.1f %.1f %.1f) mm R = %.1f mm\n",1000*sr0[0],1000*sr0[1],1000*sr0[2],1000*sR);
-//    float scale = dR/sR;
-//    qDebug() << "Scale: " << scale;
-
-//    //  apply scaling
-//    sLm *= scale;
-
-//    qDebug() << "tsLm";
-//    std::cout << sLm << std::endl;
-
-//    Qt3DCore::QTransform transform;
-//    QMatrix4x4 mat;
-//    for(int r = 0; r < 4; ++r) {
-//        for(int c = 0; c < 4; ++c) {
-//            mat(r,c) = trans(r,c);
-//        }
-//    }
-//    transform.setMatrix(mat);
-
-//    pDigItem->setTransform(transform);
-
-//    for(int i = 0; i < t_digAvr.size(); i++){
-//        if(t_digAvr[i].kind == FIFFV_POINT_CARDINAL/* || t_digAvr[i].kind ==  FIFFV_POINT_HPI*/){
-//        sLm(i,0) = t_digAvr[i].r[0];
-//        sLm(i,1) = t_digAvr[i].r[1];
-//        sLm(i,2) = t_digAvr[i].r[2];
-//        }
-//    }
-
-//    //Update Average head surface
-//    QList<QStandardItem*> itemList = m_pBemHeadAvr->findChildren(Data3DTreeModelItemTypes::BemSurfaceItem);
-//    for(int j = 0; j < itemList.size(); ++j) {
-//        if(BemSurfaceTreeItem* pBemItem = dynamic_cast<BemSurfaceTreeItem*>(itemList.at(j))) {
-//            //If it is the kid's model scale it
-////            pBemItem->setScale(scale);
-//            pBemItem->setTransform(transAvr);
-//            pBemItem->setTransform(transform);
-//        }
-//    }
+    // align fiducials and scale average head
     alignFiducials(fileName);
+
     return lDigPoints;
 }
 
@@ -559,22 +442,18 @@ void HpiView::alignFiducials(const QString& fileNameDigData)
             pDigItem->setTransform(transform);
         }
     }
+
     QFile file (QCoreApplication::applicationDirPath() + "/resources/general/hpiAlignment/fsaverage-trans.fif");
     FiffCoordTrans transAvr(file);
 
     QList<QStandardItem*> itemListB = m_pBemHeadAvr->findChildren(Data3DTreeModelItemTypes::BemSurfaceItem);
     for(int j = 0; j < itemListB.size(); ++j) {
         if(BemSurfaceTreeItem* pBemItem = dynamic_cast<BemSurfaceTreeItem*>(itemListB.at(j))) {
-            //If it is the kid's model scale it
-//            pBemItem->setScale(scale);
             pBemItem->applyTransform(transAvr, true);
             pBemItem->applyTransform(transform);
             pBemItem->setScale(scales[0]);
         }
     }
-
-    std::cout<<"rot:"<<std::endl<<t_digData->head_mri_t_adj->rot;
-    std::cout<<std::endl<<"move:"<<std::endl<<t_digData->head_mri_t_adj->move;
 
     delete surface;
     delete pMneMshDisplaySurfaceSet;
@@ -620,7 +499,7 @@ void HpiView::onBtnLoadPolhemusFile()
 {
     //Get file location
     QString fileName_HPI = QFileDialog::getOpenFileName(this,
-            tr("Open digitizer file"),QCoreApplication::applicationDirPath() + "MNE-sample-data/chpi/raw" , tr("Fiff file (*.fif)"));
+            tr("Open digitizer file"),"", tr("Fiff file (*.fif)"));
 
     if(!fileName_HPI.isEmpty()) {
         ui->m_lineEdit_filePath->setText(fileName_HPI);
@@ -805,7 +684,7 @@ void HpiView::storeResults(const FiffCoordTrans& devHeadTrans, const FiffDigPoin
 
 void HpiView::update3DView()
 {
-    if(m_pTrackedDigitizer && m_pFiffInfo && m_pBemHeadAdult && m_pBemHeadKid) {
+    if(m_pTrackedDigitizer && m_pFiffInfo && m_pBemHeadAvr) {
         //Prepare new transform
         QMatrix4x4 mat;
         for(int r = 0; r < 4; ++r) {
@@ -825,21 +704,11 @@ void HpiView::update3DView()
             }
         }
 
-        //Update adult head surface
-        itemList = m_pBemHeadAdult->findChildren(Data3DTreeModelItemTypes::BemSurfaceItem);
-        for(int j = 0; j < itemList.size(); ++j) {
-            if(BemSurfaceTreeItem* pBemItem = dynamic_cast<BemSurfaceTreeItem*>(itemList.at(j))) {
-                pBemItem->setTransform( transform);
-            }
-        }
-
-        //Update kid's head surface
-        itemList = m_pBemHeadKid->findChildren(Data3DTreeModelItemTypes::BemSurfaceItem);
-        for(int j = 0; j < itemList.size(); ++j) {
-            if(BemSurfaceTreeItem* pBemItem = dynamic_cast<BemSurfaceTreeItem*>(itemList.at(j))) {
-                //If it is the kid's model scale it
+        // Update average head
+        QList<QStandardItem*> itemListB = m_pBemHeadAvr->findChildren(Data3DTreeModelItemTypes::BemSurfaceItem);
+        for(int j = 0; j < itemListB.size(); ++j) {
+            if(BemSurfaceTreeItem* pBemItem = dynamic_cast<BemSurfaceTreeItem*>(itemListB.at(j))) {
                 pBemItem->setTransform(transform);
-                pBemItem->setScale(0.65f);
             }
         }
     }

--- a/libraries/disp3D/viewers/hpiview.h
+++ b/libraries/disp3D/viewers/hpiview.h
@@ -52,6 +52,7 @@
 
 #include <QWidget>
 #include <QPointer>
+#include <Qt3DCore/QTransform>
 
 //=============================================================================================================
 // EIGEN INCLUDES
@@ -262,10 +263,15 @@ protected:
     bool                                        m_bUseComp;             /**< Use Comps's.*/
     bool                                        m_bLastFitGood;         /**< Flag specifying if last fit was ok or not.*/
 
+    float                                       m_scale;                /**< Scaling factor for average head*/
+
     Eigen::SparseMatrix<double>                 m_sparseMatCals;        /**< Sparse calibration matrix.*/
     Eigen::MatrixXd                             m_matValue;             /**< The current data block.*/
     Eigen::MatrixXd                             m_matProjectors;        /**< Holds the matrix with the SSP and compensator projectors.*/
     Eigen::MatrixXd                             m_matCompProjectors;    /**< Holds the matrix with the SSP and compensator projectors.*/
+
+    Qt3DCore::QTransform                        m_tFid;                 /**< Transformation matrix avr_tracked fiducials */
+    FIFFLIB::FiffCoordTrans                     m_tAvr;                 /**< Transformation matrix head_mri for average head */
 
     QSharedPointer<DISP3DLIB::View3D>           m_pView3D;              /**< The 3D view. */
     QSharedPointer<DISP3DLIB::Data3DTreeModel>  m_pData3DModel;         /**< The Disp3D model. */

--- a/libraries/disp3D/viewers/hpiview.h
+++ b/libraries/disp3D/viewers/hpiview.h
@@ -232,6 +232,17 @@ protected:
      */
     void update3DView();
 
+    //=========================================================================================================
+    /**
+     * Computes the transformation matrix between two sets of 3D points.
+     *
+     * @param[in] NH     The first set of input 3D points (row-wise order).
+     * @param[in] BT     The second set of input 3D points (row-wise order).
+     *
+     * @return Returns the transformation matrix.
+     */
+    static Eigen::Matrix4f computeTransformation(Eigen::MatrixXf NH, Eigen::MatrixXf BT);
+
 //    //=========================================================================================================
 //    /**
 //    * Align the MEG fiducials to the MRI fiducials.
@@ -263,6 +274,7 @@ protected:
 
     QPointer<DISP3DLIB::BemTreeItem>            m_pBemHeadKid;          /**< The BEM head model for a kid. */
     QPointer<DISP3DLIB::BemTreeItem>            m_pBemHeadAdult;        /**< The BEM head model for an adult. */
+    QPointer<DISP3DLIB::BemTreeItem>            m_pBemHeadAvr;          /**< TThe fsaverage BEM head model. */
 
     QPointer<DISP3DLIB::DigitizerSetTreeItem>   m_pTrackedDigitizer;    /**< The 3D item pointing to the tracked digitizers. */
 

--- a/libraries/disp3D/viewers/hpiview.h
+++ b/libraries/disp3D/viewers/hpiview.h
@@ -263,14 +263,12 @@ protected:
     bool                                        m_bUseComp;             /**< Use Comps's.*/
     bool                                        m_bLastFitGood;         /**< Flag specifying if last fit was ok or not.*/
 
-    float                                       m_scale;                /**< Scaling factor for average head*/
-
     Eigen::SparseMatrix<double>                 m_sparseMatCals;        /**< Sparse calibration matrix.*/
     Eigen::MatrixXd                             m_matValue;             /**< The current data block.*/
     Eigen::MatrixXd                             m_matProjectors;        /**< Holds the matrix with the SSP and compensator projectors.*/
     Eigen::MatrixXd                             m_matCompProjectors;    /**< Holds the matrix with the SSP and compensator projectors.*/
 
-    Qt3DCore::QTransform                        m_tFid;                 /**< Transformation matrix avr_tracked fiducials */
+    Qt3DCore::QTransform                        m_tAlignment;                 /**< Transformation matrix avr_tracked fiducials */
     FIFFLIB::FiffCoordTrans                     m_tAvr;                 /**< Transformation matrix head_mri for average head */
 
     QSharedPointer<DISP3DLIB::View3D>           m_pView3D;              /**< The 3D view. */

--- a/libraries/disp3D/viewers/hpiview.h
+++ b/libraries/disp3D/viewers/hpiview.h
@@ -233,17 +233,6 @@ protected:
      */
     void update3DView();
 
-    //=========================================================================================================
-    /**
-     * Computes the transformation matrix between two sets of 3D points.
-     *
-     * @param[in] NH     The first set of input 3D points (row-wise order).
-     * @param[in] BT     The second set of input 3D points (row-wise order).
-     *
-     * @return Returns the transformation matrix.
-     */
-    static Eigen::Matrix4f computeTransformation(Eigen::MatrixXf NH, Eigen::MatrixXf BT);
-
 //    //=========================================================================================================
 //    /**
 //    * Align the MEG fiducials to the MRI fiducials.
@@ -268,8 +257,7 @@ protected:
     Eigen::MatrixXd                             m_matProjectors;        /**< Holds the matrix with the SSP and compensator projectors.*/
     Eigen::MatrixXd                             m_matCompProjectors;    /**< Holds the matrix with the SSP and compensator projectors.*/
 
-    Qt3DCore::QTransform                        m_tAlignment;                 /**< Transformation matrix avr_tracked fiducials */
-    FIFFLIB::FiffCoordTrans                     m_tAvr;                 /**< Transformation matrix head_mri for average head */
+    Qt3DCore::QTransform                        m_tAlignment;           /**< Transformation matrix alignment fiducials/tracked in head space */
 
     QSharedPointer<DISP3DLIB::View3D>           m_pView3D;              /**< The 3D view. */
     QSharedPointer<DISP3DLIB::Data3DTreeModel>  m_pData3DModel;         /**< The Disp3D model. */
@@ -277,7 +265,6 @@ protected:
     QSharedPointer<RTPROCESSINGLIB::RtHpi>         m_pRtHPI;            /**< The real-time HPI object. */
 
     QPointer<DISP3DLIB::BemTreeItem>            m_pBemHeadAvr;          /**< TThe fsaverage BEM head model. */
-    QPointer<DISP3DLIB::DigitizerSetTreeItem>   m_pAvrFid;              /**< The 3D item pointing to the average fiducials. */
     QPointer<DISP3DLIB::DigitizerSetTreeItem>   m_pTrackedDigitizer;    /**< The 3D item pointing to the tracked digitizers. */
 
     double                                      m_dMaxHpiFitError;      /**< The maximum HPI fitting error allowed.*/

--- a/libraries/disp3D/viewers/hpiview.h
+++ b/libraries/disp3D/viewers/hpiview.h
@@ -279,7 +279,7 @@ protected:
     QSharedPointer<RTPROCESSINGLIB::RtHpi>         m_pRtHPI;            /**< The real-time HPI object. */
 
     QPointer<DISP3DLIB::BemTreeItem>            m_pBemHeadAvr;          /**< TThe fsaverage BEM head model. */
-
+    QPointer<DISP3DLIB::DigitizerSetTreeItem>   m_pAvrFid;              /**< The 3D item pointing to the average fiducials. */
     QPointer<DISP3DLIB::DigitizerSetTreeItem>   m_pTrackedDigitizer;    /**< The 3D item pointing to the tracked digitizers. */
 
     double                                      m_dMaxHpiFitError;      /**< The maximum HPI fitting error allowed.*/

--- a/libraries/disp3D/viewers/hpiview.h
+++ b/libraries/disp3D/viewers/hpiview.h
@@ -270,10 +270,8 @@ protected:
     QSharedPointer<DISP3DLIB::View3D>           m_pView3D;              /**< The 3D view. */
     QSharedPointer<DISP3DLIB::Data3DTreeModel>  m_pData3DModel;         /**< The Disp3D model. */
     QSharedPointer<FIFFLIB::FiffInfo>           m_pFiffInfo;            /**< The FiffInfo. */
-    QSharedPointer<RTPROCESSINGLIB::RtHpi>         m_pRtHPI;               /**< The real-time HPI object. */
+    QSharedPointer<RTPROCESSINGLIB::RtHpi>         m_pRtHPI;            /**< The real-time HPI object. */
 
-    QPointer<DISP3DLIB::BemTreeItem>            m_pBemHeadKid;          /**< The BEM head model for a kid. */
-    QPointer<DISP3DLIB::BemTreeItem>            m_pBemHeadAdult;        /**< The BEM head model for an adult. */
     QPointer<DISP3DLIB::BemTreeItem>            m_pBemHeadAvr;          /**< TThe fsaverage BEM head model. */
 
     QPointer<DISP3DLIB::DigitizerSetTreeItem>   m_pTrackedDigitizer;    /**< The 3D item pointing to the tracked digitizers. */

--- a/libraries/mne/c/mne_surface_or_volume.cpp
+++ b/libraries/mne/c/mne_surface_or_volume.cpp
@@ -2835,7 +2835,8 @@ int MneSurfaceOrVolume::align_fiducials(FiffDigitizerData* head_dig,
                                         MneMshDisplaySurface* head_surf,
                                         int niter,
                                         int scale_head,
-                                        float omit_dist)
+                                        float omit_dist,
+                                        float *scales)
 
 {
     float           *head_fid[3],*mri_fid[3],**fid;
@@ -2843,7 +2844,7 @@ int MneSurfaceOrVolume::align_fiducials(FiffDigitizerData* head_dig,
     FiffDigPoint    p;
     FiffDigitizerData*  dig = NULL;
     float          nasion_weight = 5.0;
-    float          scales[3];
+
 
 
     if (!head_dig) {

--- a/libraries/mne/c/mne_surface_or_volume.h
+++ b/libraries/mne/c/mne_surface_or_volume.h
@@ -327,7 +327,8 @@ public:
                                MneMshDisplaySurface* head_surf,
                                int niter,
                                int scale_head,
-                               float omit_dist);
+                               float omit_dist,
+                               float *scales);
 
     static void get_head_scale(FIFFLIB::FiffDigitizerData* dig,
                                    float **mri_fid,

--- a/libraries/utils/sphere.cpp
+++ b/libraries/utils/sphere.cpp
@@ -164,7 +164,7 @@ bool Sphere::fit_sphere_to_points(const MatrixXf &rr, float simplex_size, Vector
      */
     fitUserRecNew user;
     float      ftol            = 1e-5f;
-    int        max_eval        = 500;
+    int        max_eval        = 3500;
     int        report_interval = -1;
     int        neval;
     MatrixXf   init_simplex;

--- a/libraries/utils/sphere.cpp
+++ b/libraries/utils/sphere.cpp
@@ -40,6 +40,9 @@
 #include "sphere.h"
 #include "simplex_algorithm.h"
 
+#include <QDebug>
+
+//*************************************************************************************************************
 //=============================================================================================================
 // EIGEN INCLUDES
 //=============================================================================================================
@@ -132,9 +135,8 @@ bool Sphere::fit_sphere_to_points(float **rr, int np, float simplex_size, float 
         rr_eigen(k, 2) = rr[k][2];
     }
 
-    if(rr_eigen.rows() > 0) {
+    if(rr_eigen.rows() < 0) {
         std::cout << "Sphere::fit_sphere_to_points - No points were passed." << std::endl;
-
         return false;
     }
 

--- a/libraries/utils/sphere.cpp
+++ b/libraries/utils/sphere.cpp
@@ -164,7 +164,7 @@ bool Sphere::fit_sphere_to_points(const MatrixXf &rr, float simplex_size, Vector
      */
     fitUserRecNew user;
     float      ftol            = 1e-5f;
-    int        max_eval        = 3500;
+    int        max_eval        = 500;
     int        report_interval = -1;
     int        neval;
     MatrixXf   init_simplex;


### PR DESCRIPTION
This PR enables alignment and scaling of an average head surface to loaded digitizes. Part of this process were:
- fix problems in old MNE-C routines for align_fiducials and fit_sphere_to_points
- delete all unnecessary surfaces

Alignment and Scaling:
- load average head and digitizes
- align and scale (in head space)
- apply head_dev from cHPI fit for real time monitoring

Closes #474 