### PR TITLE
[ENH] Add automatic frequency ordering to HPIFit

### DIFF
--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -141,7 +141,6 @@ int main(int argc, char *argv[])
     MatrixXd position;              // Position matrix to save quaternions etc.
 
     // setup informations for HPI fit (VectorView)
-//    QVector<int> vFreqs {166,154,161,158};
     QVector<int> vFreqs {154,158,161,166};
     QVector<double> vError;
     VectorXd vGoF;
@@ -179,6 +178,7 @@ int main(int argc, char *argv[])
     }
     qInfo() << "[done]";
 
+    // order frequencies
     qInfo() << "Find Order...";
     timer.start();
     HPIFit::findOrder(matData,
@@ -190,47 +190,46 @@ int main(int argc, char *argv[])
                    fittedPointSet,
                    pFiffInfo);
     qInfo() << "Ordered Frequencies: ";
-    qInfo() << vFreqs;
-    qInfo() << "The HPI-Fit took" << timer.elapsed() << "milliseconds";
+    qInfo() << "findOrder() took" << timer.elapsed() << "milliseconds";
     qInfo() << "[done]";
 
-//    // read and fit
-//    for(int i = 1; i < time.size(); i++) {
-//        from = first + time(i)*pFiffInfo->sfreq;
-//        to = from + quantum;
-//        if (to > last) {
-//            to = last;
-//            qWarning() << "Block size < quantum " << quantum;
-//        }
-//        // Reading
-//        if(!raw.read_raw_segment(matData, times, from, to)) {
-//            qCritical("error during read_raw_segment");
-//            return -1;
-//        }
-//        qInfo() << "[done]";
+    // read and fit
+    for(int i = 0; i < time.size(); i++) {
+        from = first + time(i)*pFiffInfo->sfreq;
+        to = from + quantum;
+        if (to > last) {
+            to = last;
+            qWarning() << "Block size < quantum " << quantum;
+        }
+        // Reading
+        if(!raw.read_raw_segment(matData, times, from, to)) {
+            qCritical("error during read_raw_segment");
+            return -1;
+        }
+        qInfo() << "[done]";
 
-//        qInfo() << "HPI-Fit...";
-//        timer.start();
-//        HPIFit::fitHPI(matData,
-//                       matProjectors,
-//                       pFiffInfo->dev_head_t,
-//                       vFreqs,
-//                       vError,
-//                       vGoF,
-//                       fittedPointSet,
-//                       pFiffInfo,
-//                       bDoDebug,
-//                       sHPIResourceDir);
-//        qInfo() << "The HPI-Fit took" << timer.elapsed() << "milliseconds";
-//        qInfo() << "[done]";
+        qInfo() << "HPI-Fit...";
+        timer.start();
+        HPIFit::fitHPI(matData,
+                       matProjectors,
+                       pFiffInfo->dev_head_t,
+                       vFreqs,
+                       vError,
+                       vGoF,
+                       fittedPointSet,
+                       pFiffInfo,
+                       bDoDebug,
+                       sHPIResourceDir);
+        qInfo() << "The HPI-Fit took" << timer.elapsed() << "milliseconds";
+        qInfo() << "[done]";
 
-//        HPIFit::storeHeadPosition(time(i), pFiffInfo->dev_head_t.trans, position, vGoF, vError);
+        HPIFit::storeHeadPosition(time(i), pFiffInfo->dev_head_t.trans, position, vGoF, vError);
 
-//        // if big head displacement occures, update debHeadTrans
-//        if(MNEMath::compareTransformation(devHeadTrans.trans, pFiffInfo->dev_head_t.trans, threshRot, threshTrans)) {
-//            devHeadTrans = pFiffInfo->dev_head_t;
-//            qInfo() << "dev_head_t has been updated.";
-//        }
-//    }
+        // if big head displacement occures, update debHeadTrans
+        if(MNEMath::compareTransformation(devHeadTrans.trans, pFiffInfo->dev_head_t.trans, threshRot, threshTrans)) {
+            devHeadTrans = pFiffInfo->dev_head_t;
+            qInfo() << "dev_head_t has been updated.";
+        }
+    }
 //    IOUtils::write_eigen_matrix(position, QCoreApplication::applicationDirPath() + "/MNE-sample-data/position.txt");
 }

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -412,7 +412,7 @@ void HPIFit::findOrder(const MatrixXd& t_mat,
 
         // get location of maximum GoF -> correct assignment of coil - frequency
         VectorXd::Index indMax;
-        double dMax = vGoFTemp.maxCoeff(&indMax);
+        vGoFTemp.maxCoeff(&indMax);
         vToOrder[indMax] = vFreqs[i];
 
         // reset values that are edidet by fitHpi

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -385,6 +385,45 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
 
 //=============================================================================================================
 
+void HPIFit::findOrder(const MatrixXd& t_mat,
+                       const MatrixXd& t_matProjectors,
+                       FiffCoordTrans& transDevHead,
+                       QVector<int>& vFreqs,
+                       QVector<double>& vError,
+                       VectorXd& vGoF,
+                       FiffDigPointSet& fittedPointSet,
+                       FiffInfo::SPtr pFiffInfo)
+{
+    // create temporary copies that are necessary to reset values that are passed to fitHpi()
+    FiffDigPointSet fittedPointSetTemp;
+    FiffCoordTrans transDevHeadTemp;
+    FiffInfo::SPtr pFiffInfoTemp;
+    QVector<int> vToOrder = vFreqs;
+    QVector<int> vFreqTemp(vFreqs.size());
+    QVector<double> vErrorTemp = vError;
+    VectorXd vGoFTemp;
+    for(int i = 0; i < vFreqs.size(); i++){
+        // reset values that are edidet by fitHpi
+        fittedPointSetTemp = fittedPointSet;
+        pFiffInfoTemp = pFiffInfo;
+        transDevHeadTemp = transDevHead;
+        vErrorTemp = vError;
+        vGoFTemp = vGoF;
+        vFreqTemp.fill(vFreqs[i]);
+
+        // hpi Fit
+        fitHPI(t_mat, t_matProjectors, transDevHeadTemp, vFreqTemp, vErrorTemp, vGoFTemp, fittedPointSetTemp, pFiffInfo);
+
+        // get location of maximum
+        MatrixXd::Index maxRow, maxCol;
+        double dMax = vGoFTemp.maxCoeff(&maxRow, &maxCol);
+        vToOrder[maxRow] = vFreqs[i];
+    }
+    vFreqs = vToOrder;
+}
+
+//=============================================================================================================
+
 CoilParam HPIFit::dipfit(struct CoilParam coil,
                          const QList<Sensor>& sensorSet,
                          const MatrixXd& data,

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -408,7 +408,7 @@ void HPIFit::findOrder(const MatrixXd& t_mat,
         vFreqTemp.fill(vFreqs[i]);
 
         // hpi Fit
-        fitHPI(t_mat, t_matProjectors, transDevHeadTemp, vFreqTemp, vErrorTemp, vGoFTemp, fittedPointSetTemp, pFiffInfo);
+        fitHPI(t_mat, t_matProjectors, transDevHeadTemp, vFreqTemp, vErrorTemp, vGoFTemp, fittedPointSetTemp, pFiffInfoTemp);
 
         // get location of maximum GoF -> correct assignment of coil - frequency
         VectorXd::Index indMax;

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -141,6 +141,29 @@ public:
 
     //=========================================================================================================
     /**
+     * Perform one single HPI fit.
+     *
+     * @param[in]    t_mat           Data to estimate the HPI positions from
+     * @param[in]    t_matProjectors The projectors to apply. Bad channels are still included.
+     * @param[out]   transDevHead    The final dev head transformation matrix
+     * @param[in]    vFreqs          The frequencies for each coil in unknown order.
+     * @param[out]   vFreqs          The frequencies for each coil in correct order.
+     * @param[out]   vError          The HPI estimation Error in mm for each fitted HPI coil.
+     * @param[out]   vGoF            The goodness of fit for each fitted HPI coil
+     * @param[out]   fittedPointSet  The final fitted positions in form of a digitizer set.
+     * @param[in]    p_pFiffInfo     Associated Fiff Information.
+     */
+    static void findOrder(const Eigen::MatrixXd& t_mat,
+                          const Eigen::MatrixXd& t_matProjectors,
+                          FIFFLIB::FiffCoordTrans &transDevHead,
+                          QVector<int>& vFreqs,
+                          QVector<double> &vError,
+                          Eigen::VectorXd& vGoF,
+                          FIFFLIB::FiffDigPointSet& fittedPointSet,
+                          QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
+
+    //=========================================================================================================
+    /**
      * Store results from dev_Head_t as quaternions in position matrix. The format is the same as you
      * get from Neuromag's MaxFilter.
      *

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -141,16 +141,16 @@ public:
 
     //=========================================================================================================
     /**
-     * Perform one single HPI fit.
+     * assign frequencies to correct position
      *
      * @param[in]    t_mat           Data to estimate the HPI positions from
      * @param[in]    t_matProjectors The projectors to apply. Bad channels are still included.
      * @param[out]   transDevHead    The final dev head transformation matrix
      * @param[in]    vFreqs          The frequencies for each coil in unknown order.
      * @param[out]   vFreqs          The frequencies for each coil in correct order.
-     * @param[out]   vError          The HPI estimation Error in mm for each fitted HPI coil.
-     * @param[out]   vGoF            The goodness of fit for each fitted HPI coil
-     * @param[out]   fittedPointSet  The final fitted positions in form of a digitizer set.
+     * @param[in]    vError          The HPI estimation Error in mm for each fitted HPI coil.
+     * @param[in]    vGoF            The goodness of fit for each fitted HPI coil
+     * @param[in]    fittedPointSet  The final fitted positions in form of a digitizer set.
      * @param[in]    p_pFiffInfo     Associated Fiff Information.
      */
     static void findOrder(const Eigen::MatrixXd& t_mat,

--- a/testframes/test_hpiFit/test_hpiFit.cpp
+++ b/testframes/test_hpiFit/test_hpiFit.cpp
@@ -150,7 +150,7 @@ void TestHpiFit::initTestCase()
     fiff_int_t to;
     fiff_int_t first = raw.first_samp;
     fiff_int_t last = raw.last_samp;
-    MatrixXd matData, times;
+    MatrixXd mData, mTimes;
 
     float quantum_sec = 0.2f;   //read and write in 200 ms junks
     fiff_int_t quantum = ceil(quantum_sec*pFiffInfo->sfreq);
@@ -170,21 +170,21 @@ void TestHpiFit::initTestCase()
     QVector<double> vError;
     VectorXd vGoF;
     FiffDigPointSet fittedPointSet;
-    Eigen::MatrixXd matProjectors = Eigen::MatrixXd::Identity(pFiffInfo->chs.size(), pFiffInfo->chs.size());
+    Eigen::MatrixXd mProjectors = Eigen::MatrixXd::Identity(pFiffInfo->chs.size(), pFiffInfo->chs.size());
     QString sHPIResourceDir = QCoreApplication::applicationDirPath() + "/HPIFittingDebug";
     bool bDoDebug = true;
 
-    // initial fit and ordering of frequencies
+    // bring frequencies into right order
     from = first + mRefPos(0,0)*pFiffInfo->sfreq;
     to = from + quantum;
-    if(!raw.read_raw_segment(matData, times, from, to)) {
+    if(!raw.read_raw_segment(mData, mTimes, from, to)) {
         qCritical("error during read_raw_segment");
     }
     qInfo() << "[done]";
 
     qInfo() << "Order Frequecies: ...";
-    HPIFit::findOrder(matData,
-                      matProjectors,
+    HPIFit::findOrder(mData,
+                      mProjectors,
                       pFiffInfo->dev_head_t,
                       vFreqs,
                       vError,
@@ -200,13 +200,13 @@ void TestHpiFit::initTestCase()
             to = last;
         }
         qInfo()  << "Reading...";
-        if(!raw.read_raw_segment(matData, times, from, to)) {
+        if(!raw.read_raw_segment(mData, mTimes, from, to)) {
             qWarning("error during read_raw_segment\n");
         }
 
         qInfo()  << "HPI-Fit...";
-        HPIFit::fitHPI(matData,
-                       matProjectors,
+        HPIFit::fitHPI(mData,
+                       mProjectors,
                        pFiffInfo->dev_head_t,
                        vFreqs,
                        vError,


### PR DESCRIPTION
This PR contains:
- fuction to assign frequencies to coil position if unknown
- add this function to HPIFit in inverse lib
- implement the new function in ex_hpiFit and test_hpiFit

How does it work:
- fill vFreqs with the same frequency, different in each iteration
- call fitHpi nFrequency times 
- choose coil-Freqency assignment with maximal gof
