### PR TITLE
[FIX,MAINT] Try to fix Linux and MacOS workflow

### DIFF
--- a/.github/workflows/devbuilds.yml
+++ b/.github/workflows/devbuilds.yml
@@ -52,7 +52,7 @@ jobs:
         architecture: 'x64'
     - name: Install Git submodules
       run: |
-        git submodule update --init
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
@@ -115,18 +115,16 @@ jobs:
         architecture: 'x64'
     - name: Install Git submodules
       run: |
-        git submodule update --init
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
         version: 5.14.1
         modules: qtcharts
-    - name: Configure and compile MNE-CPP
-      run: |
-        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples
-        make -j2
     - name: Compile BrainFlow submodule
       run: |
+        # This needs to be done before we build mne scan because 
+        # plugins are copied into the .app folder by mne_scan.pro
         cd applications/mne_scan/plugins/brainflowboard/brainflow
         mkdir build
         cd build
@@ -138,11 +136,15 @@ jobs:
         cd applications/mne_scan/plugins/brainflowboard
         qmake -makefile brainflowboard.pro
         make -j2
-        cp -a ./brainflow/installed/lib/. ../../../../bin/mne_scan.app/Contents/MacOS
+    - name: Configure and compile MNE-CPP
+      run: |
+        qmake -r MNECPP_CONFIG+=noTests
+        make -j2
+        cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. bin/mne_scan.app/Contents/Frameworks
     - name: Package binaries
       run: |
         # Creating archive of all macos deployed applications
-        tar cfvz mne-cpp-macos-x86_64.tar.gz bin/mne_scan.dmg
+        tar cfvz mne-cpp-macos-x86_64.tar.gz bin/. lib/.
     - name: Deploy MNE Scan binaries with dev_build release on Github
       uses: svenstaro/upload-release-action@v1-release
       with:
@@ -166,7 +168,7 @@ jobs:
         architecture: 'x64'   
     - name: Install Git submodules
       run: |
-        git submodule update --init
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:

--- a/.github/workflows/devbuilds.yml
+++ b/.github/workflows/devbuilds.yml
@@ -75,7 +75,7 @@ jobs:
         cd applications/mne_scan/plugins/brainflowboard
         qmake -makefile brainflowboard.pro
         make -j2
-        cp -a ./brainflow/installed/lib/. ../../../../bin/
+        cp -a ./brainflow/installed/lib/. ../../../../lib/
     - name: Package binaries
       run: |
         # Install libxkbcommon so linuxdeployqt can find it
@@ -123,8 +123,8 @@ jobs:
         modules: qtcharts
     - name: Compile BrainFlow submodule
       run: |
-        # This needs to be done before we build mne scan because 
-        # plugins are copied into the .app folder by mne_scan.pro
+        # This needs to be done before we build MNE Scan because plugins are 
+        # copied into the .app folder by mne_scan.pro immediatley after compilation
         cd applications/mne_scan/plugins/brainflowboard/brainflow
         mkdir build
         cd build

--- a/applications/mne_scan/mne_scan/mne_scan.pro
+++ b/applications/mne_scan/mne_scan/mne_scan.pro
@@ -207,15 +207,12 @@ macx {
     plugins.path = Contents/MacOS/
     plugins.files = $${ROOT_DIR}/bin/mne_scan_plugins
     QMAKE_BUNDLE_DATA += plugins
-    EXTRA_ARGS = -dmg
 
     # 3 entries returned in DEPLOY_CMD
     DEPLOY_CMD = $$macDeployArgs($${TARGET},$${TARGET_EXT},$${MNE_BINARY_DIR},$${MNE_LIBRARY_DIR},$${EXTRA_ARGS})
     QMAKE_POST_LINK += $${DEPLOY_CMD}
 
-    deploy_app = $$member(DEPLOY_CMD, 1)
-    dmg_file = $$replace(deploy_app, .app, .dmg)
-    QMAKE_CLEAN += -r $${deploy_app} $${dmg_file}
+    QMAKE_CLEAN += -r $$member(DEPLOY_CMD, 1)
 }
 
 # Activate FFTW backend in Eigen for non-static builds only


### PR DESCRIPTION
This PR introduces the following changes:

- Only pull brainflow submodule in devbuilds workflow
- Change ordering when building brainflow plugin on MacOS workflow
- Copy brainflow libs into mne-cpp/lib in Linux workflow
- Remove .dmg flag in mne_scan.pro
- Include examples and other cmd line tools to mac os builds. Closes #482 