### PR TITLE
[FIX] Fix FiffSimulator crashes

### DIFF
--- a/applications/mne_scan/plugins/fiffsimulator/fiffsimulatorproducer.cpp
+++ b/applications/mne_scan/plugins/fiffsimulator/fiffsimulatorproducer.cpp
@@ -146,7 +146,7 @@ void FiffSimulatorProducer::run()
     connectDataClient(m_pFiffSimulator->m_sFiffSimulatorIP);
 
     qint32 count = 0;
-    while(m_pRtDataClient->state() != QTcpSocket::ConnectedState) {
+    while(!isInterruptionRequested() && m_pRtDataClient->state() != QTcpSocket::ConnectedState) {
         msleep(100);
         this->connectDataClient(m_pFiffSimulator->m_sFiffSimulatorIP);
         ++count;


### PR DESCRIPTION
Fix crashes relating to the FiffSimulator plugin in MNE Scan introduced by initializing some pointer too late.