### PR TITLE
[ENH] Add advanced model for hpi fit

### DIFF
--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
     parser.setApplicationDescription("hpiFit Example");
     parser.addHelpOption();
     qInfo() << "Please download the mne-cpp-test-data folder from Github (mne-tools) into mne-cpp/bin.";
-    QCommandLineOption inputOption("fileIn", "The input file <in>.", "in", QCoreApplication::applicationDirPath() + "/mne-cpp-test-data/MEG/sample/test_hpiFit_raw.fif");
+    QCommandLineOption inputOption("fileIn", "The input file <in>.", "in", QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/raw/data_with_movement_chpi_raw.fif");
 
     parser.addOption(inputOption);
 

--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
     parser.setApplicationDescription("hpiFit Example");
     parser.addHelpOption();
     qInfo() << "Please download the mne-cpp-test-data folder from Github (mne-tools) into mne-cpp/bin.";
-    QCommandLineOption inputOption("fileIn", "The input file <in>.", "in", QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/raw/data_with_movement_chpi_raw.fif");
+    QCommandLineOption inputOption("fileIn", "The input file <in>.", "in", QCoreApplication::applicationDirPath() + "/mne-cpp-test-data/MEG/sample/test_hpiFit_raw.fif");
 
     parser.addOption(inputOption);
 
@@ -121,19 +121,20 @@ int main(int argc, char *argv[])
     fiff_int_t first = raw.first_samp;
     fiff_int_t last = raw.last_samp;
 
-    float dTSec = 0.1;             // time between hpi fits
     float fQuantumSec = 0.2f;       // read and write in 200 ms junks
     fiff_int_t iQuantum = ceil(fQuantumSec*pFiffInfo->sfreq);
 
     // create time vector that specifies when to fit
-    int iN = ceil((last-first)/iQuantum);
+    float dTSec = 0.1;                              // time between hpi fits
+    int iQuantumT = floor(dTSec*pFiffInfo->sfreq);   // samples between fits
+    int iN = floor((last-first)/iQuantumT);
     RowVectorXf vecTime = RowVectorXf::LinSpaced(iN, 0, iN-1) * dTSec;
 
     // To fit at specific times outcommend the following block
     // Read Quaternion File
 //    MatrixXd matPos;
 //    qInfo() << "Specify the path to your Position file (.txt)";
-//    IOUtils::read_eigen_matrix(matPos, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/posMax_data_with_movement_chpi.txt");
+//    IOUtils::read_eigen_matrix(matPos, QCoreApplication::applicationDirPath() + "/mne-cpp-test-data/Result/ref_hpiFit_pos.txt");
 //    RowVectorXd vecTime = matPos.col(0);
 
     MatrixXd matPosition;              // matPosition matrix to save quaternions etc.
@@ -234,5 +235,5 @@ int main(int argc, char *argv[])
             qInfo() << "dev_head_t has been updated.";
         }
     }
-    //IOUtils::write_eigen_matrix(matPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/chpi/pos/position.txt");
+    // IOUtils::write_eigen_matrix(matPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/position.txt");
 }

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -136,7 +136,7 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
 
     // check if we have to update the model
     if(m_bUpdateModel) {
-        updateModel(pFiffInfo->sfreq,t_mat.cols(),/*pFiffInfo->linefreq*/ 60 ,vecFreqs);
+        updateModel(pFiffInfo->sfreq,t_mat.cols(),pFiffInfo->linefreq,vecFreqs);
     }
 
     // Make sure the fitted digitzers are empty
@@ -396,7 +396,7 @@ void HPIFit::findOrder(const MatrixXd& t_mat,
         vecFreqTemp.fill(vecFreqs[i]);
 
         // update model and hpi Fit
-        updateModel(pFiffInfo->sfreq,t_mat.cols(),/*pFiffInfo->linefreq*/ 60 ,vecFreqTemp);
+        updateModel(pFiffInfo->sfreq,t_mat.cols(),pFiffInfo->linefreq,vecFreqTemp);
         fitHPI(t_mat, t_matProjectors, transDevHeadTemp, vecFreqTemp, vecErrorTemp, vecGoFTemp, fittedPointSetTemp, pFiffInfoTemp);
 
         // get location of maximum GoF -> correct assignment of coil - frequency
@@ -410,17 +410,17 @@ void HPIFit::findOrder(const MatrixXd& t_mat,
         fittedPointSetTemp = fittedPointSet;
         pFiffInfoTemp = pFiffInfo;
         transDevHeadTemp = transDevHead;
+
         if(bIdentity) {
             transDevHeadTemp.trans(3,0) = 0.000001;
         }
-
         vecErrorTemp = vecError;
         vecGoFTemp = vecGoF;
     }
     // check if still all frequencies are represented and update model
     if(std::accumulate(vecFreqs.begin(), vecFreqs.end(), .0) ==  std::accumulate(vecToOrder.begin(), vecToOrder.end(), .0)) {
         vecFreqs = vecToOrder;
-        updateModel(pFiffInfo->sfreq,t_mat.cols(),/*pFiffInfo->linefreq*/ 60 ,vecFreqs);
+        updateModel(pFiffInfo->sfreq,t_mat.cols(),pFiffInfo->linefreq,vecFreqs);
     } else {
         qWarning() << "HPIFit::findOrder: frequencie ordering went wrong";
     }

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -285,8 +285,7 @@ private:
 
     //=========================================================================================================
     /**
-     * Read from FwdCoilSet and store into sensors struct.
-     * Can be deleted as soon as FwdCoilSet is refactored to QList and EigenMatrix.
+     * Update the model of sinoids for the hpi data
      *
      * @param[in] iSamF             The sample frequency.
      * @param[in] iSamLoc           The minimum samples required to localize numLoc times in a second
@@ -303,7 +302,8 @@ private:
 
     Eigen::MatrixXd     m_matModel;         /**< The model that contains the sines/cosines for the hpi fit*/
     bool                m_bDoFastFit;       /**< Do fast fit */
-    bool                m_bUpdateModel;     /**< indicates if Model has to be updated */
+
+    QVector<int>        m_vecFreqs;         /**< The frequencies for each coil in unknown order. */
 
 };
 

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -243,7 +243,6 @@ protected:
      *
      * @return Returns the transformation matrix.
      */
-
     Eigen::Matrix4d computeTransformation(Eigen::MatrixXd matNH,
                                           Eigen::MatrixXd matBT);
 
@@ -280,7 +279,7 @@ private:
     void updateChannels(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
 
     QList<FIFFLIB::FiffChInfo>   m_lChannels;             /**< Channellist with bads excluded */
-    QVector<int>                 m_vInnerind;             /**< index of inner channels  */
+    QVector<int>                 m_vecInnerind;           /**< index of inner channels  */
     QList<QString>               m_lBads;                 /**< contains bad channels  */
 
     //=========================================================================================================
@@ -294,7 +293,6 @@ private:
      *
      * @return The updated model
      */
-
     void updateModel(const int iSamF,
                      const int iSamLoc,
                      const int iLineF,

--- a/libraries/inverse/hpiFit/hpifit.h
+++ b/libraries/inverse/hpiFit/hpifit.h
@@ -140,8 +140,12 @@ public:
     //=========================================================================================================
     /**
      * Default constructor.
+     *
+     * @param[in] pFiffInfo        Associated Fiff Information
+     * @param[in] bDoFastFit       Do the fast fit by fitting to the more basic Model
      */
-    explicit HPIFit(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo);
+    explicit HPIFit(QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo,
+                    bool bDoFastFit = true);
 
     //=========================================================================================================
     /**
@@ -255,8 +259,6 @@ protected:
     void createSensorSet(SensorSet& sensors,
                          FWDLIB::FwdCoilSet* coils);
 
-    //=========================================================================================================
-
     SensorSet                m_sensors;            /**< sensor struct that contains information about all sensors */
 
 private:
@@ -280,6 +282,28 @@ private:
     QList<FIFFLIB::FiffChInfo>   m_lChannels;             /**< Channellist with bads excluded */
     QVector<int>                 m_vInnerind;             /**< index of inner channels  */
     QList<QString>               m_lBads;                 /**< contains bad channels  */
+
+    //=========================================================================================================
+    /**
+     * Read from FwdCoilSet and store into sensors struct.
+     * Can be deleted as soon as FwdCoilSet is refactored to QList and EigenMatrix.
+     *
+     * @param[in] iSamF             The sample frequency.
+     * @param[in] iSamLoc           The minimum samples required to localize numLoc times in a second
+     * @param[in] iLineF            The line frequency.
+     * @param[in] vecFreqs          The frequencies for each coil in unknown order.
+     *
+     * @return The updated model
+     */
+
+    void updateModel(const int iSamF,
+                     const int iSamLoc,
+                     const int iLineF,
+                     const QVector<int>& vecFreqs);
+
+    Eigen::MatrixXd     m_matModel;         /**< The model that contains the sines/cosines for the hpi fit*/
+    bool                m_bDoFastFit;       /**< Do fast fit */
+    bool                m_bUpdateModel;     /**< indicates if Model has to be updated */
 
 };
 


### PR DESCRIPTION
This PR adds an advanced model for the sinoides by adding line frequency and harmonics, linear componend and DC componend . This is implemented as extra mode, so you have to choose it when initializing the constructor. Per default, the fast and basic model is used. 
