### PR TITLE
[FIX, ENH] Fix rt filtering and improve rt averaging control

### DIFF
--- a/applications/mne_scan/libs/scDisp/realtimeevokedsetwidget.cpp
+++ b/applications/mne_scan/libs/scDisp/realtimeevokedsetwidget.cpp
@@ -255,62 +255,62 @@ void RealTimeEvokedSetWidget::init()
         //Init control widgets
         QList<QWidget*> lControlWidgets;
 
-        // Quick control projectors
-        ProjectorsView* pProjectorsView = new ProjectorsView(QString("RTESW/%1").arg(t_sRTESName));
-        pProjectorsView->setObjectName("group_tab_View_SSP");
-        lControlWidgets.append(pProjectorsView);
+//        // Quick control projectors
+//        ProjectorsView* pProjectorsView = new ProjectorsView(QString("RTESW/%1").arg(t_sRTESName));
+//        pProjectorsView->setObjectName("group_tab_View_SSP");
+//        lControlWidgets.append(pProjectorsView);
 
-        connect(pProjectorsView, &ProjectorsView::projSelectionChanged,
-                m_pEvokedSetModel.data(), &EvokedSetModel::updateProjection);
+//        connect(pProjectorsView, &ProjectorsView::projSelectionChanged,
+//                m_pEvokedSetModel.data(), &EvokedSetModel::updateProjection);
 
-        connect(pProjectorsView, &ProjectorsView::projSelectionChanged,
-                m_pButterflyView.data(), &ButterflyView::updateView);
+//        connect(pProjectorsView, &ProjectorsView::projSelectionChanged,
+//                m_pButterflyView.data(), &ButterflyView::updateView);
 
-        pProjectorsView->setProjectors(m_pFiffInfo->projs);
+//        pProjectorsView->setProjectors(m_pFiffInfo->projs);
 
-        // Quick control compensators
-        CompensatorView* pCompensatorView = new CompensatorView(QString("RTESW/%1").arg(t_sRTESName));
-        pCompensatorView->setObjectName("group_tab_View_Comp");
-        lControlWidgets.append(pCompensatorView);
+//        // Quick control compensators
+//        CompensatorView* pCompensatorView = new CompensatorView(QString("RTESW/%1").arg(t_sRTESName));
+//        pCompensatorView->setObjectName("group_tab_View_Comp");
+//        lControlWidgets.append(pCompensatorView);
 
-        connect(pCompensatorView, &CompensatorView::compSelectionChanged,
-                m_pEvokedSetModel.data(), &EvokedSetModel::updateCompensator);
+//        connect(pCompensatorView, &CompensatorView::compSelectionChanged,
+//                m_pEvokedSetModel.data(), &EvokedSetModel::updateCompensator);
 
-        connect(pCompensatorView, &CompensatorView::compSelectionChanged,
-                m_pButterflyView.data(), &ButterflyView::updateView);
+//        connect(pCompensatorView, &CompensatorView::compSelectionChanged,
+//                m_pButterflyView.data(), &ButterflyView::updateView);
 
-        pCompensatorView->setCompensators(m_pFiffInfo->comps);
+//        pCompensatorView->setCompensators(m_pFiffInfo->comps);
 
-        // Quick control filter settings
-        FilterSettingsView* pFilterSettingsView = new FilterSettingsView(QString("RTESW/%1").arg(t_sRTESName));
-        pFilterSettingsView->setObjectName("group_tab_View_Filter");
-        lControlWidgets.append(pFilterSettingsView);
+//        // Quick control filter settings
+//        FilterSettingsView* pFilterSettingsView = new FilterSettingsView(QString("RTESW/%1").arg(t_sRTESName));
+//        pFilterSettingsView->setObjectName("group_tab_View_Filter");
+//        lControlWidgets.append(pFilterSettingsView);
 
-        connect(pFilterSettingsView->getFilterView().data(), &FilterDesignView::filterChannelTypeChanged,
-                m_pEvokedSetModel.data(), &EvokedSetModel::setFilterChannelType);
+//        connect(pFilterSettingsView->getFilterView().data(), &FilterDesignView::filterChannelTypeChanged,
+//                m_pEvokedSetModel.data(), &EvokedSetModel::setFilterChannelType);
 
-        connect(pFilterSettingsView->getFilterView().data(), &FilterDesignView::filterChanged,
-                m_pEvokedSetModel.data(), &EvokedSetModel::setFilter);
+//        connect(pFilterSettingsView->getFilterView().data(), &FilterDesignView::filterChanged,
+//                m_pEvokedSetModel.data(), &EvokedSetModel::setFilter);
 
-        connect(this, &RealTimeEvokedSetWidget::windowSizeChanged,
-                pFilterSettingsView->getFilterView().data(), &FilterDesignView::setWindowSize);
+//        connect(this, &RealTimeEvokedSetWidget::windowSizeChanged,
+//                pFilterSettingsView->getFilterView().data(), &FilterDesignView::setWindowSize);
 
-        connect(this, &RealTimeEvokedSetWidget::windowSizeChanged,
-                pFilterSettingsView->getFilterView().data(), &FilterDesignView::setMaxFilterTaps);
+//        connect(this, &RealTimeEvokedSetWidget::windowSizeChanged,
+//                pFilterSettingsView->getFilterView().data(), &FilterDesignView::setMaxFilterTaps);
 
-        connect(pFilterSettingsView, &FilterSettingsView::filterActivationChanged,
-                m_pEvokedSetModel.data(), &EvokedSetModel::setFilterActive);
+//        connect(pFilterSettingsView, &FilterSettingsView::filterActivationChanged,
+//                m_pEvokedSetModel.data(), &EvokedSetModel::setFilterActive);
 
-        m_pEvokedSetModel->setFilterActive(pFilterSettingsView->getFilterActive());
+//        m_pEvokedSetModel->setFilterActive(pFilterSettingsView->getFilterActive());
 
-        pFilterSettingsView->getFilterView()->init(m_pFiffInfo->sfreq);
+//        pFilterSettingsView->getFilterView()->init(m_pFiffInfo->sfreq);
 
-        if(!m_pRTESet->getValue()->evoked.isEmpty()) {
-            m_iMaxFilterTapSize = m_pRTESet->getValue()->evoked.first().data.cols();
+//        if(!m_pRTESet->getValue()->evoked.isEmpty()) {
+//            m_iMaxFilterTapSize = m_pRTESet->getValue()->evoked.first().data.cols();
 
-            pFilterSettingsView->getFilterView()->setWindowSize(m_iMaxFilterTapSize);
-            pFilterSettingsView->getFilterView()->setMaxFilterTaps(m_iMaxFilterTapSize);
-        }
+//            pFilterSettingsView->getFilterView()->setWindowSize(m_iMaxFilterTapSize);
+//            pFilterSettingsView->getFilterView()->setMaxFilterTaps(m_iMaxFilterTapSize);
+//        }
 
         // Scaling
         ScalingView* pScalingView = new ScalingView(QString("RTESW/%1").arg(t_sRTESName),

--- a/applications/mne_scan/libs/scDisp/realtimemultisamplearraywidget.cpp
+++ b/applications/mne_scan/libs/scDisp/realtimemultisamplearraywidget.cpp
@@ -151,7 +151,7 @@ void RealTimeMultiSampleArrayWidget::init()
         rtmsaLayout->setContentsMargins(0,0,0,0);
         rtmsaLayout->addWidget(m_pChannelDataView);
         this->setLayout(rtmsaLayout);
-        this->setMinimumSize(200,20);
+        this->setMinimumSize(300,50);
 
         // Init channel view
         QSettings settings;

--- a/applications/mne_scan/libs/scDisp/realtimemultisamplearraywidget.cpp
+++ b/applications/mne_scan/libs/scDisp/realtimemultisamplearraywidget.cpp
@@ -151,6 +151,7 @@ void RealTimeMultiSampleArrayWidget::init()
         rtmsaLayout->setContentsMargins(0,0,0,0);
         rtmsaLayout->addWidget(m_pChannelDataView);
         this->setLayout(rtmsaLayout);
+        this->setMinimumSize(200,20);
 
         // Init channel view
         QSettings settings;

--- a/applications/mne_scan/mne_scan/main.cpp
+++ b/applications/mne_scan/mne_scan/main.cpp
@@ -137,9 +137,9 @@ int main(int argc, char *argv[])
 
     splashscreen->finish(&mainWin);
 
-    QSurfaceFormat fmt;
-    fmt.setSamples(10);
-    QSurfaceFormat::setDefaultFormat(fmt);
+//    QSurfaceFormat fmt;
+//    fmt.setSamples(10);
+//    QSurfaceFormat::setDefaultFormat(fmt);
 
     return app.exec();
 }

--- a/applications/mne_scan/mne_scan/main.cpp
+++ b/applications/mne_scan/mne_scan/main.cpp
@@ -137,9 +137,9 @@ int main(int argc, char *argv[])
 
     splashscreen->finish(&mainWin);
 
-//    QSurfaceFormat fmt;
-//    fmt.setSamples(10);
-//    QSurfaceFormat::setDefaultFormat(fmt);
+    QSurfaceFormat fmt;
+    fmt.setSamples(10);
+    QSurfaceFormat::setDefaultFormat(fmt);
 
     return app.exec();
 }

--- a/applications/mne_scan/plugins/babymeg/babymeg.cpp
+++ b/applications/mne_scan/plugins/babymeg/babymeg.cpp
@@ -227,6 +227,10 @@ bool BabyMEG::stop()
     requestInterruption();
     wait(500);
 
+    // Clear all data in the buffer connected to displays and other plugins
+    m_pRTMSABabyMEG->data()->clear();
+    m_pCircularBuffer->clear();
+
     return true;
 }
 

--- a/applications/mne_scan/plugins/brainamp/brainamp.cpp
+++ b/applications/mne_scan/plugins/brainamp/brainamp.cpp
@@ -296,9 +296,9 @@ bool BrainAMP::stop()
     //Stop the producer thread first
     m_pBrainAMPProducer->stop();
 
-    m_pCircularBuffer->clear();
-
+    // Clear all data in the buffer connected to displays and other plugins
     m_pRMTSA_BrainAMP->data()->clear();
+    m_pCircularBuffer->clear();
 
     //Store settings for next use
     QSettings settings;

--- a/applications/mne_scan/plugins/eegosports/eegosports.cpp
+++ b/applications/mne_scan/plugins/eegosports/eegosports.cpp
@@ -580,7 +580,9 @@ bool EEGoSports::stop()
     //Stop the producer thread
     m_pEEGoSportsProducer->stop();
 
+    // Clear all data in the buffer connected to displays and other plugins
     m_pRMTSA_EEGoSports->data()->clear();
+    m_pCircularBuffer->clear();
 
     //Store settings for next use. Do this in stop() since it will crash if we do it in the destructor.
     QSettings settings;

--- a/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.cpp
+++ b/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.cpp
@@ -182,6 +182,7 @@ bool FiffSimulator::stop()
 
     // Clear all data in the buffer connected to displays and other plugins
     m_pRTMSA_FiffSimulator->data()->clear();
+    m_pCircularBuffer->clear();
 
     return true;
 }

--- a/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
@@ -156,7 +156,9 @@ bool FtBuffer::stop()
     m_pFtBuffProducer.clear();
     m_pFtBuffProducer = QSharedPointer<FtBuffProducer>::create(this);
 
+    // Clear all data in the buffer connected to displays and other plugins
     m_pRTMSA_BufferOutput->data()->clear();
+    m_pCircularBuffer->clear();
 
     qInfo() << "[FtBuffer::stop] Stopped.";
     return true;

--- a/applications/mne_scan/plugins/gusbamp/gusbamp.cpp
+++ b/applications/mne_scan/plugins/gusbamp/gusbamp.cpp
@@ -231,9 +231,9 @@ bool GUSBAmp::stop()
     //Stop the producer thread first
     m_pGUSBAmpProducer->stop();
 
-    m_pCircularBuffer->clear();
-
+    // Clear all data in the buffer connected to displays and other plugins
     m_pRTMSA_GUSBAmp->data()->clear();
+    m_pCircularBuffer->clear();
 
     return true;
 }

--- a/applications/mne_scan/plugins/lsladapter/lsladapter.cpp
+++ b/applications/mne_scan/plugins/lsladapter/lsladapter.cpp
@@ -186,9 +186,7 @@ bool LSLAdapter::start()
 
 bool LSLAdapter::stop()
 {
-    // make sure that this thread is completely finished
-    //this->wait();
-    // clear data in RTMSA
+    // Clear all data in the buffer connected to displays and other plugins
     m_pRTMSA->data()->clear();
 
     // stop the producer and wait for it

--- a/applications/mne_scan/plugins/natus/natus.cpp
+++ b/applications/mne_scan/plugins/natus/natus.cpp
@@ -248,7 +248,9 @@ bool Natus::stop()
     requestInterruption();
     wait(500);
 
+    // Clear all data in the buffer connected to displays and other plugins
     m_pRMTSA_Natus->data()->clear();
+    m_pCircularBuffer->clear();
 
     m_pProducerThread.quit();
     m_pProducerThread.wait();

--- a/applications/mne_scan/plugins/rtcmne/rtcmne.h
+++ b/applications/mne_scan/plugins/rtcmne/rtcmne.h
@@ -243,6 +243,9 @@ protected:
     QSharedPointer<FIFFLIB::FiffInfo>                                                       m_pFiffInfo;                /**< Fiff information. */
     QSharedPointer<FIFFLIB::FiffInfo>                                                       m_pFiffInfoInput;           /**< Fiff information of the evoked. */
 
+    bool                            m_bEvokedInput;
+    bool                            m_bRawInput;
+
     QMutex                          m_qMutex;                   /**< The mutex ensuring thread safety. */
     QFuture<void>                   m_future;                   /**< The future monitoring the clustering. */
 

--- a/applications/mne_scan/plugins/rtcmne/rtcmne.h
+++ b/applications/mne_scan/plugins/rtcmne/rtcmne.h
@@ -243,8 +243,8 @@ protected:
     QSharedPointer<FIFFLIB::FiffInfo>                                                       m_pFiffInfo;                /**< Fiff information. */
     QSharedPointer<FIFFLIB::FiffInfo>                                                       m_pFiffInfoInput;           /**< Fiff information of the evoked. */
 
-    bool                            m_bEvokedInput;
-    bool                            m_bRawInput;
+    bool                            m_bEvokedInput;             /**< Flag whether an evoked input was received. */
+    bool                            m_bRawInput;                /**< Flag whether a raw data input was received. */
 
     QMutex                          m_qMutex;                   /**< The mutex ensuring thread safety. */
     QFuture<void>                   m_future;                   /**< The future monitoring the clustering. */

--- a/applications/mne_scan/plugins/tmsi/tmsi.cpp
+++ b/applications/mne_scan/plugins/tmsi/tmsi.cpp
@@ -515,7 +515,9 @@ bool TMSI::stop()
     requestInterruption();
     wait(500);
 
+    // Clear all data in the buffer connected to displays and other plugins
     m_pRMTSA_TMSI->data()->clear();
+    m_pCircularBuffer->clear();
 
     if(m_pTmsiManualAnnotationWidget) {
         m_pTmsiManualAnnotationWidget->hide();

--- a/libraries/disp/viewers/filterdesignview.cpp
+++ b/libraries/disp/viewers/filterdesignview.cpp
@@ -478,7 +478,7 @@ void FilterDesignView::filterParametersChanged()
 
     int fftLength = m_iWindowSize + ui->m_spinBox_filterTaps->value() * 4; // *2 to take into account the overlap in front and back after the convolution. Another *2 to take into account the appended and prepended data.
     int exp = ceil(MNEMath::log2(fftLength));
-    fftLength = pow(2, exp) <512 ? 512 : pow(2, exp);
+    fftLength = pow(2, exp) < 512 ? 512 : pow(2, exp);
 
 //    qDebug() <<"fftLength: "<<fftLength;
 //    qDebug()<<"m_iWindowSize: "<<m_iWindowSize;

--- a/libraries/rtprocessing/rtfilter.h
+++ b/libraries/rtprocessing/rtfilter.h
@@ -101,6 +101,8 @@ public:
      */
     ~RtFilter();
 
+    static void filterChannel(RtFilter::RtFilterData &channelDataTime);
+
     //=========================================================================================================
     /**
      * Calculates the filtered version of the raw input data


### PR DESCRIPTION
This PR includes:

 - Fix rt filtering problem where timings of channels, which were not filtered, were mismatched with the rest of the data
 - Remove noise reduction tools in rt averaging control GUI
 - Fix data handling in source loc plugin
 - Clear buffers after stopping sensor plugins 
 - Impose minimum size for the rt raw data display
 - Define `RtFilter::filterChannel()` as static instead of global