### PR TITLE
[WIP][ENH,MAINT] Accelerate HPI fit and add freq ordering to plugin 

### DIFF
--- a/applications/mne_scan/libs/scDisp/realtime3dwidget.cpp
+++ b/applications/mne_scan/libs/scDisp/realtime3dwidget.cpp
@@ -229,7 +229,7 @@ void RealTime3DWidget::update(SCMEASLIB::Measurement::SPtr pMeasurement)
             // Add sensor surface VectorView
             QFile t_fileVVSensorSurfaceBEM(QCoreApplication::applicationDirPath() + "/resources/general/sensorSurfaces/306m.fif");
             MNEBem t_sensorVVSurfaceBEM(t_fileVVSensorSurfaceBEM);
-            m_pData3DModel->addMegSensorInfo("Device", "BabyMEG", QList<FiffChInfo>(), t_sensorVVSurfaceBEM);
+            m_pData3DModel->addMegSensorInfo("Device", "VectorView", QList<FiffChInfo>(), t_sensorVVSurfaceBEM);
 
             // Add average head surface
             QFile t_fileHeadAvr(QCoreApplication::applicationDirPath() + "/resources/general/hpiAlignment/fsaverage-head.fif");;

--- a/applications/mne_scan/plugins/hpi/FormFiles/hpisetup.ui
+++ b/applications/mne_scan/plugins/hpi/FormFiles/hpisetup.ui
@@ -83,13 +83,6 @@
        </property>
       </spacer>
      </item>
-     <item row="2" column="2">
-      <widget class="QPushButton" name="m_qPushButton_About">
-       <property name="text">
-        <string>About</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
   </layout>

--- a/applications/mne_scan/plugins/hpi/FormFiles/hpisetupwidget.cpp
+++ b/applications/mne_scan/plugins/hpi/FormFiles/hpisetupwidget.cpp
@@ -59,8 +59,6 @@ HpiSetupWidget::HpiSetupWidget(Hpi* toolbox, QWidget *parent)
 , m_pHpi(toolbox)
 {
     ui.setupUi(this);
-
-    // connect(ui.m_qPushButton_About, SIGNAL(released()), this, SLOT(showAboutDialog()));
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/plugins/hpi/FormFiles/hpisetupwidget.cpp
+++ b/applications/mne_scan/plugins/hpi/FormFiles/hpisetupwidget.cpp
@@ -60,7 +60,7 @@ HpiSetupWidget::HpiSetupWidget(Hpi* toolbox, QWidget *parent)
 {
     ui.setupUi(this);
 
-    connect(ui.m_qPushButton_About, SIGNAL(released()), this, SLOT(showAboutDialog()));
+    // connect(ui.m_qPushButton_About, SIGNAL(released()), this, SLOT(showAboutDialog()));
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -409,8 +409,23 @@ void Hpi::onDevHeadTransAvailable(const FIFFLIB::FiffCoordTrans& devHeadTrans)
 
 void Hpi::run()
 {
-    HPIFit HPI = HPIFit(m_pFiffInfo);
+    // Wait for fiff info
+    while(true) {
+        m_mutex.lock();
+        if(m_pFiffInfo) {
+            m_mutex.unlock();
+            break;
+        }
+        m_mutex.unlock();
+        msleep(100);
+    }
+
+    // init hpi fit
     HpiFitResult fitResult;
+    fitResult.devHeadTrans = m_pFiffInfo->dev_head_t;
+
+    HPIFit HPI = HPIFit(m_pFiffInfo);
+
     double dErrorMax = 0.0;
     int iDataIndexCounter = 0;
     MatrixXd matData;

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -360,7 +360,7 @@ void Hpi::onDoFreqOrder()
        msgBox.exec();
        return;
     }
-    qDebug() << "Order Frequencies";
+
     m_bDoFreqOrder = true;
 }
 
@@ -370,7 +370,7 @@ void Hpi::onCoilFrequenciesChanged(const QVector<int>& vCoilFreqs)
 {
     m_mutex.lock();
     m_vCoilFreqs = vCoilFreqs;
-    qDebug() << m_vCoilFreqs;
+
     m_mutex.unlock();
 }
 
@@ -414,7 +414,7 @@ void Hpi::run()
     double dErrorMax = 0.0;
     int iDataIndexCounter = 0;
     MatrixXd matData;
-    qDebug() << m_vCoilFreqs;
+
     m_mutex.lock();
     int iNumberOfFitsPerSecond = m_iNumberOfFitsPerSecond;
     m_mutex.unlock();
@@ -445,7 +445,6 @@ void Hpi::run()
                 m_mutex.lock();
                 fitResult.sFilePathDigitzers = m_sFilePathDigitzers;
                 if(m_bDoFreqOrder) {
-                    qDebug() << "Before Order: "<< m_vCoilFreqs;
                     // find correct frequencie order if requested
                     HPI.findOrder(matDataMerged,
                                   m_matCompProjectors,
@@ -455,7 +454,6 @@ void Hpi::run()
                                   fitResult.GoF,
                                   fitResult.fittedCoils,
                                   m_pFiffInfo);
-                    qDebug() << "After Order: "<< m_vCoilFreqs;
                     m_bDoFreqOrder = false;
                 }
                 m_mutex.unlock();
@@ -464,7 +462,6 @@ void Hpi::run()
                 // Perform actual fitting
                 m_mutex.lock();
                 fitResult.sFilePathDigitzers = m_sFilePathDigitzers;
-                qDebug() << m_vCoilFreqs;
                 HPI.fitHPI(matDataMerged,
                            m_matCompProjectors,
                            fitResult.devHeadTrans,
@@ -473,8 +470,6 @@ void Hpi::run()
                            fitResult.GoF,
                            fitResult.fittedCoils,
                            m_pFiffInfo);
-                std::cout << "GoF" << fitResult.GoF;
-                qDebug() << "error" << fitResult.errorDistances;
                 m_mutex.unlock();
 
                 //Check if the error meets distance requirement

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -64,7 +64,6 @@ using namespace DISPLIB;
 using namespace FIFFLIB;
 using namespace SCSHAREDLIB;
 using namespace Eigen;
-using namespace RTPROCESSINGLIB;
 using namespace INVERSELIB;
 
 //=============================================================================================================

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -384,6 +384,7 @@ void Hpi::onDevHeadTransAvailable(const FIFFLIB::FiffCoordTrans& devHeadTrans)
 
 void Hpi::run()
 {
+    HPIFit HPI = HPIFit(m_pFiffInfo);
     HpiFitResult fitResult;
     double dErrorMax = 0.0;
     int iDataIndexCounter = 0;
@@ -418,14 +419,14 @@ void Hpi::run()
 
                 m_mutex.lock();
                 fitResult.sFilePathDigitzers = m_sFilePathDigitzers;
-                HPIFit::fitHPI(matDataMerged,
-                               m_matCompProjectors,
-                               fitResult.devHeadTrans,
-                               m_vCoilFreqs,
-                               fitResult.errorDistances,
-                               fitResult.GoF,
-                               fitResult.fittedCoils,
-                               m_pFiffInfo);
+                HPI.fitHPI(matDataMerged,
+                           m_matCompProjectors,
+                           fitResult.devHeadTrans,
+                           m_vCoilFreqs,
+                           fitResult.errorDistances,
+                           fitResult.GoF,
+                           fitResult.fittedCoils,
+                           m_pFiffInfo);
                 m_mutex.unlock();
 
                 //Check if the error meets distance requirement

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -360,8 +360,9 @@ void Hpi::onDoFreqOrder()
        msgBox.exec();
        return;
     }
-
+    m_mutex.lock();
     m_bDoFreqOrder = true;
+    m_mutex.unlock();
 }
 
 //=============================================================================================================
@@ -370,7 +371,6 @@ void Hpi::onCoilFrequenciesChanged(const QVector<int>& vCoilFreqs)
 {
     m_mutex.lock();
     m_vCoilFreqs = vCoilFreqs;
-
     m_mutex.unlock();
 }
 
@@ -453,7 +453,6 @@ void Hpi::run()
                 matDataMerged.block(0, iDataIndexCounter, matData.rows(), matDataMerged.cols()-iDataIndexCounter) = matData.block(0, 0, matData.rows(), matDataMerged.cols()-iDataIndexCounter);
 
                 // Perform HPI fit
-                // order frequenie order if requested
                 fitResult.devHeadTrans.from = 1;
                 fitResult.devHeadTrans.to = 4;
 
@@ -473,7 +472,6 @@ void Hpi::run()
                 }
                 m_mutex.unlock();
 
-                // Perform HPI fit
                 // Perform actual fitting
                 m_mutex.lock();
                 fitResult.sFilePathDigitzers = m_sFilePathDigitzers;

--- a/applications/mne_scan/plugins/hpi/hpi.h
+++ b/applications/mne_scan/plugins/hpi/hpi.h
@@ -170,6 +170,12 @@ private:
 
     //=========================================================================================================
     /**
+     * Call this funciton whenever the frequencie ordering was requested.
+     */
+    void onDoFreqOrder();
+
+    //=========================================================================================================
+    /**
      * Call this funciton whenever the coil frequencies changed.
      *
      * @param[in] vCoilFreqs    The new coil frequencies.
@@ -231,6 +237,7 @@ private:
 
     double                      m_dAllowedMeanErrorDist;    /**< The allowed error distance in order for the last fit to be counted as a good fit.*/
 
+    bool                        m_bDoFreqOrder;             /**< Order Frequencies.*/
     bool                        m_bDoSingleHpi;             /**< Do a single HPI fit.*/
     bool                        m_bDoContinousHpi;          /**< Do continous HPI fitting.*/
     bool                        m_bUseSSP;                  /**< Use SSP's.*/

--- a/applications/mne_scan/plugins/hpi/hpi.h
+++ b/applications/mne_scan/plugins/hpi/hpi.h
@@ -43,7 +43,6 @@
 
 #include <utils/generics/circularbuffer.h>
 #include <scShared/Interfaces/IAlgorithm.h>
-#include <rtprocessing/rthpis.h>
 
 //=============================================================================================================
 // QT INCLUDES
@@ -65,10 +64,6 @@ namespace FIFFLIB {
     class FiffInfo;
     class FiffDigPoint;
     class FiffCoordTrans;
-}
-
-namespace RTPROCESSINGLIB {
-    class RtHpi;
 }
 
 namespace SCMEASLIB{

--- a/applications/mne_scan/plugins/hpi/hpi.h
+++ b/applications/mne_scan/plugins/hpi/hpi.h
@@ -66,6 +66,10 @@ namespace FIFFLIB {
     class FiffCoordTrans;
 }
 
+namespace INVERSELIB {
+    class HPIFit;
+}
+
 namespace SCMEASLIB{
     class RealTimeMultiSampleArray;
     class RealTimeHpiResult;

--- a/applications/mne_scan/plugins/hpi/hpi.h
+++ b/applications/mne_scan/plugins/hpi/hpi.h
@@ -174,7 +174,7 @@ private:
 
     //=========================================================================================================
     /**
-     * Call this funciton whenever the frequencie ordering was requested.
+     * Call this funciton whenever frequency ordering was requested.
      */
     void onDoFreqOrder();
 

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -234,5 +234,5 @@ int main(int argc, char *argv[])
             qInfo() << "dev_head_t has been updated.";
         }
     }
-    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_01_Faster_MEG.txt");
+    // IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_03_Faster_MEG.txt");
 }

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -113,9 +113,9 @@ int main(int argc, char *argv[])
     float fThreshTrans = 0.005;    // in m
 
     // Set up the reading parameters
-    RowVectorXi vPicks = pFiffInfo->pick_types(true, false, false);
+    RowVectorXi vecPicks = pFiffInfo->pick_types(true, false, false);
 
-    MatrixXd mData, mTimes;
+    MatrixXd matData, matTimes;
 
     fiff_int_t from, to;
     fiff_int_t first = raw.first_samp;
@@ -127,25 +127,25 @@ int main(int argc, char *argv[])
 
 //    // create time vector that specifies when to fit
 //    int iN = ceil((last-first)/iQuantum);
-//    RowVectorXf vTime = RowVectorXf::LinSpaced(iN, 0, iN-1) * dTSec;
+//    RowVectorXf vecTime = RowVectorXf::LinSpaced(iN, 0, iN-1) * dTSec;
 
     // To fit at specific times outcommend the following block
     // Read Quaternion File
-    MatrixXd pos;
+    MatrixXd matPos;
     qInfo() << "Specify the path to your Position file (.txt)";
-    IOUtils::read_eigen_matrix(pos, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/posMax_data_with_movement_chpi.txt");
-    RowVectorXd vTime = pos.col(0);
+    IOUtils::read_eigen_matrix(matPos, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/posMax_data_with_movement_chpi.txt");
+    RowVectorXd vecTime = matPos.col(0);
 
-    MatrixXd mPosition;              // mPosition matrix to save quaternions etc.
+    MatrixXd matPosition;              // matPosition matrix to save quaternions etc.
 
     // setup informations for HPI fit (VectorView)
-    QVector<int> vFreqs {154,158,161,166};
-    QVector<double> vError;
-    VectorXd vGoF;
+    QVector<int> vecFreqs {154,158,161,166};
+    QVector<double> vecError;
+    VectorXd vecGoF;
     FiffDigPointSet fittedPointSet;
 
     // Use SSP + SGM + calibration
-    MatrixXd mProjectors = MatrixXd::Identity(pFiffInfo->chs.size(), pFiffInfo->chs.size());
+    MatrixXd matProjectors = MatrixXd::Identity(pFiffInfo->chs.size(), pFiffInfo->chs.size());
 
     //Do a copy here because we are going to change the activity flags of the SSP's
     FiffInfo infoTemp = *(pFiffInfo.data());
@@ -156,11 +156,11 @@ int main(int argc, char *argv[])
     }
 
     //Create the projector for all SSP's on
-    infoTemp.make_projector(mProjectors);
+    infoTemp.make_projector(matProjectors);
 
     //set columns of matrix to zero depending on bad channels indexes
     for(qint32 j = 0; j < infoTemp.bads.size(); ++j) {
-        mProjectors.col(infoTemp.ch_names.indexOf(infoTemp.bads.at(j))).setZero();
+        matProjectors.col(infoTemp.ch_names.indexOf(infoTemp.bads.at(j))).setZero();
     }
 
     // if debugging files are necessary set bDoDebug = true;
@@ -170,9 +170,9 @@ int main(int argc, char *argv[])
     HPIFit HPI = HPIFit(pFiffInfo);
 
     // ordering of frequencies
-    from = first + vTime(0)*pFiffInfo->sfreq;
+    from = first + vecTime(0)*pFiffInfo->sfreq;
     to = from + iQuantum;
-    if(!raw.read_raw_segment(mData, mTimes, from, to)) {
+    if(!raw.read_raw_segment(matData, matTimes, from, to)) {
         qCritical("error during read_raw_segment");
         return -1;
     }
@@ -181,12 +181,12 @@ int main(int argc, char *argv[])
     // order frequencies
     qInfo() << "Find Order...";
     timer.start();
-    HPI.findOrder(mData,
-                  mProjectors,
+    HPI.findOrder(matData,
+                  matProjectors,
                   pFiffInfo->dev_head_t,
-                  vFreqs,
-                  vError,
-                  vGoF,
+                  vecFreqs,
+                  vecError,
+                  vecGoF,
                   fittedPointSet,
                   pFiffInfo);
     qInfo() << "Ordered Frequencies: ";
@@ -196,15 +196,15 @@ int main(int argc, char *argv[])
     float fTimer = 0.0;
 
     // read and fit
-    for(int i = 0; i < vTime.size(); i++) {
-        from = first + vTime(i)*pFiffInfo->sfreq;
+    for(int i = 0; i < vecTime.size(); i++) {
+        from = first + vecTime(i)*pFiffInfo->sfreq;
         to = from + iQuantum;
         if (to > last) {
             to = last;
             qWarning() << "Block size < iQuantum " << iQuantum;
         }
         // Reading
-        if(!raw.read_raw_segment(mData, mTimes, from, to)) {
+        if(!raw.read_raw_segment(matData, matTimes, from, to)) {
             qCritical("error during read_raw_segment");
             return -1;
         }
@@ -212,12 +212,12 @@ int main(int argc, char *argv[])
 
         qInfo() << "HPI-Fit...";
         timer.start();
-        HPI.fitHPI(mData,
-                   mProjectors,
+        HPI.fitHPI(matData,
+                   matProjectors,
                    pFiffInfo->dev_head_t,
-                   vFreqs,
-                   vError,
-                   vGoF,
+                   vecFreqs,
+                   vecError,
+                   vecGoF,
                    fittedPointSet,
                    pFiffInfo,
                    bDoDebug,
@@ -226,13 +226,13 @@ int main(int argc, char *argv[])
         qInfo() << "The HPI-Fit took" << fTimer << "milliseconds";
         qInfo() << "[done]";
 
-        HPIFit::storeHeadPosition(vTime(i), pFiffInfo->dev_head_t.trans, mPosition, vGoF, vError);
-        mPosition(i,9) = fTimer;
+        HPIFit::storeHeadPosition(vecTime(i), pFiffInfo->dev_head_t.trans, matPosition, vecGoF, vecError);
+        matPosition(i,9) = fTimer;
         // if big head displacement occures, update debHeadTrans
         if(MNEMath::compareTransformation(transDevHead.trans, pFiffInfo->dev_head_t.trans, fThreshRot, fThreshTrans)) {
             transDevHead = pFiffInfo->dev_head_t;
             qInfo() << "dev_head_t has been updated.";
         }
     }
-    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_03_Faster_MEG.txt");
+    IOUtils::write_eigen_matrix(matPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_03_Faster_Home.txt");
 }

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
     parser.setApplicationDescription("hpiFit Example");
     parser.addHelpOption();
     qInfo() << "Please download the mne-cpp-test-data folder from Github (mne-tools) into mne-cpp/bin.";
-    QCommandLineOption inputOption("fileIn", "The input file <in>.", "in", QCoreApplication::applicationDirPath() + "/mne-cpp-test-data/MEG/sample/test_hpiFit_raw.fif");
+    QCommandLineOption inputOption("fileIn", "The input file <in>.", "in", QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/raw/data_with_movement_chpi_raw.fif");
 
     parser.addOption(inputOption);
 
@@ -125,16 +125,16 @@ int main(int argc, char *argv[])
     float fQuantumSec = 0.2f;       // read and write in 200 ms junks
     fiff_int_t iQuantum = ceil(fQuantumSec*pFiffInfo->sfreq);
 
-    // create time vector that specifies when to fit
-    int iN = ceil((last-first)/iQuantum);
-    RowVectorXf vTime = RowVectorXf::LinSpaced(iN, 0, iN-1) * dTSec;
+//    // create time vector that specifies when to fit
+//    int iN = ceil((last-first)/iQuantum);
+//    RowVectorXf vTime = RowVectorXf::LinSpaced(iN, 0, iN-1) * dTSec;
 
     // To fit at specific times outcommend the following block
-//    // Read Quaternion File
-//    MatrixXd pos;
-//    qInfo() << "Specify the path to your Position file (.txt)";
-//    IOUtils::read_eigen_matrix(pos, QCoreApplication::applicationDirPath() + "/mne-cpp-test-data/Result/ref_hpiFit_pos.txt");
-//    RowVectorXd time = pos.col(0);
+    // Read Quaternion File
+    MatrixXd pos;
+    qInfo() << "Specify the path to your Position file (.txt)";
+    IOUtils::read_eigen_matrix(pos, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/posMax_data_with_movement_chpi.txt");
+    RowVectorXd vTime = pos.col(0);
 
     MatrixXd mPosition;              // mPosition matrix to save quaternions etc.
 
@@ -191,6 +191,8 @@ int main(int argc, char *argv[])
     qInfo() << "findOrder() took" << timer.elapsed() << "milliseconds";
     qInfo() << "[done]";
 
+    float fTimer = 0.0;
+
     // read and fit
     for(int i = 0; i < vTime.size(); i++) {
         from = first + vTime(i)*pFiffInfo->sfreq;
@@ -218,16 +220,17 @@ int main(int argc, char *argv[])
                        pFiffInfo,
                        bDoDebug,
                        sHPIResourceDir);
-        qInfo() << "The HPI-Fit took" << timer.elapsed() << "milliseconds";
+        fTimer = timer.elapsed();
+        qInfo() << "The HPI-Fit took" << fTimer << "milliseconds";
         qInfo() << "[done]";
 
         HPIFit::storeHeadPosition(vTime(i), pFiffInfo->dev_head_t.trans, mPosition, vGoF, vError);
-
+        mPosition(i,9) = fTimer;
         // if big head displacement occures, update debHeadTrans
         if(MNEMath::compareTransformation(transDevHead.trans, pFiffInfo->dev_head_t.trans, fThreshRot, fThreshTrans)) {
             transDevHead = pFiffInfo->dev_head_t;
             qInfo() << "dev_head_t has been updated.";
         }
     }
-//    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/mPosition.txt");
+    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_01_Faster_Home.txt");
 }

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -234,5 +234,5 @@ int main(int argc, char *argv[])
             qInfo() << "dev_head_t has been updated.";
         }
     }
-    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_02_Faster_MEG.txt");
+    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_03_Faster_MEG.txt");
 }

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -167,6 +167,8 @@ int main(int argc, char *argv[])
     QString sHPIResourceDir = QCoreApplication::applicationDirPath() + "/HPIFittingDebug";
     bool bDoDebug = false;
 
+    HPIFit HPI = HPIFit(pFiffInfo);
+
     // ordering of frequencies
     from = first + vTime(0)*pFiffInfo->sfreq;
     to = from + iQuantum;
@@ -179,14 +181,14 @@ int main(int argc, char *argv[])
     // order frequencies
     qInfo() << "Find Order...";
     timer.start();
-    HPIFit::findOrder(mData,
-                   mProjectors,
-                   pFiffInfo->dev_head_t,
-                   vFreqs,
-                   vError,
-                   vGoF,
-                   fittedPointSet,
-                   pFiffInfo);
+    HPI.findOrder(mData,
+                  mProjectors,
+                  pFiffInfo->dev_head_t,
+                  vFreqs,
+                  vError,
+                  vGoF,
+                  fittedPointSet,
+                  pFiffInfo);
     qInfo() << "Ordered Frequencies: ";
     qInfo() << "findOrder() took" << timer.elapsed() << "milliseconds";
     qInfo() << "[done]";
@@ -210,16 +212,16 @@ int main(int argc, char *argv[])
 
         qInfo() << "HPI-Fit...";
         timer.start();
-        HPIFit::fitHPI(mData,
-                       mProjectors,
-                       pFiffInfo->dev_head_t,
-                       vFreqs,
-                       vError,
-                       vGoF,
-                       fittedPointSet,
-                       pFiffInfo,
-                       bDoDebug,
-                       sHPIResourceDir);
+        HPI.fitHPI(mData,
+                   mProjectors,
+                   pFiffInfo->dev_head_t,
+                   vFreqs,
+                   vError,
+                   vGoF,
+                   fittedPointSet,
+                   pFiffInfo,
+                   bDoDebug,
+                   sHPIResourceDir);
         fTimer = timer.elapsed();
         qInfo() << "The HPI-Fit took" << fTimer << "milliseconds";
         qInfo() << "[done]";
@@ -232,5 +234,5 @@ int main(int argc, char *argv[])
             qInfo() << "dev_head_t has been updated.";
         }
     }
-    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_01_Faster_Home.txt");
+    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_01_Faster_MEG.txt");
 }

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -234,5 +234,5 @@ int main(int argc, char *argv[])
             qInfo() << "dev_head_t has been updated.";
         }
     }
-    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_01_Faster_MEG.txt");
+    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_02_Faster_MEG.txt");
 }

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -234,5 +234,5 @@ int main(int argc, char *argv[])
             qInfo() << "dev_head_t has been updated.";
         }
     }
-    // IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_03_Faster_MEG.txt");
+    IOUtils::write_eigen_matrix(mPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/pos_01_Faster_MEG.txt");
 }

--- a/libraries/disp/viewers/formfiles/hpisettingsview.ui
+++ b/libraries/disp/viewers/formfiles/hpisettingsview.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>254</width>
-    <height>721</height>
+    <height>836</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -31,6 +31,269 @@
      <property name="spacing">
       <number>6</number>
      </property>
+     <item row="1" column="0">
+      <widget class="QGroupBox" name="m_groupBox_hpiFitting">
+       <property name="minimumSize">
+        <size>
+         <width>228</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>300</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="title">
+        <string>Fitting</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Coil frequencies:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTableWidget" name="m_tableWidget_Frequencies">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>114</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QAbstractScrollArea::AdjustIgnored</enum>
+          </property>
+          <property name="showGrid">
+           <bool>true</bool>
+          </property>
+          <attribute name="horizontalHeaderCascadingSectionResizes">
+           <bool>false</bool>
+          </attribute>
+          <attribute name="horizontalHeaderMinimumSectionSize">
+           <number>30</number>
+          </attribute>
+          <attribute name="horizontalHeaderDefaultSectionSize">
+           <number>80</number>
+          </attribute>
+          <attribute name="verticalHeaderVisible">
+           <bool>false</bool>
+          </attribute>
+          <attribute name="verticalHeaderDefaultSectionSize">
+           <number>22</number>
+          </attribute>
+          <column>
+           <property name="text">
+            <string>Coil #</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Frequency</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="m_pushButton_removeCoil">
+          <property name="text">
+           <string>-</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="m_pushButton_addCoil">
+          <property name="text">
+           <string>+</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Line" name="line_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="m_checkBox_useSSP">
+          <property name="text">
+           <string>Use SSP</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="m_checkBox_useComp">
+          <property name="text">
+           <string>Use compensators</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="m_checkBox_continousHPI">
+          <property name="text">
+           <string>Do continous HPI fitting</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="m_pushButton_doFreqOrder">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>23</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Order coil frequencies</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="m_pushButton_doSingleFit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>23</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Perform single HPI fit</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Line" name="line_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>Fitting errors:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTableWidget" name="m_tableWidget_errors">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>113</height>
+           </size>
+          </property>
+          <attribute name="verticalHeaderVisible">
+           <bool>false</bool>
+          </attribute>
+          <attribute name="verticalHeaderDefaultSectionSize">
+           <number>22</number>
+          </attribute>
+          <column>
+           <property name="text">
+            <string>Coil #</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Error in mm</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="m_label_averagedFitError">
+          <property name="text">
+           <string>0mm</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Average error:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="m_doubleSpinBox_maxHPIContinousDist">
+          <property name="suffix">
+           <string>mm</string>
+          </property>
+          <property name="maximum">
+           <double>9999.989999999999782</double>
+          </property>
+          <property name="value">
+           <double>10.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Error threshold:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="m_label_fitFeedback">
+          <property name="text">
+           <string>No fit yet</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
      <item row="0" column="0">
       <widget class="QGroupBox" name="m_groupBox_loadDigitizers">
        <property name="minimumSize">
@@ -134,19 +397,6 @@
        </layout>
       </widget>
      </item>
-     <item row="2" column="0">
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item row="0" column="1" rowspan="2">
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -160,243 +410,18 @@
        </property>
       </spacer>
      </item>
-     <item row="1" column="0">
-      <widget class="QGroupBox" name="m_groupBox_hpiFitting">
-       <property name="minimumSize">
+     <item row="2" column="0">
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
         <size>
-         <width>228</width>
-         <height>0</height>
+         <width>20</width>
+         <height>40</height>
         </size>
        </property>
-       <property name="maximumSize">
-        <size>
-         <width>300</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="title">
-        <string>Fitting</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="6" column="0">
-         <widget class="QPushButton" name="m_pushButton_addCoil">
-          <property name="text">
-           <string>+</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QPushButton" name="m_pushButton_removeCoil">
-          <property name="text">
-           <string>-</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0" rowspan="2" colspan="2">
-         <widget class="QTableWidget" name="m_tableWidget_Frequencies">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>114</height>
-           </size>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QAbstractScrollArea::AdjustIgnored</enum>
-          </property>
-          <property name="showGrid">
-           <bool>true</bool>
-          </property>
-          <attribute name="horizontalHeaderCascadingSectionResizes">
-           <bool>false</bool>
-          </attribute>
-          <attribute name="horizontalHeaderMinimumSectionSize">
-           <number>30</number>
-          </attribute>
-          <attribute name="horizontalHeaderDefaultSectionSize">
-           <number>80</number>
-          </attribute>
-          <attribute name="verticalHeaderVisible">
-           <bool>false</bool>
-          </attribute>
-          <attribute name="verticalHeaderDefaultSectionSize">
-           <number>22</number>
-          </attribute>
-          <column>
-           <property name="text">
-            <string>Coil #</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Frequency</string>
-           </property>
-          </column>
-         </widget>
-        </item>
-        <item row="15" column="0" colspan="2">
-         <widget class="QToolButton" name="m_pushButton_doSingleFit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>23</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Perform single HPI fit</string>
-          </property>
-         </widget>
-        </item>
-        <item row="19" column="0" colspan="2">
-         <widget class="QTableWidget" name="m_tableWidget_errors">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>113</height>
-           </size>
-          </property>
-          <attribute name="verticalHeaderVisible">
-           <bool>false</bool>
-          </attribute>
-          <attribute name="verticalHeaderDefaultSectionSize">
-           <number>22</number>
-          </attribute>
-          <column>
-           <property name="text">
-            <string>Coil #</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Error in mm</string>
-           </property>
-          </column>
-         </widget>
-        </item>
-        <item row="20" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Average error:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="21" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Error threshold:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="20" column="1">
-         <widget class="QLabel" name="m_label_averagedFitError">
-          <property name="text">
-           <string>0mm</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="21" column="1">
-         <widget class="QDoubleSpinBox" name="m_doubleSpinBox_maxHPIContinousDist">
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>10.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="16" column="0" colspan="2">
-         <widget class="Line" name="line_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="22" column="0" colspan="2">
-         <widget class="QLabel" name="m_label_fitFeedback">
-          <property name="text">
-           <string>No fit yet</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0" colspan="2">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Coil frequencies:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0" colspan="2">
-         <widget class="Line" name="line_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="18" column="0" colspan="2">
-         <widget class="QLabel" name="label_11">
-          <property name="text">
-           <string>Fitting errors:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="13" column="0" colspan="2">
-         <widget class="QCheckBox" name="m_checkBox_continousHPI">
-          <property name="text">
-           <string>Do continous HPI fitting</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0" colspan="2">
-         <widget class="QCheckBox" name="m_checkBox_useComp">
-          <property name="text">
-           <string>Use compensators</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0" colspan="2">
-         <widget class="QCheckBox" name="m_checkBox_useSSP">
-          <property name="text">
-           <string>Use SSP</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -78,6 +78,8 @@ HpiSettingsView::HpiSettingsView(const QString& sSettingsPath,
 
     connect(m_ui->m_pushButton_loadDigitizers, &QPushButton::released,
             this, &HpiSettingsView::onLoadDigitizers);
+    connect(m_ui->m_pushButton_doFreqOrder, &QPushButton::clicked,
+            this, &HpiSettingsView::doFreqOrder);
     connect(m_ui->m_pushButton_doSingleFit, &QPushButton::clicked,
             this, &HpiSettingsView::doSingleHpiFit);
     connect(m_ui->m_tableWidget_Frequencies, &QTableWidget::cellChanged,

--- a/libraries/disp/viewers/hpisettingsview.h
+++ b/libraries/disp/viewers/hpisettingsview.h
@@ -214,7 +214,7 @@ signals:
 
     //=========================================================================================================
     /**
-     * Emit this signal whenever the freuence ordering is supposed to be triggered.
+     * Emit this signal whenever the frequency ordering is supposed to be triggered.
      */
     void doFreqOrder();
 

--- a/libraries/disp/viewers/hpisettingsview.h
+++ b/libraries/disp/viewers/hpisettingsview.h
@@ -214,6 +214,12 @@ signals:
 
     //=========================================================================================================
     /**
+     * Emit this signal whenever the freuence ordering is supposed to be triggered.
+     */
+    void doFreqOrder();
+
+    //=========================================================================================================
+    /**
      * Emit this signal whenever a single HPI fit is supposed to be triggered.
      */
     void doSingleHpiFit();

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -263,6 +263,8 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
                 mCoilPos.row(j) = (-1 * pFiffInfo->chs.at(vChIdcs(j)).chpos.ez * 0.03 + r0).cast<double>();
             }
         }
+        qWarning() << "dError > 0.003";
+        std::cout << mCoilPos << std::endl;
     } else {
             mCoilPos = transDevHead.apply_inverse_trans(mHeadHPI.cast<float>()).cast<double>();
     }
@@ -315,6 +317,12 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
 
         fittedPointSet << digPoint;
     }
+    dError = std::accumulate(vError.begin(), vError.end(), .0) / vError.size();
+    qDebug() << "Error: " << dError;
+    if(dError > 0.03) {
+        qCritical() << dError;
+    }
+    qDebug() << "GoF: " << vGoF.mean();
 
     if(bDoDebug) {
         // DEBUG HPI fitting and write debug results
@@ -568,17 +576,6 @@ void HPIFit::createSensorSet(Sensor& sensors, FwdCoilSet* coils)
         sensors.cosmag.block(i*iNp,0,iNp,3) = mCosmag;
         sensors.rmag.block(i*iNp,0,iNp,3) = mRmag;
     }
-//    MatrixXd x = sensors.w.segment(0*iNp,iNp) * sensors.rmag.block(0*iNp,0,iNp,sensors.rmag.cols());
-//    std::cout << sensors.w.segment(0*iNp,iNp) << std::endl;
-//    std::cout << sensors.rmag.block(0*iNp,0,iNp,sensors.rmag.cols()) << std::endl;
-//    qDebug() << x.cols() << "x" << x.rows();
-//    std::cout << x << std::endl;
-//    qDebug() << "sensors.rmag " << sensors.rmag.rows() << "x" << sensors.rmag.cols();
-//    std::cout << sensors.rmag << std::endl;
-//    qDebug() << "sensors.cosmag " << sensors.cosmag.rows() << "x" << sensors.cosmag.cols();
-//    std::cout << sensors.cosmag << std::endl;
-//    qDebug() << "sensors.w" << sensors.w.rows() << "x" << sensors.w.cols();
-//    std::cout << sensors.w << std::endl;
 }
 
 //=============================================================================================================

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -86,7 +86,7 @@ HPIFit::HPIFit(FiffInfo::SPtr pFiffInfo)
     // init channel list and sensorSet
     m_channels = QList<FIFFLIB::FiffChInfo>();
     m_innerind = QVector<int>();
-    m_sensorSet = QList<Sensor>();
+    m_sensorSet = QList<HPIFitData::Sensor>();
 
     // Get the indices of inner layer channels and exclude bad channels and create channellist
     int numCh = pFiffInfo->nchan;
@@ -433,7 +433,7 @@ void HPIFit::findOrder(const MatrixXd& t_mat,
 //=============================================================================================================
 
 CoilParam HPIFit::dipfit(struct CoilParam coil,
-                         const QList<Sensor>& sensorSet,
+                         const QList<HPIFitData::Sensor>& sensorSet,
                          const MatrixXd& data,
                          int numCoils,
                          const MatrixXd& t_matProjectors)
@@ -547,11 +547,11 @@ Eigen::Matrix4d HPIFit::computeTransformation(Eigen::MatrixXd NH, MatrixXd BT)
 
 //=============================================================================================================
 
-void HPIFit::createSensorSet(QList<struct Sensor>& sensors, FwdCoilSet* coils)
+void HPIFit::createSensorSet(QList<HPIFitData::Sensor>& sensors, FwdCoilSet* coils)
 {
     int nchan = coils->ncoil;
     for(int i = 0; i < nchan; i++){
-        Sensor s;
+        HPIFitData::Sensor s;
         FwdCoil* coil = (coils->coils[i]);
         int np = coil->np;
         MatrixXd rmag = MatrixXd::Zero(np,3);

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -85,6 +85,7 @@ HPIFit::HPIFit(FiffInfo::SPtr pFiffInfo)
 {
     // init channel list and sensorSet
     m_channels = QList<FIFFLIB::FiffChInfo>();
+    m_innerind = QVector<int>();
     m_sensorSet = QList<Sensor>();
 
     // Get the indices of inner layer channels and exclude bad channels and create channellist

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -81,7 +81,7 @@ using namespace FWDLIB;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-HPIFit::HPIFit()
+HPIFit::HPIFit(FiffInfo::SPtr pFiffInfo)
 {
 }
 

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -470,7 +470,7 @@ CoilParam HPIFit::dipfit(struct CoilParam coil,
             coil.dpfiterror(i) = lCoilData.at(i).errorInfo.error;
             coil.dpfitnumitr(i) = lCoilData.at(i).errorInfo.numIterations;
 
-            //std::cout<<std::endl<< "HPIFit::dipfit - Itr steps for coil " << i << " =" <<coil.dpfitnumitr(i);
+            // std::cout<<std::endl<< "HPIFit::dipfit - Itr steps for coil " << i << " =" <<coil.dpfitnumitr(i);
         }
     }
 

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -256,6 +256,9 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
     }
 
     //Generate seed point by projection the found channel position 3cm inwards
+    vError.resize(iNumCoils);
+    qDebug() << iNumCoils;
+    qDebug() << vError;
     double dError = std::accumulate(vError.begin(), vError.end(), .0) / vError.size();
     MatrixXd mCoilPos = MatrixXd::Zero(iNumCoils,3);
 
@@ -299,7 +302,7 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
     MatrixXd mDiffPos = mTestPos.block(0,0,3,iNumCoils) - mHeadHPI.transpose();
 
     for(int i = 0; i < mDiffPos.cols(); ++i) {
-        vError.append(mDiffPos.col(i).norm());
+        vError[i] = mDiffPos.col(i).norm();
     }
 
     // store Goodness of Fit

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -83,6 +83,10 @@ using namespace FWDLIB;
 
 HPIFit::HPIFit(FiffInfo::SPtr pFiffInfo)
 {
+    // init channel list and sensorSet
+    m_channels = QList<FIFFLIB::FiffChInfo>();
+    m_sensorSet = QList<Sensor>();
+
     // Get the indices of inner layer channels and exclude bad channels and create channellist
     int numCh = pFiffInfo->nchan;
     for (int i = 0; i < numCh; ++i) {
@@ -100,7 +104,7 @@ HPIFit::HPIFit(FiffInfo::SPtr pFiffInfo)
 
     // Setup Constructors for Coil Set
     FwdCoilSet* templates = NULL;
-    FwdCoilSet* m_megCoils = NULL;
+    FwdCoilSet* megCoils = NULL;
 
     // Create MEG-Coils and read doil_def.dat
     QString qPath = QString(QCoreApplication::applicationDirPath() + "/resources/general/coilDefinitions/coil_def.dat");
@@ -111,8 +115,8 @@ HPIFit::HPIFit(FiffInfo::SPtr pFiffInfo)
 
     templates = FwdCoilSet::read_coil_defs(qPath);
 
-    m_megCoils = templates->create_meg_coils(m_channels,nch,acc,t);
-    createSensorSet(m_sensorSet,m_megCoils);
+    megCoils = templates->create_meg_coils(m_channels,nch,acc,t);
+    createSensorSet(m_sensorSet,megCoils);
 
 }
 
@@ -142,7 +146,7 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
 
     //struct SensorInfo sensors;
     struct CoilParam coil;
-    int numCh = pFiffInfo->nchan;
+
     int samF = pFiffInfo->sfreq;
     int samLoc = t_mat.cols(); // minimum samples required to localize numLoc times in a second
 

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -86,7 +86,7 @@ HPIFit::HPIFit(FiffInfo::SPtr pFiffInfo)
     // init channel list and sensorSet
     m_channels = QList<FIFFLIB::FiffChInfo>();
     m_innerind = QVector<int>();
-    m_sensorSet = QList<HPIFitData::Sensor>();
+    m_sensorSet = QList<Sensor>();
 
     // Get the indices of inner layer channels and exclude bad channels and create channellist
     int numCh = pFiffInfo->nchan;
@@ -433,7 +433,7 @@ void HPIFit::findOrder(const MatrixXd& t_mat,
 //=============================================================================================================
 
 CoilParam HPIFit::dipfit(struct CoilParam coil,
-                         const QList<HPIFitData::Sensor>& sensorSet,
+                         const QList<Sensor>& sensorSet,
                          const MatrixXd& data,
                          int numCoils,
                          const MatrixXd& t_matProjectors)
@@ -547,11 +547,11 @@ Eigen::Matrix4d HPIFit::computeTransformation(Eigen::MatrixXd NH, MatrixXd BT)
 
 //=============================================================================================================
 
-void HPIFit::createSensorSet(QList<HPIFitData::Sensor>& sensors, FwdCoilSet* coils)
+void HPIFit::createSensorSet(QList<Sensor>& sensors, FwdCoilSet* coils)
 {
     int nchan = coils->ncoil;
     for(int i = 0; i < nchan; i++){
-        HPIFitData::Sensor s;
+        Sensor s;
         FwdCoil* coil = (coils->coils[i]);
         int np = coil->np;
         MatrixXd rmag = MatrixXd::Zero(np,3);

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -470,7 +470,7 @@ CoilParam HPIFit::dipfit(struct CoilParam coil,
             coil.dpfiterror(i) = lCoilData.at(i).errorInfo.error;
             coil.dpfitnumitr(i) = lCoilData.at(i).errorInfo.numIterations;
 
-            // std::cout<<std::endl<< "HPIFit::dipfit - Itr steps for coil " << i << " =" <<coil.dpfitnumitr(i);
+            //std::cout<<std::endl<< "HPIFit::dipfit - Itr steps for coil " << i << " =" <<coil.dpfitnumitr(i);
         }
     }
 

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -129,6 +129,9 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
         updateCoils();
     }
 
+    // Make sure the fitted digitzers are empty
+    fittedPointSet.clear();
+
     // init coil parameters
     struct CoilParam coil;
 
@@ -253,26 +256,6 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
     }
 
     //Generate seed point by projection the found channel position 3cm inwards
-<<<<<<< HEAD
-    vError.resize(numCoils);
-    double error = std::accumulate(vError.begin(), vError.end(), .0) / vError.size();
-    MatrixXd coilPos = MatrixXd::Zero(numCoils,3);
-
-    if(transDevHead.trans == MatrixXd::Identity(4,4).cast<float>() || error > 0.003){
-        for (int j = 0; j < chIdcs.rows(); ++j) {
-            if(chIdcs(j) < pFiffInfo->chs.size()) {
-                Vector3f r0 = pFiffInfo->chs.at(chIdcs(j)).chpos.r0;
-                coilPos.row(j) = (-1 * pFiffInfo->chs.at(chIdcs(j)).chpos.ez * 0.03 + r0).cast<double>();
-||||||| constructed merge base
-    double error = std::accumulate(vError.begin(), vError.end(), .0) / vError.size();
-    MatrixXd coilPos = MatrixXd::Zero(numCoils,3);
-
-    if(transDevHead.trans == MatrixXd::Identity(4,4).cast<float>() || error > 0.003){
-        for (int j = 0; j < chIdcs.rows(); ++j) {
-            if(chIdcs(j) < pFiffInfo->chs.size()) {
-                Vector3f r0 = pFiffInfo->chs.at(chIdcs(j)).chpos.r0;
-                coilPos.row(j) = (-1 * pFiffInfo->chs.at(chIdcs(j)).chpos.ez * 0.03 + r0).cast<double>();
-=======
     double dError = std::accumulate(vError.begin(), vError.end(), .0) / vError.size();
     MatrixXd mCoilPos = MatrixXd::Zero(iNumCoils,3);
 
@@ -281,7 +264,6 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
             if(vChIdcs(j) < pFiffInfo->chs.size()) {
                 Vector3f r0 = pFiffInfo->chs.at(vChIdcs(j)).chpos.r0;
                 mCoilPos.row(j) = (-1 * pFiffInfo->chs.at(vChIdcs(j)).chpos.ez * 0.03 + r0).cast<double>();
->>>>>>> MAINT: naming conventions
             }
         }
         //std::cout << "HPIFit::fitHPI - Coil " << j << " max value index " << iChIdx << std::endl;
@@ -316,16 +298,8 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
     MatrixXd mTestPos = mTrans * mTemp;
     MatrixXd mDiffPos = mTestPos.block(0,0,3,iNumCoils) - mHeadHPI.transpose();
 
-<<<<<<< HEAD
-    for(int i = 0; i < diffPos.cols(); ++i) {
-        vError[i] = diffPos.col(i).norm();
-||||||| constructed merge base
-    for(int i = 0; i < diffPos.cols(); ++i) {
-        vError.append(diffPos.col(i).norm());
-=======
     for(int i = 0; i < mDiffPos.cols(); ++i) {
         vError.append(mDiffPos.col(i).norm());
->>>>>>> MAINT: naming conventions
     }
 
     // store Goodness of Fit

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -144,16 +144,16 @@ public:
      * @param[in]    bDoDebug        Print debug info to cmd line and write debug info to file.
      * @param[in]    sHPIResourceDir The path to the debug file which is to be written.
      */
-    static void fitHPI(const Eigen::MatrixXd& t_mat,
-                       const Eigen::MatrixXd& t_matProjectors,
-                       FIFFLIB::FiffCoordTrans &transDevHead,
-                       const QVector<int>& vFreqs,
-                       QVector<double> &vError,
-                       Eigen::VectorXd& vGoF,
-                       FIFFLIB::FiffDigPointSet& fittedPointSet,
-                       QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo,
-                       bool bDoDebug = false,
-                       const QString& sHPIResourceDir = QString("./HPIFittingDebug"));
+    void fitHPI(const Eigen::MatrixXd& t_mat,
+                const Eigen::MatrixXd& t_matProjectors,
+                FIFFLIB::FiffCoordTrans &transDevHead,
+                const QVector<int>& vFreqs,
+                QVector<double> &vError,
+                Eigen::VectorXd& vGoF,
+                FIFFLIB::FiffDigPointSet& fittedPointSet,
+                QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo,
+                bool bDoDebug = false,
+                const QString& sHPIResourceDir = QString("./HPIFittingDebug"));
 
     //=========================================================================================================
     /**
@@ -169,14 +169,14 @@ public:
      * @param[in]    fittedPointSet  The final fitted positions in form of a digitizer set.
      * @param[in]    p_pFiffInfo     Associated Fiff Information.
      */
-    static void findOrder(const Eigen::MatrixXd& t_mat,
-                          const Eigen::MatrixXd& t_matProjectors,
-                          FIFFLIB::FiffCoordTrans &transDevHead,
-                          QVector<int>& vFreqs,
-                          QVector<double> &vError,
-                          Eigen::VectorXd& vGoF,
-                          FIFFLIB::FiffDigPointSet& fittedPointSet,
-                          QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
+    void findOrder(const Eigen::MatrixXd& t_mat,
+                   const Eigen::MatrixXd& t_matProjectors,
+                   FIFFLIB::FiffCoordTrans &transDevHead,
+                   QVector<int>& vFreqs,
+                   QVector<double> &vError,
+                   Eigen::VectorXd& vGoF,
+                   FIFFLIB::FiffDigPointSet& fittedPointSet,
+                   QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 
     //=========================================================================================================
     /**
@@ -191,11 +191,11 @@ public:
      *
      * ToDo: get estimated movement velocity and stroe it in channel 9
      */
-    static void storeHeadPosition(float time,
-                                  const Eigen::MatrixXf& devHeadT,
-                                  Eigen::MatrixXd& position,
-                                  const Eigen::VectorXd& vGoF,
-                                  const QVector<double>& vError);    
+    void storeHeadPosition(float time,
+                           const Eigen::MatrixXf& devHeadT,
+                           Eigen::MatrixXd& position,
+                           const Eigen::VectorXd& vGoF,
+                           const QVector<double>& vError);
 protected:
     //=========================================================================================================
     /**
@@ -209,11 +209,11 @@ protected:
      *
      * @return Returns the coil parameters.
      */
-    static CoilParam dipfit(struct CoilParam coil,
-                            const QList<struct Sensor>& sensorSet,
-                            const Eigen::MatrixXd &data,
-                            int numCoils,
-                            const Eigen::MatrixXd &t_matProjectors);
+    CoilParam dipfit(struct CoilParam coil,
+                     const QList<struct Sensor>& sensorSet,
+                     const Eigen::MatrixXd &data,
+                     int numCoils,
+                     const Eigen::MatrixXd &t_matProjectors);
 
     //=========================================================================================================
     /**
@@ -241,10 +241,10 @@ protected:
 
     //=========================================================================================================
 
-    static QList<FIFFLIB::FiffChInfo>   m_channels;             /**< Channellist */
-    static QList<Sensor>                m_sensorSet;            /**< sensorSet */
-    static QVector<int>                 m_innerind;             /**< innerind  */
-    static QString                      m_sHPIResourceDir;      /**< Hold the resource folder to store the debug information in. */
+    QList<FIFFLIB::FiffChInfo>   m_channels;             /**< Channellist */
+    QList<struct Sensor>         m_sensorSet;            /**< sensorSet */
+    QVector<int>                 m_innerind;             /**< innerind  */
+    QString                      m_sHPIResourceDir;      /**< Hold the resource folder to store the debug information in. */
 };
 
 //=============================================================================================================

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -42,6 +42,7 @@
 //=============================================================================================================
 
 #include "../inverse_global.h"
+#include "hpifitdata.h"
 
 #include <fiff/fiff_dig_point_set.h>
 #include <fiff/fiff_dig_point.h>
@@ -191,11 +192,11 @@ public:
      *
      * ToDo: get estimated movement velocity and stroe it in channel 9
      */
-    void storeHeadPosition(float time,
-                           const Eigen::MatrixXf& devHeadT,
-                           Eigen::MatrixXd& position,
-                           const Eigen::VectorXd& vGoF,
-                           const QVector<double>& vError);
+    static void storeHeadPosition(float time,
+                                  const Eigen::MatrixXf& devHeadT,
+                                  Eigen::MatrixXd& position,
+                                  const Eigen::VectorXd& vGoF,
+                                  const QVector<double>& vError);
 protected:
     //=========================================================================================================
     /**
@@ -210,7 +211,7 @@ protected:
      * @return Returns the coil parameters.
      */
     CoilParam dipfit(struct CoilParam coil,
-                     const QList<struct Sensor>& sensorSet,
+                     const QList<HPIFitData::Sensor>& sensorSet,
                      const Eigen::MatrixXd &data,
                      int numCoils,
                      const Eigen::MatrixXd &t_matProjectors);
@@ -236,13 +237,12 @@ protected:
      * @param[in] coils     The coilset to read the sensor information from.
      *
      */
-    static void createSensorSet(QList<struct Sensor>& sensors,
-                                FWDLIB::FwdCoilSet* coils);
+    void createSensorSet(QList<HPIFitData::Sensor>& sensors, FWDLIB::FwdCoilSet* coils);
 
     //=========================================================================================================
 
     QList<FIFFLIB::FiffChInfo>   m_channels;             /**< Channellist */
-    QList<struct Sensor>         m_sensorSet;            /**< sensorSet */
+    QList<HPIFitData::Sensor>    m_sensorSet;            /**< sensorSet */
     QVector<int>                 m_innerind;             /**< innerind  */
     QString                      m_sHPIResourceDir;      /**< Hold the resource folder to store the debug information in. */
 };

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -110,7 +110,7 @@ struct HpiFitResult {
 /**
  * The strucut specifing the sensor parameters.
  */
-struct Sensor {
+struct SensorSet {
     Eigen::MatrixXd r0;
     Eigen::MatrixXd rmag;
     Eigen::MatrixXd cosmag;
@@ -147,23 +147,23 @@ public:
     /**
      * Perform one single HPI fit.
      *
-     * @param[in]    t_mat           Data to estimate the HPI positions from
-     * @param[in]    t_matProjectors The projectors to apply. Bad channels are still included.
-     * @param[out]   transDevHead    The final dev head transformation matrix
-     * @param[in]    vFreqs          The frequencies for each coil.
-     * @param[out]   vError          The HPI estimation Error in mm for each fitted HPI coil.
-     * @param[out]   vGoF            The goodness of fit for each fitted HPI coil
-     * @param[out]   fittedPointSet  The final fitted positions in form of a digitizer set.
-     * @param[in]    pFiffInfo     Associated Fiff Information.
-     * @param[in]    bDoDebug        Print debug info to cmd line and write debug info to file.
-     * @param[in]    sHPIResourceDir The path to the debug file which is to be written.
+     * @param[in]    t_mat              Data to estimate the HPI positions from
+     * @param[in]    t_matProjectors    The projectors to apply. Bad channels are still included.
+     * @param[out]   transDevHead       The final dev head transformation matrix
+     * @param[in]    vecFreqs           The frequencies for each coil.
+     * @param[out]   vecError           The HPI estimation Error in mm for each fitted HPI coil.
+     * @param[out]   vecGoF             The goodness of fit for each fitted HPI coil
+     * @param[out]   fittedPointSet     The final fitted positions in form of a digitizer set.
+     * @param[in]    pFiffInfo          Associated Fiff Information.
+     * @param[in]    bDoDebug           Print debug info to cmd line and write debug info to file.
+     * @param[in]    sHPIResourceDir    The path to the debug file which is to be written.
      */
     void fitHPI(const Eigen::MatrixXd& t_mat,
                 const Eigen::MatrixXd& t_matProjectors,
                 FIFFLIB::FiffCoordTrans &transDevHead,
-                const QVector<int>& vFreqs,
-                QVector<double> &vError,
-                Eigen::VectorXd& vGoF,
+                const QVector<int>& vecFreqs,
+                QVector<double>& vecError,
+                Eigen::VectorXd& vecGoF,
                 FIFFLIB::FiffDigPointSet& fittedPointSet,
                 QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo,
                 bool bDoDebug = false,
@@ -173,22 +173,22 @@ public:
     /**
      * assign frequencies to correct position
      *
-     * @param[in]    t_mat           Data to estimate the HPI positions from
-     * @param[in]    t_matProjectors The projectors to apply. Bad channels are still included.
-     * @param[in]    transDevHead    The final dev head transformation matrix
-     * @param[in]    vFreqs          The frequencies for each coil in unknown order.
-     * @param[out]   vFreqs          The frequencies for each coil in correct order.
-     * @param[in]    vError          The HPI estimation Error in mm for each fitted HPI coil.
-     * @param[in]    vGoF            The goodness of fit for each fitted HPI coil
-     * @param[in]    fittedPointSet  The final fitted positions in form of a digitizer set.
-     * @param[in]    pFiffInfo     Associated Fiff Information.
+     * @param[in]    t_mat              Data to estimate the HPI positions from
+     * @param[in]    t_matProjectors    The projectors to apply. Bad channels are still included.
+     * @param[in]    transDevHead       The final dev head transformation matrix
+     * @param[in]    vecFreqs           The frequencies for each coil in unknown order.
+     * @param[out]   vecFreqs           The frequencies for each coil in correct order.
+     * @param[in]    vecError           The HPI estimation Error in mm for each fitted HPI coil.
+     * @param[in]    vecGoF             The goodness of fit for each fitted HPI coil
+     * @param[in]    fittedPointSet     The final fitted positions in form of a digitizer set.
+     * @param[in]    pFiffInfo          Associated Fiff Information.
      */
     void findOrder(const Eigen::MatrixXd& t_mat,
                    const Eigen::MatrixXd& t_matProjectors,
                    FIFFLIB::FiffCoordTrans &transDevHead,
-                   QVector<int>& vFreqs,
-                   QVector<double> &vError,
-                   Eigen::VectorXd& vGoF,
+                   QVector<int>& vecFreqs,
+                   QVector<double> &vecError,
+                   Eigen::VectorXd& vecGoF,
                    FIFFLIB::FiffDigPointSet& fittedPointSet,
                    QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 
@@ -198,35 +198,35 @@ public:
      * get from Neuromag's MaxFilter.
      *
      *
-     * @param[in]   fTime          The corresponding time in the measurement for the fit.
-     * @param[in]   pFiffInfo     The FiffInfo file from the measurement.
-     * @param[out]  mPosition      The matrix to store the results.
-     * @param[in]   vGoF          The goodness of fit for each coil.
-     * @param[in]   vError        The Hpi estimation Error per coil.
+     * @param[in]   fTime           The corresponding time in the measurement for the fit.
+     * @param[in]   pFiffInfo       The FiffInfo file from the measurement.
+     * @param[out]  matPosition     The matrix to store the results.
+     * @param[in]   vecGoF          The goodness of fit for each coil.
+     * @param[in]   vecError        The Hpi estimation Error per coil.
      *
      * ToDo: get estimated movement velocity and store it in channel 9
      */
     static void storeHeadPosition(float fTime,
                                   const Eigen::MatrixXf& transDevHead,
-                                  Eigen::MatrixXd& mPosition,
-                                  const Eigen::VectorXd& vGoF,
-                                  const QVector<double>& vError);
+                                  Eigen::MatrixXd& matPosition,
+                                  const Eigen::VectorXd& vecGoF,
+                                  const QVector<double>& vecError);
 protected:
     //=========================================================================================================
     /**
      * Fits dipoles for the given coils and a given data set.
      *
-     * @param[in] CoilParam       The coil parameters.
-     * @param[in] lSensorSet      The sensor information.
-     * @param[in] mData           The data which used to fit the coils.
-     * @param[in] iNumCoils       The number of coils.
-     * @param[in] t_matProjectors The projectors to apply. Bad channels are still included.
+     * @param[in] CoilParam         The coil parameters.
+     * @param[in] sensors           The sensor information.
+     * @param[in] matData           The data which used to fit the coils.
+     * @param[in] iNumCoils         The number of coils.
+     * @param[in] t_matProjectors   The projectors to apply. Bad channels are still included.
      *
      * @return Returns the coil parameters.
      */
     CoilParam dipfit(struct CoilParam coil,
-                     const Sensor& sensors,
-                     const Eigen::MatrixXd &mData,
+                     const SensorSet& sensors,
+                     const Eigen::MatrixXd &matData,
                      int iNumCoils,
                      const Eigen::MatrixXd &t_matProjectors);
 
@@ -234,38 +234,38 @@ protected:
     /**
      * Computes the transformation matrix between two sets of 3D points.
      *
-     * @param[in] mNH    The first set of input 3D points (row-wise order).
-     * @param[in] mBT    The second set of input 3D points (row-wise order).
+     * @param[in] matNH    The first set of input 3D points (row-wise order).
+     * @param[in] matBT    The second set of input 3D points (row-wise order).
      *
      * @return Returns the transformation matrix.
      */
 
-    Eigen::Matrix4d computeTransformation(Eigen::MatrixXd mNH,
-                                          Eigen::MatrixXd mBT);
+    Eigen::Matrix4d computeTransformation(Eigen::MatrixXd matNH,
+                                          Eigen::MatrixXd matBT);
 
     //=========================================================================================================
     /**
-     * Read from FwdCoilSet and store into lSensorSet struct.
+     * Read from FwdCoilSet and store into sensors struct.
      * Can be deleted as soon as FwdCoilSet is refactored to QList and EigenMatrix.
      *
-     * @param[in] lSensorSet    The struct to save sensor information.
+     * @param[in] sensors       The struct to save sensor information.
      * @param[in] coils         The coilset to read the sensor information from.
      *
      */
-    void createSensorSet(Sensor& sensor,
+    void createSensorSet(SensorSet& sensors,
                          FWDLIB::FwdCoilSet* coils);
 
     //=========================================================================================================
 
-    Sensor                m_sensors;            /**< sensors */
+    SensorSet                m_sensors;            /**< sensor struct that contains information about all sensors */
 
 private:
     //=========================================================================================================
     /**
-     * Update FwdCoilSet and store into lSensorSet struct.
+     * Update FwdCoilSet and store into sensors struct.
      *
      */
-    void updateCoils();
+    void updateSensor();
 
     FWDLIB::FwdCoilSet* m_coilTemplate;
     FWDLIB::FwdCoilSet* m_coilMeg;
@@ -277,7 +277,7 @@ private:
      */
     void updateChannels(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 
-    QList<FIFFLIB::FiffChInfo>   m_lChannels;             /**< Channellist with excluded bads */
+    QList<FIFFLIB::FiffChInfo>   m_lChannels;             /**< Channellist with bads excluded */
     QVector<int>                 m_vInnerind;             /**< index of inner channels  */
     QList<QString>               m_lBads;                 /**< contains bad channels  */
 

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -127,7 +127,7 @@ public:
     /**
      * Default constructor.
      */
-    explicit HPIFit();
+    explicit HPIFit(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 
     //=========================================================================================================
     /**

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -108,6 +108,19 @@ struct HpiFitResult {
     QString                     sFilePathDigitzers;
 };
 
+//=========================================================================================================
+/**
+ * The strucut specifing the sensor parameters.
+ */
+struct Sensor {
+    Eigen::RowVector3d r0;
+    Eigen::MatrixXd rmag;
+    Eigen::MatrixXd cosmag;
+    Eigen::MatrixXd tra;
+    Eigen::RowVectorXd w;
+    int np;
+};
+
 //=============================================================================================================
 // INVERSELIB FORWARD DECLARATIONS
 //=============================================================================================================
@@ -142,6 +155,7 @@ public:
      * @param[out]   vError          The HPI estimation Error in mm for each fitted HPI coil.
      * @param[out]   vGoF            The goodness of fit for each fitted HPI coil
      * @param[out]   fittedPointSet  The final fitted positions in form of a digitizer set.
+     * @param[in]    pFiffInfo     Associated Fiff Information.
      * @param[in]    bDoDebug        Print debug info to cmd line and write debug info to file.
      * @param[in]    sHPIResourceDir The path to the debug file which is to be written.
      */
@@ -162,13 +176,13 @@ public:
      *
      * @param[in]    t_mat           Data to estimate the HPI positions from
      * @param[in]    t_matProjectors The projectors to apply. Bad channels are still included.
-     * @param[out]   transDevHead    The final dev head transformation matrix
+     * @param[in]    transDevHead    The final dev head transformation matrix
      * @param[in]    vFreqs          The frequencies for each coil in unknown order.
      * @param[out]   vFreqs          The frequencies for each coil in correct order.
      * @param[in]    vError          The HPI estimation Error in mm for each fitted HPI coil.
      * @param[in]    vGoF            The goodness of fit for each fitted HPI coil
      * @param[in]    fittedPointSet  The final fitted positions in form of a digitizer set.
-     * @param[in]    p_pFiffInfo     Associated Fiff Information.
+     * @param[in]    pFiffInfo     Associated Fiff Information.
      */
     void findOrder(const Eigen::MatrixXd& t_mat,
                    const Eigen::MatrixXd& t_matProjectors,
@@ -211,7 +225,7 @@ protected:
      * @return Returns the coil parameters.
      */
     CoilParam dipfit(struct CoilParam coil,
-                     const QList<HPIFitData::Sensor>& sensorSet,
+                     const QList<Sensor>& sensorSet,
                      const Eigen::MatrixXd &data,
                      int numCoils,
                      const Eigen::MatrixXd &t_matProjectors);
@@ -237,12 +251,12 @@ protected:
      * @param[in] coils     The coilset to read the sensor information from.
      *
      */
-    void createSensorSet(QList<HPIFitData::Sensor>& sensors, FWDLIB::FwdCoilSet* coils);
+    void createSensorSet(QList<Sensor>& sensors, FWDLIB::FwdCoilSet* coils);
 
     //=========================================================================================================
 
     QList<FIFFLIB::FiffChInfo>   m_channels;             /**< Channellist */
-    QList<HPIFitData::Sensor>    m_sensorSet;            /**< sensorSet */
+    QList<Sensor>                m_sensorSet;            /**< sensorSet */
     QVector<int>                 m_innerind;             /**< innerind  */
     QString                      m_sHPIResourceDir;      /**< Hold the resource folder to store the debug information in. */
 };

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -42,7 +42,7 @@
 //=============================================================================================================
 
 #include "../inverse_global.h"
-#include "hpifitdata.h"
+#include "fiff/fiff_ch_info.h"
 
 #include <fiff/fiff_dig_point_set.h>
 #include <fiff/fiff_dig_point.h>
@@ -71,7 +71,6 @@ namespace FWDLIB{
 
 namespace FIFFLIB{
     class FiffInfo;
-    class FiffChInfo;
     class FiffCoordTrans;
     class FiffDigPointSet;
 }

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -259,7 +259,7 @@ protected:
 private:
     //=========================================================================================================
     /**
-     * update FwdCoilSet and store into sensors struct.
+     * Update FwdCoilSet and store into sensors struct.
      *
      */
     void updateCoils();
@@ -269,7 +269,7 @@ private:
 
     //=========================================================================================================
     /**
-     * update the channellist for init and if bads are changing
+     * Update the channellist for init and if bads changed
      *
      */
     void updateChannels(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -241,12 +241,10 @@ protected:
 
     //=========================================================================================================
 
-    //=========================================================================================================
-
-    QList<FIFFLIB::FiffChInfo> m_channels;          /**< Channellist */
-    QList<Sensor> m_sensorSet;                      /**< sensorSet */
-
-    static QString         m_sHPIResourceDir;      /**< Hold the resource folder to store the debug information in. */
+    static QList<FIFFLIB::FiffChInfo>   m_channels;             /**< Channellist */
+    static QList<Sensor>                m_sensorSet;            /**< sensorSet */
+    static QVector<int>                 m_innerind;             /**< innerind  */
+    static QString                      m_sHPIResourceDir;      /**< Hold the resource folder to store the debug information in. */
 };
 
 //=============================================================================================================

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -254,10 +254,30 @@ protected:
 
     //=========================================================================================================
 
-    QList<FIFFLIB::FiffChInfo>   m_channels;             /**< Channellist */
     QList<Sensor>                m_sensorSet;            /**< sensorSet */
-    QVector<int>                 m_innerind;             /**< innerind  */
-    QString                      m_sHPIResourceDir;      /**< Hold the resource folder to store the debug information in. */
+
+private:
+    //=========================================================================================================
+    /**
+     * update FwdCoilSet and store into sensors struct.
+     *
+     */
+    void updateCoils();
+
+    FWDLIB::FwdCoilSet* m_templates;
+    FWDLIB::FwdCoilSet* m_megCoils;
+
+    //=========================================================================================================
+    /**
+     * update the channellist for init and if bads are changing
+     *
+     */
+    void updateChannels(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
+
+    QList<FIFFLIB::FiffChInfo>   m_channels;             /**< Channellist with excluded bads */
+    QVector<int>                 m_innerind;             /**< index of inner channels  */
+    QList<QString>               m_bads;                 /**< contains bad channels  */
+
 };
 
 //=============================================================================================================

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -198,16 +198,26 @@ public:
      * get from Neuromag's MaxFilter.
      *
      *
+<<<<<<< HEAD
      * @param[in]   time          The corresponding time in the measurement for the fit.
      * @param[out]  position      The matrix to store the results.
+||||||| constructed merge base
+     * @param[in]   time          The corresponding time in the measurement for the fit.
+     * @param[in]   pFiffInfo     The FiffInfo file from the measurement.
+     * @param[out]  position      The matrix to store the results.
+=======
+     * @param[in]   fTime          The corresponding time in the measurement for the fit.
+     * @param[in]   pFiffInfo     The FiffInfo file from the measurement.
+     * @param[out]  mPosition      The matrix to store the results.
+>>>>>>> MAINT: naming conventions
      * @param[in]   vGoF          The goodness of fit for each coil.
      * @param[in]   vError        The Hpi estimation Error per coil.
      *
      * ToDo: get estimated movement velocity and stroe it in channel 9
      */
-    static void storeHeadPosition(float time,
-                                  const Eigen::MatrixXf& devHeadT,
-                                  Eigen::MatrixXd& position,
+    static void storeHeadPosition(float fTime,
+                                  const Eigen::MatrixXf& transDevHead,
+                                  Eigen::MatrixXd& mPosition,
                                   const Eigen::VectorXd& vGoF,
                                   const QVector<double>& vError);
 protected:
@@ -215,57 +225,75 @@ protected:
     /**
      * Fits dipoles for the given coils and a given data set.
      *
+<<<<<<< HEAD
      * @param[in] coil            The coil parameters.
      * @param[in] sensorSet       The sensor information.
      * @param[in] data            The data which used to fit the coils.
      * @param[in] numCoils        The number of coils.
+||||||| constructed merge base
+     * @param[in] CoilParam       The coil parameters.
+     * @param[in] sensors         The sensor information.
+     * @param[in] data            The data which used to fit the coils.
+     * @param[in] numCoils        The number of coils.
+=======
+     * @param[in] CoilParam       The coil parameters.
+     * @param[in] lSensorSet      The sensor information.
+     * @param[in] mData           The data which used to fit the coils.
+     * @param[in] iNumCoils       The number of coils.
+>>>>>>> MAINT: naming conventions
      * @param[in] t_matProjectors The projectors to apply. Bad channels are still included.
      *
      * @return Returns the coil parameters.
      */
     CoilParam dipfit(struct CoilParam coil,
-                     const QList<Sensor>& sensorSet,
-                     const Eigen::MatrixXd &data,
-                     int numCoils,
+                     const QList<Sensor>& lSensorSet,
+                     const Eigen::MatrixXd &mData,
+                     int iNumCoils,
                      const Eigen::MatrixXd &t_matProjectors);
 
     //=========================================================================================================
     /**
      * Computes the transformation matrix between two sets of 3D points.
      *
-     * @param[in] NH     The first set of input 3D points (row-wise order).
-     * @param[in] BT     The second set of input 3D points (row-wise order).
+     * @param[in] mNH    The first set of input 3D points (row-wise order).
+     * @param[in] mBT    The second set of input 3D points (row-wise order).
      *
      * @return Returns the transformation matrix.
      */
+<<<<<<< HEAD
     static Eigen::Matrix4d computeTransformation(Eigen::MatrixXd NH,
                                                  Eigen::MatrixXd BT);
+||||||| constructed merge base
+    Eigen::Matrix4d computeTransformation(Eigen::MatrixXd NH, Eigen::MatrixXd BT);
+=======
+    Eigen::Matrix4d computeTransformation(Eigen::MatrixXd mNH, Eigen::MatrixXd mBT);
+>>>>>>> MAINT: naming conventions
 
     //=========================================================================================================
     /**
-     * Read from FwdCoilSet and store into sensors struct.
+     * Read from FwdCoilSet and store into lSensorSet struct.
      * Can be deleted as soon as FwdCoilSet is refactored to QList and EigenMatrix.
      *
-     * @param[in] sensors     The struct to save sensor information.
-     * @param[in] coils     The coilset to read the sensor information from.
+     * @param[in] lSensorSet    The struct to save sensor information.
+     * @param[in] coils         The coilset to read the sensor information from.
      *
      */
-    void createSensorSet(QList<Sensor>& sensors, FWDLIB::FwdCoilSet* coils);
+    void createSensorSet(QList<Sensor>& lSensorSet, FWDLIB::FwdCoilSet* coils);
 
     //=========================================================================================================
 
-    QList<Sensor>                m_sensorSet;            /**< sensorSet */
+    QList<Sensor>                m_lSensorSet;            /**< lSensorSet */
 
 private:
     //=========================================================================================================
     /**
-     * Update FwdCoilSet and store into sensors struct.
+     * Update FwdCoilSet and store into lSensorSet struct.
      *
      */
     void updateCoils();
 
-    FWDLIB::FwdCoilSet* m_templates;
-    FWDLIB::FwdCoilSet* m_megCoils;
+    FWDLIB::FwdCoilSet* m_coilTemplate;
+    FWDLIB::FwdCoilSet* m_coilMeg;
 
     //=========================================================================================================
     /**
@@ -274,9 +302,9 @@ private:
      */
     void updateChannels(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 
-    QList<FIFFLIB::FiffChInfo>   m_channels;             /**< Channellist with excluded bads */
-    QVector<int>                 m_innerind;             /**< index of inner channels  */
-    QList<QString>               m_bads;                 /**< contains bad channels  */
+    QList<FIFFLIB::FiffChInfo>   m_lChannels;             /**< Channellist with excluded bads */
+    QVector<int>                 m_vInnerind;             /**< index of inner channels  */
+    QList<QString>               m_lBads;                 /**< contains bad channels  */
 
 };
 

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -111,11 +111,12 @@ struct HpiFitResult {
  * The strucut specifing the sensor parameters.
  */
 struct Sensor {
-    Eigen::RowVector3d r0;
+    Eigen::MatrixXd r0;
     Eigen::MatrixXd rmag;
     Eigen::MatrixXd cosmag;
     Eigen::MatrixXd tra;
     Eigen::RowVectorXd w;
+    int ncoils;
     int np;
 };
 
@@ -224,7 +225,7 @@ protected:
      * @return Returns the coil parameters.
      */
     CoilParam dipfit(struct CoilParam coil,
-                     const QList<Sensor>& lSensorSet,
+                     const Sensor& sensors,
                      const Eigen::MatrixXd &mData,
                      int iNumCoils,
                      const Eigen::MatrixXd &t_matProjectors);
@@ -251,12 +252,12 @@ protected:
      * @param[in] coils         The coilset to read the sensor information from.
      *
      */
-    void createSensorSet(QList<Sensor>& lSensorSet,
+    void createSensorSet(Sensor& sensor,
                          FWDLIB::FwdCoilSet* coils);
 
     //=========================================================================================================
 
-    QList<Sensor>                m_lSensorSet;            /**< lSensorSet */
+    Sensor                m_sensors;            /**< sensors */
 
 private:
     //=========================================================================================================

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -107,7 +107,6 @@ struct HpiFitResult {
     QString                     sFilePathDigitzers;
 };
 
-//=========================================================================================================
 /**
  * The strucut specifing the sensor parameters.
  */
@@ -198,22 +197,13 @@ public:
      * get from Neuromag's MaxFilter.
      *
      *
-<<<<<<< HEAD
-     * @param[in]   time          The corresponding time in the measurement for the fit.
-     * @param[out]  position      The matrix to store the results.
-||||||| constructed merge base
-     * @param[in]   time          The corresponding time in the measurement for the fit.
-     * @param[in]   pFiffInfo     The FiffInfo file from the measurement.
-     * @param[out]  position      The matrix to store the results.
-=======
      * @param[in]   fTime          The corresponding time in the measurement for the fit.
      * @param[in]   pFiffInfo     The FiffInfo file from the measurement.
      * @param[out]  mPosition      The matrix to store the results.
->>>>>>> MAINT: naming conventions
      * @param[in]   vGoF          The goodness of fit for each coil.
      * @param[in]   vError        The Hpi estimation Error per coil.
      *
-     * ToDo: get estimated movement velocity and stroe it in channel 9
+     * ToDo: get estimated movement velocity and store it in channel 9
      */
     static void storeHeadPosition(float fTime,
                                   const Eigen::MatrixXf& transDevHead,
@@ -225,22 +215,10 @@ protected:
     /**
      * Fits dipoles for the given coils and a given data set.
      *
-<<<<<<< HEAD
-     * @param[in] coil            The coil parameters.
-     * @param[in] sensorSet       The sensor information.
-     * @param[in] data            The data which used to fit the coils.
-     * @param[in] numCoils        The number of coils.
-||||||| constructed merge base
-     * @param[in] CoilParam       The coil parameters.
-     * @param[in] sensors         The sensor information.
-     * @param[in] data            The data which used to fit the coils.
-     * @param[in] numCoils        The number of coils.
-=======
      * @param[in] CoilParam       The coil parameters.
      * @param[in] lSensorSet      The sensor information.
      * @param[in] mData           The data which used to fit the coils.
      * @param[in] iNumCoils       The number of coils.
->>>>>>> MAINT: naming conventions
      * @param[in] t_matProjectors The projectors to apply. Bad channels are still included.
      *
      * @return Returns the coil parameters.
@@ -260,14 +238,9 @@ protected:
      *
      * @return Returns the transformation matrix.
      */
-<<<<<<< HEAD
-    static Eigen::Matrix4d computeTransformation(Eigen::MatrixXd NH,
-                                                 Eigen::MatrixXd BT);
-||||||| constructed merge base
-    Eigen::Matrix4d computeTransformation(Eigen::MatrixXd NH, Eigen::MatrixXd BT);
-=======
-    Eigen::Matrix4d computeTransformation(Eigen::MatrixXd mNH, Eigen::MatrixXd mBT);
->>>>>>> MAINT: naming conventions
+
+    Eigen::Matrix4d computeTransformation(Eigen::MatrixXd mNH,
+                                          Eigen::MatrixXd mBT);
 
     //=========================================================================================================
     /**
@@ -278,7 +251,8 @@ protected:
      * @param[in] coils         The coilset to read the sensor information from.
      *
      */
-    void createSensorSet(QList<Sensor>& lSensorSet, FWDLIB::FwdCoilSet* coils);
+    void createSensorSet(QList<Sensor>& lSensorSet,
+                         FWDLIB::FwdCoilSet* coils);
 
     //=========================================================================================================
 

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -70,6 +70,7 @@ namespace FWDLIB{
 
 namespace FIFFLIB{
     class FiffInfo;
+    class FiffChInfo;
     class FiffCoordTrans;
     class FiffDigPointSet;
 }
@@ -194,9 +195,7 @@ public:
                                   const Eigen::MatrixXf& devHeadT,
                                   Eigen::MatrixXd& position,
                                   const Eigen::VectorXd& vGoF,
-                                  const QVector<double>& vError);
-
-
+                                  const QVector<double>& vError);    
 protected:
     //=========================================================================================================
     /**
@@ -241,6 +240,11 @@ protected:
                                 FWDLIB::FwdCoilSet* coils);
 
     //=========================================================================================================
+
+    //=========================================================================================================
+
+    QList<FIFFLIB::FiffChInfo> m_channels;          /**< Channellist */
+    QList<Sensor> m_sensorSet;                      /**< sensorSet */
 
     static QString         m_sHPIResourceDir;      /**< Hold the resource folder to store the debug information in. */
 };

--- a/libraries/inverse/hpiFit/hpifitdata.cpp
+++ b/libraries/inverse/hpiFit/hpifitdata.cpp
@@ -39,7 +39,7 @@
 //=============================================================================================================
 
 #include "hpifitdata.h"
-
+#include "hpifit.h"
 #include <utils/mnemath.h>
 
 #include <algorithm>
@@ -159,7 +159,7 @@ Eigen::MatrixXd HPIFitData::magnetic_dipole(Eigen::MatrixXd pos,
 
 //=============================================================================================================
 
-Eigen::MatrixXd HPIFitData::compute_leadfield(const Eigen::MatrixXd& pos, const struct Sensor& sensor)
+Eigen::MatrixXd HPIFitData::compute_leadfield(const Eigen::MatrixXd& pos, const Sensor& sensor)
 {
 
     Eigen::MatrixXd pnt, ori, lf;

--- a/libraries/inverse/hpiFit/hpifitdata.cpp
+++ b/libraries/inverse/hpiFit/hpifitdata.cpp
@@ -44,6 +44,9 @@
 
 #include <algorithm>
 
+#include <iostream>
+#include <fstream>
+
 //=============================================================================================================
 // EIGEN INCLUDES
 //=============================================================================================================
@@ -53,7 +56,7 @@
 //=============================================================================================================
 
 #include <qmath.h>
-
+#include <QDebug>
 //=============================================================================================================
 // USED NAMESPACES
 //=============================================================================================================
@@ -232,7 +235,7 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
 
     //tolx = tolf = 1e-4;
     // Seok
-    tolx = tolf = 1e-9;
+    tolx = tolf = 1e-7;
 
     switch(display) {
         case 0:
@@ -342,9 +345,18 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
 
         temp2 = tempX2.maxCoeff();
 
+        std::ofstream f_temp1("/autofs/cluster/fusion/rd454/git/mne-cpp/bin/MNE-sample-data/chpi/pos/temp1.txt", std::ios_base::app | std::ios_base::out);
+        f_temp1 << temp1;
+        std::ofstream f_temp2("/autofs/cluster/fusion/rd454/git/mne-cpp/bin/MNE-sample-data/chpi/pos/temp2.txt", std::ios_base::app | std::ios_base::out);
+        f_temp2 << temp2 << ",";
+
         if((temp1 <= tolf) && (temp2 <= tolx)) {
+            f_temp1 << "\n";
+            f_temp2 << "\n";
             break;
         }
+        f_temp1 << ",";
+        f_temp2 << ",";
 
         xbar = v.block(0,0,n,n).rowwise().sum();
         xbar /= n;
@@ -352,7 +364,7 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
         xr = (1+rho) * xbar - rho * v.block(0,n,v.rows(),1);
 
         x = xr.transpose();
-        //std::cout << "Iteration Count: " << itercount << ":" << x << std::endl;
+        // std::cout << "Iteration Count: " << itercount << ":" << x << std::endl;
 
         fxr = dipfitError(x, data, sensorSet, matProjectors);
 
@@ -452,6 +464,9 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
 
     // Seok
     simplex_numitr = itercount;
+
+    std::ofstream result("/autofs/cluster/fusion/rd454/git/mne-cpp/bin/MNE-sample-data/chpi/pos/iter.txt", std::ios_base::app | std::ios_base::out);
+    result << itercount << "\n";
 
     return x;
 }

--- a/libraries/inverse/hpiFit/hpifitdata.cpp
+++ b/libraries/inverse/hpiFit/hpifitdata.cpp
@@ -185,9 +185,8 @@ DipFitError HPIFitData::dipfitError(const Eigen::MatrixXd& pos,
     Eigen::MatrixXd lf(data.size(),3);
     // field vector to store calculated value from averaging np integration points on sensor
     for(int i = 0; i < sensorSet.size(); i++){
-        Sensor sensor = sensorSet[i];
-        lfSensor = compute_leadfield(pos, sensor);
-        lf.row(i) = sensor.w * lfSensor;
+        lfSensor = compute_leadfield(pos, sensorSet[i]);
+        lf.row(i) = sensorSet[i].w * lfSensor;
     }
     // Compute lead field for a magnetic dipole in infinite vacuum
 
@@ -230,7 +229,7 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
 
     DipFitError tempdip, fxr, fxe, fxc, fxcc;
 
-    tolx = tolf = 1e-4;
+    tolx = tolf = 1e-5;
     // Seok
     // tolx = tolf = 1e-9;
 

--- a/libraries/inverse/hpiFit/hpifitdata.cpp
+++ b/libraries/inverse/hpiFit/hpifitdata.cpp
@@ -82,12 +82,12 @@ void HPIFitData::doDipfitConcurrent()
     QList<Sensor> lCurrentSensors = this->lSensorSet;
 
     int iDisplay = 0;
-    int iNaxiter = 500;
+    int iMaxiter = 200;
     int iSimplexNumitr = 0;
 
     this->coilPos = fminsearch(vCurrentCoil,
-                               iNaxiter,
-                               2 * iNaxiter * vCurrentCoil.cols(),
+                               iMaxiter,
+                               2 * iMaxiter * vCurrentCoil.cols(),
                                iDisplay,
                                vCurrentData,
                                this->matProjector,
@@ -212,7 +212,7 @@ bool HPIFitData::compare(HPISortStruct a, HPISortStruct b)
 //=============================================================================================================
 
 Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& mPos,
-                                       int iNaxiter,
+                                       int iMaxiter,
                                        int iMaxfun,
                                        int iDisplay,
                                        const Eigen::MatrixXd& mData,
@@ -323,7 +323,7 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& mPos,
 
     tempX1 = Eigen::MatrixXd::Zero(1,n);
 
-    while ((func_evals < iMaxfun) && (itercount < iNaxiter)) {
+    while ((func_evals < iMaxfun) && (itercount < iMaxiter)) {
 
         for (int i = 0;i < n;i++) {
             tempX1(i) = std::fabs(fv[0] - fv[i+1]);

--- a/libraries/inverse/hpiFit/hpifitdata.cpp
+++ b/libraries/inverse/hpiFit/hpifitdata.cpp
@@ -44,9 +44,6 @@
 
 #include <algorithm>
 
-#include <iostream>
-#include <fstream>
-
 //=============================================================================================================
 // EIGEN INCLUDES
 //=============================================================================================================
@@ -56,7 +53,7 @@
 //=============================================================================================================
 
 #include <qmath.h>
-#include <QDebug>
+
 //=============================================================================================================
 // USED NAMESPACES
 //=============================================================================================================
@@ -235,7 +232,7 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
 
     //tolx = tolf = 1e-4;
     // Seok
-    tolx = tolf = 1e-7;
+    tolx = tolf = 1e-9;
 
     switch(display) {
         case 0:
@@ -345,18 +342,9 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
 
         temp2 = tempX2.maxCoeff();
 
-        std::ofstream f_temp1("/autofs/cluster/fusion/rd454/git/mne-cpp/bin/MNE-sample-data/chpi/pos/temp1.txt", std::ios_base::app | std::ios_base::out);
-        f_temp1 << temp1;
-        std::ofstream f_temp2("/autofs/cluster/fusion/rd454/git/mne-cpp/bin/MNE-sample-data/chpi/pos/temp2.txt", std::ios_base::app | std::ios_base::out);
-        f_temp2 << temp2 << ",";
-
         if((temp1 <= tolf) && (temp2 <= tolx)) {
-            f_temp1 << "\n";
-            f_temp2 << "\n";
             break;
         }
-        f_temp1 << ",";
-        f_temp2 << ",";
 
         xbar = v.block(0,0,n,n).rowwise().sum();
         xbar /= n;
@@ -364,7 +352,7 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
         xr = (1+rho) * xbar - rho * v.block(0,n,v.rows(),1);
 
         x = xr.transpose();
-        // std::cout << "Iteration Count: " << itercount << ":" << x << std::endl;
+        //std::cout << "Iteration Count: " << itercount << ":" << x << std::endl;
 
         fxr = dipfitError(x, data, sensorSet, matProjectors);
 
@@ -464,9 +452,6 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
 
     // Seok
     simplex_numitr = itercount;
-
-    std::ofstream result("/autofs/cluster/fusion/rd454/git/mne-cpp/bin/MNE-sample-data/chpi/pos/iter.txt", std::ios_base::app | std::ios_base::out);
-    result << itercount << "\n";
 
     return x;
 }

--- a/libraries/inverse/hpiFit/hpifitdata.cpp
+++ b/libraries/inverse/hpiFit/hpifitdata.cpp
@@ -230,9 +230,9 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
 
     DipFitError tempdip, fxr, fxe, fxc, fxcc;
 
-    //tolx = tolf = 1e-4;
+    tolx = tolf = 1e-4;
     // Seok
-    tolx = tolf = 1e-9;
+    // tolx = tolf = 1e-9;
 
     switch(display) {
         case 0:

--- a/libraries/inverse/hpiFit/hpifitdata.cpp
+++ b/libraries/inverse/hpiFit/hpifitdata.cpp
@@ -176,7 +176,7 @@ Eigen::MatrixXd HPIFitData::compute_leadfield(const Eigen::MatrixXd& pos, const 
 
 DipFitError HPIFitData::dipfitError(const Eigen::MatrixXd& pos,
                                     const Eigen::MatrixXd& data,
-                                    const QList<Sensor>& sensorSet,
+                                    const QList<struct Sensor>& sensorSet,
                                     const Eigen::MatrixXd& matProjectors)
 {
     // Variable Declaration
@@ -218,7 +218,7 @@ Eigen::MatrixXd HPIFitData::fminsearch(const Eigen::MatrixXd& pos,
                                        int display,
                                        const Eigen::MatrixXd& data,
                                        const Eigen::MatrixXd& matProjectors,
-                                       const QList<Sensor>& sensorSet,
+                                       const QList<struct Sensor>& sensorSet,
                                        int &simplex_numitr)
 {
     double tolx, tolf, rho, chi, psi, sigma, func_evals, usual_delta, zero_term_delta, temp1, temp2;

--- a/libraries/inverse/hpiFit/hpifitdata.h
+++ b/libraries/inverse/hpiFit/hpifitdata.h
@@ -84,18 +84,7 @@ struct DipFitError {
     int numIterations;
 };
 
-//=========================================================================================================
-/**
- * The strucut specifing the sensor parameters.
- */
-struct Sensor {
-    Eigen::RowVector3d r0;
-    Eigen::MatrixXd rmag;
-    Eigen::MatrixXd cosmag;
-    Eigen::MatrixXd tra;
-    Eigen::RowVectorXd w;
-    int np;
-};
+
 
 //=========================================================================================================
 /**
@@ -128,6 +117,19 @@ public:
      * Default constructor.
      */
     explicit HPIFitData();
+
+    //=========================================================================================================
+    /**
+     * The strucut specifing the sensor parameters.
+     */
+    struct Sensor {
+        Eigen::RowVector3d r0;
+        Eigen::MatrixXd rmag;
+        Eigen::MatrixXd cosmag;
+        Eigen::MatrixXd tra;
+        Eigen::RowVectorXd w;
+        int np;
+    };
 
     //=========================================================================================================
     /**

--- a/libraries/inverse/hpiFit/hpifitdata.h
+++ b/libraries/inverse/hpiFit/hpifitdata.h
@@ -174,11 +174,11 @@ protected:
     //=========================================================================================================
     /**
      * fminsearch Multidimensional unconstrained nonlinear minimization (Nelder-Mead).
-     * X = fminsearch(X0, iNaxiter, iMaxfun, iDisplay, mData, lSensorSet) starts at X0 and
+     * X = fminsearch(X0, iMaxiter, iMaxfun, iDisplay, mData, lSensorSet) starts at X0 and
      * attempts to find a local minimizer
      */
     Eigen::MatrixXd fminsearch(const Eigen::MatrixXd& mPos,
-                               int iNaxiter,
+                               int iMaxiter,
                                int iMaxfun,
                                int iDisplay,
                                const Eigen::MatrixXd& mData,

--- a/libraries/inverse/hpiFit/hpifitdata.h
+++ b/libraries/inverse/hpiFit/hpifitdata.h
@@ -128,7 +128,7 @@ public:
     Eigen::MatrixXd         coilPos;
     Eigen::RowVectorXd      sensorData;
     DipFitError             errorInfo;
-    struct Sensor           sensors;
+    struct SensorSet        sensors;
     Eigen::MatrixXd         matProjector;
 
 protected:
@@ -137,21 +137,21 @@ protected:
      * magnetic_dipole leadfield for a magnetic dipole in an infinite medium.
      * The function has been compared with matlab magnetic_dipole and it gives same output.
      */
-    Eigen::MatrixXd magnetic_dipole(Eigen::MatrixXd mPos,
-                                    Eigen::MatrixXd mPnt,
-                                    Eigen::MatrixXd mOri);
+    Eigen::MatrixXd magnetic_dipole(Eigen::MatrixXd matPos,
+                                    Eigen::MatrixXd matPnt,
+                                    Eigen::MatrixXd matOri);
 
     //=========================================================================================================
     /**
      * compute_leadfield computes a forward solution for a dipole in a a volume
      * conductor model. The forward solution is expressed as the leadfield
      * matrix (Nchan*3), where each column corresponds with the potential or field
-     * distributions on all lSensorSet for one of the x,y,z-orientations of the dipole.
+     * distributions on all sensors for one of the x,y,z-orientations of the dipole.
      * The function has been compared with matlab ft_compute_leadfield and it gives
      * same output.
      */
-    Eigen::MatrixXd compute_leadfield(const Eigen::MatrixXd& mPos,
-                                      const struct Sensor& sensor);
+    Eigen::MatrixXd compute_leadfield(const Eigen::MatrixXd& matPos,
+                                      const struct SensorSet& sensors);
 
     //=========================================================================================================
     /**
@@ -160,9 +160,9 @@ protected:
      * The function has been compared with matlab dipfit_error and it gives
      * same output
      */
-    DipFitError dipfitError(const Eigen::MatrixXd& mPos,
-                            const Eigen::MatrixXd& mData,
-                            const struct Sensor& sensors,
+    DipFitError dipfitError(const Eigen::MatrixXd& matPos,
+                            const Eigen::MatrixXd& matData,
+                            const struct SensorSet& sensors,
                             const Eigen::MatrixXd& matProjectors);
 
     //=========================================================================================================
@@ -174,16 +174,16 @@ protected:
     //=========================================================================================================
     /**
      * fminsearch Multidimensional unconstrained nonlinear minimization (Nelder-Mead).
-     * X = fminsearch(X0, iMaxiter, iMaxfun, iDisplay, mData, lSensorSet) starts at X0 and
+     * X = fminsearch(X0, iMaxiter, iMaxfun, iDisplay, matData, sensors) starts at X0 and
      * attempts to find a local minimizer
      */
-    Eigen::MatrixXd fminsearch(const Eigen::MatrixXd& mPos,
+    Eigen::MatrixXd fminsearch(const Eigen::MatrixXd& matPos,
                                int iMaxiter,
                                int iMaxfun,
                                int iDisplay,
-                               const Eigen::MatrixXd& mData,
+                               const Eigen::MatrixXd& matData,
                                const Eigen::MatrixXd& matProjectors,
-                               const struct Sensor& lSensorSet,
+                               const struct SensorSet& sensors,
                                int &iSimplexNumitr);
 };
 

--- a/libraries/inverse/hpiFit/hpifitdata.h
+++ b/libraries/inverse/hpiFit/hpifitdata.h
@@ -128,7 +128,7 @@ public:
     Eigen::MatrixXd         coilPos;
     Eigen::RowVectorXd      sensorData;
     DipFitError             errorInfo;
-    QList<struct Sensor>    lSensorSet;
+    struct Sensor           sensors;
     Eigen::MatrixXd         matProjector;
 
 protected:
@@ -162,7 +162,7 @@ protected:
      */
     DipFitError dipfitError(const Eigen::MatrixXd& mPos,
                             const Eigen::MatrixXd& mData,
-                            const QList<struct Sensor>& lSensorSet,
+                            const struct Sensor& sensors,
                             const Eigen::MatrixXd& matProjectors);
 
     //=========================================================================================================
@@ -183,7 +183,7 @@ protected:
                                int iDisplay,
                                const Eigen::MatrixXd& mData,
                                const Eigen::MatrixXd& matProjectors,
-                               const QList<struct Sensor>& lSensorSet,
+                               const struct Sensor& lSensorSet,
                                int &iSimplexNumitr);
 };
 

--- a/libraries/inverse/hpiFit/hpifitdata.h
+++ b/libraries/inverse/hpiFit/hpifitdata.h
@@ -42,6 +42,7 @@
 //=============================================================================================================
 
 #include "../inverse_global.h"
+#include "hpifit.h"
 
 //=============================================================================================================
 // EIGEN INCLUDES
@@ -120,19 +121,6 @@ public:
 
     //=========================================================================================================
     /**
-     * The strucut specifing the sensor parameters.
-     */
-    struct Sensor {
-        Eigen::RowVector3d r0;
-        Eigen::MatrixXd rmag;
-        Eigen::MatrixXd cosmag;
-        Eigen::MatrixXd tra;
-        Eigen::RowVectorXd w;
-        int np;
-    };
-
-    //=========================================================================================================
-    /**
      * dipfit function is adapted from Fieldtrip Software.
      */
     void doDipfitConcurrent();
@@ -140,7 +128,7 @@ public:
     Eigen::MatrixXd     coilPos;
     Eigen::RowVectorXd  sensorData;
     DipFitError         errorInfo;
-    QList<Sensor>       sensorSet;
+    QList<struct Sensor>       sensorSet;
     Eigen::MatrixXd     matProjector;
 
 protected:
@@ -174,7 +162,7 @@ protected:
      */
     DipFitError dipfitError(const Eigen::MatrixXd& pos,
                             const Eigen::MatrixXd& data,
-                            const QList<Sensor>& sensorSet,
+                            const QList<struct Sensor>& sensorSet,
                             const Eigen::MatrixXd& matProjectors);
 
     //=========================================================================================================
@@ -195,7 +183,7 @@ protected:
                                int display,
                                const Eigen::MatrixXd& data,
                                const Eigen::MatrixXd& matProjectors,
-                               const QList<Sensor>& sensorSet,
+                               const QList<struct Sensor>& sensorSet,
                                int &simplex_numitr);
 };
 

--- a/libraries/inverse/hpiFit/hpifitdata.h
+++ b/libraries/inverse/hpiFit/hpifitdata.h
@@ -125,11 +125,11 @@ public:
      */
     void doDipfitConcurrent();
 
-    Eigen::MatrixXd     coilPos;
-    Eigen::RowVectorXd  sensorData;
-    DipFitError         errorInfo;
-    QList<struct Sensor>       sensorSet;
-    Eigen::MatrixXd     matProjector;
+    Eigen::MatrixXd         coilPos;
+    Eigen::RowVectorXd      sensorData;
+    DipFitError             errorInfo;
+    QList<struct Sensor>    lSensorSet;
+    Eigen::MatrixXd         matProjector;
 
 protected:
     //=========================================================================================================
@@ -137,20 +137,20 @@ protected:
      * magnetic_dipole leadfield for a magnetic dipole in an infinite medium.
      * The function has been compared with matlab magnetic_dipole and it gives same output.
      */
-    Eigen::MatrixXd magnetic_dipole(Eigen::MatrixXd pos,
-                                    Eigen::MatrixXd pnt,
-                                    Eigen::MatrixXd ori);
+    Eigen::MatrixXd magnetic_dipole(Eigen::MatrixXd mPos,
+                                    Eigen::MatrixXd mPnt,
+                                    Eigen::MatrixXd mOri);
 
     //=========================================================================================================
     /**
      * compute_leadfield computes a forward solution for a dipole in a a volume
      * conductor model. The forward solution is expressed as the leadfield
      * matrix (Nchan*3), where each column corresponds with the potential or field
-     * distributions on all sensors for one of the x,y,z-orientations of the dipole.
+     * distributions on all lSensorSet for one of the x,y,z-orientations of the dipole.
      * The function has been compared with matlab ft_compute_leadfield and it gives
      * same output.
      */
-    Eigen::MatrixXd compute_leadfield(const Eigen::MatrixXd& pos,
+    Eigen::MatrixXd compute_leadfield(const Eigen::MatrixXd& mPos,
                                       const struct Sensor& sensor);
 
     //=========================================================================================================
@@ -160,9 +160,9 @@ protected:
      * The function has been compared with matlab dipfit_error and it gives
      * same output
      */
-    DipFitError dipfitError(const Eigen::MatrixXd& pos,
-                            const Eigen::MatrixXd& data,
-                            const QList<struct Sensor>& sensorSet,
+    DipFitError dipfitError(const Eigen::MatrixXd& mPos,
+                            const Eigen::MatrixXd& mData,
+                            const QList<struct Sensor>& lSensorSet,
                             const Eigen::MatrixXd& matProjectors);
 
     //=========================================================================================================
@@ -174,17 +174,17 @@ protected:
     //=========================================================================================================
     /**
      * fminsearch Multidimensional unconstrained nonlinear minimization (Nelder-Mead).
-     * X = fminsearch(X0, maxiter, maxfun, display, data, sensors) starts at X0 and
+     * X = fminsearch(X0, iNaxiter, iMaxfun, iDisplay, mData, lSensorSet) starts at X0 and
      * attempts to find a local minimizer
      */
-    Eigen::MatrixXd fminsearch(const Eigen::MatrixXd& pos,
-                               int maxiter,
-                               int maxfun,
-                               int display,
-                               const Eigen::MatrixXd& data,
+    Eigen::MatrixXd fminsearch(const Eigen::MatrixXd& mPos,
+                               int iNaxiter,
+                               int iMaxfun,
+                               int iDisplay,
+                               const Eigen::MatrixXd& mData,
                                const Eigen::MatrixXd& matProjectors,
-                               const QList<struct Sensor>& sensorSet,
-                               int &simplex_numitr);
+                               const QList<struct Sensor>& lSensorSet,
+                               int &iSimplexNumitr);
 };
 
 //=============================================================================================================

--- a/libraries/rtprocessing/rthpis.h
+++ b/libraries/rtprocessing/rthpis.h
@@ -66,6 +66,7 @@ namespace FIFFLIB {
 }
 
 namespace INVERSELIB {
+    class HPIFit;
     struct HpiFitResult;
 }
 
@@ -99,6 +100,7 @@ public:
     void doWork(const Eigen::MatrixXd& matData,
                 const Eigen::MatrixXd& matProjectors,
                 const QVector<int>& vFreqs,
+                QSharedPointer<INVERSELIB::HPIFit> pHpiFit,
                 QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 
 signals:
@@ -179,7 +181,7 @@ protected:
     void handleResults(const INVERSELIB::HpiFitResult &fitResult);
 
     QSharedPointer<FIFFLIB::FiffInfo>               m_pFiffInfo;           /**< Holds the fiff measurement information. */
-
+    QSharedPointer<INVERSELIB::HPIFit>              m_pHpiFit;              /**< Holds the HpiFit object. */
     QThread             m_workerThread;         /**< The worker thread. */
     QVector<int>        m_vCoilFreqs;           /**< Vector contains the HPI coil frequencies. */
     Eigen::MatrixXd     m_matProjectors;        /**< Holds the matrix with the SSP and compensator projectors.*/
@@ -189,6 +191,7 @@ signals:
     void operate(const Eigen::MatrixXd& matData,
                  const Eigen::MatrixXd& matProjectors,
                  const QVector<int>& vFreqs,
+                 QSharedPointer<INVERSELIB::HPIFit> pHpiFit,
                  QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 };
 

--- a/libraries/rtprocessing/rthpis.h
+++ b/libraries/rtprocessing/rthpis.h
@@ -93,8 +93,7 @@ public:
     /**
      * Creates the real-time HPI worker object.
      *
-     * @param[in] p_pFiffInfo        Associated Fiff Information
-     * @param[in] parent     Parent QObject (optional)
+     * @param[in] pFiffInfo        Associated Fiff Information
      */
     explicit RtHpiWorker(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 

--- a/libraries/rtprocessing/rthpis.h
+++ b/libraries/rtprocessing/rthpis.h
@@ -88,6 +88,16 @@ class RTPROCESINGSHARED_EXPORT RtHpiWorker : public QObject
     Q_OBJECT
 
 public:
+
+    //=========================================================================================================
+    /**
+     * Creates the real-time HPI worker object.
+     *
+     * @param[in] p_pFiffInfo        Associated Fiff Information
+     * @param[in] parent     Parent QObject (optional)
+     */
+    explicit RtHpiWorker(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
+
     //=========================================================================================================
     /**
      * Perform one single HPI fit.
@@ -100,8 +110,11 @@ public:
     void doWork(const Eigen::MatrixXd& matData,
                 const Eigen::MatrixXd& matProjectors,
                 const QVector<int>& vFreqs,
-                QSharedPointer<INVERSELIB::HPIFit> pHpiFit,
                 QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
+
+protected:
+    //=========================================================================================================
+    QSharedPointer<INVERSELIB::HPIFit>              m_pHpiFit;             /**< Holds the HpiFit object. */
 
 signals:
     void resultReady(const INVERSELIB::HpiFitResult &fitResult);
@@ -181,7 +194,6 @@ protected:
     void handleResults(const INVERSELIB::HpiFitResult &fitResult);
 
     QSharedPointer<FIFFLIB::FiffInfo>               m_pFiffInfo;           /**< Holds the fiff measurement information. */
-    QSharedPointer<INVERSELIB::HPIFit>              m_pHpiFit;              /**< Holds the HpiFit object. */
     QThread             m_workerThread;         /**< The worker thread. */
     QVector<int>        m_vCoilFreqs;           /**< Vector contains the HPI coil frequencies. */
     Eigen::MatrixXd     m_matProjectors;        /**< Holds the matrix with the SSP and compensator projectors.*/
@@ -191,7 +203,6 @@ signals:
     void operate(const Eigen::MatrixXd& matData,
                  const Eigen::MatrixXd& matProjectors,
                  const QVector<int>& vFreqs,
-                 QSharedPointer<INVERSELIB::HPIFit> pHpiFit,
                  QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 };
 

--- a/testframes/test_hpiFit/test_hpiFit.cpp
+++ b/testframes/test_hpiFit/test_hpiFit.cpp
@@ -174,6 +174,8 @@ void TestHpiFit::initTestCase()
     QString sHPIResourceDir = QCoreApplication::applicationDirPath() + "/HPIFittingDebug";
     bool bDoDebug = true;
 
+    HPIFit HPI = HPIFit(pFiffInfo);
+
     // bring frequencies into right order
     from = first + mRefPos(0,0)*pFiffInfo->sfreq;
     to = from + quantum;
@@ -183,14 +185,14 @@ void TestHpiFit::initTestCase()
     qInfo() << "[done]";
 
     qInfo() << "Order Frequecies: ...";
-    HPIFit::findOrder(mData,
-                      mProjectors,
-                      pFiffInfo->dev_head_t,
-                      vFreqs,
-                      vError,
-                      vGoF,
-                      fittedPointSet,
-                      pFiffInfo);
+    HPI.findOrder(mData,
+                  mProjectors,
+                  pFiffInfo->dev_head_t,
+                  vFreqs,
+                  vError,
+                  vGoF,
+                  fittedPointSet,
+                  pFiffInfo);
     qInfo() << "[done]";
 
     for(int i = 0; i < mRefPos.rows(); i++) {
@@ -205,16 +207,16 @@ void TestHpiFit::initTestCase()
         }
 
         qInfo()  << "HPI-Fit...";
-        HPIFit::fitHPI(mData,
-                       mProjectors,
-                       pFiffInfo->dev_head_t,
-                       vFreqs,
-                       vError,
-                       vGoF,
-                       fittedPointSet,
-                       pFiffInfo,
-                       bDoDebug = 0,
-                       sHPIResourceDir);
+        HPI.fitHPI(mData,
+                   mProjectors,
+                   pFiffInfo->dev_head_t,
+                   vFreqs,
+                   vError,
+                   vGoF,
+                   fittedPointSet,
+                   pFiffInfo,
+                   bDoDebug = 0,
+                   sHPIResourceDir);
         qInfo() << "[done]\n";
 
         if(MNEMath::compareTransformation(devHeadT.trans, pFiffInfo->dev_head_t.trans, threshRot, threshTrans)) {


### PR DESCRIPTION
This PR adds the frequency ordering to the hpi plugin in mne-scan and improves the performance of the hpi fitting. 

**frequency ordering:**
- add a push button to control panel and implement it into the hpi-plugin

**performance improvement:**
I was able to improve the performance of the hpi fit from **~250 ms** per fit to **~65 ms** per fit on my laptop. I got this improvement by:

- move calculation of everything that only has to be calculated once to the constructor (~225 ms)
- optimize parameters of minimization algorithm fminsearch (~112 ms)
- replace qlist in Sensor Struct with Eigen Matrices (~65 ms)

The result is shown in the following figure, just to give an impression. The values are calculated on one .fif file and all in all ~360 fits were performed. The figure shows the result of each improvement described above.
![Figure_1](https://user-images.githubusercontent.com/40984141/77914568-6a29b300-7296-11ea-8cce-8d5e3496b9ab.png)

**Everything else**
- apply changes in the use of hpifit class everywhere where needed
- apply pedantic naming conventions