### PR TITLE
[FIX] Fix default ports in FiffSimulator plugin

### DIFF
--- a/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.cpp
+++ b/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.cpp
@@ -83,7 +83,7 @@ FiffSimulator::FiffSimulator()
 , m_iBufferSize(-1)
 , m_pCircularBuffer(QSharedPointer<CircularBuffer_Matrix_float>(new CircularBuffer_Matrix_float(40)))
 , m_pRtCmdClient(QSharedPointer<RtCmdClient>::create())
-, m_iDefaultPort(4217)
+, m_iDefaultPortCmdClient(4217)
 {
     //init channels when fiff info is available
     connect(this, &FiffSimulator::fiffInfoAvailable,
@@ -277,7 +277,7 @@ void FiffSimulator::connectCmdClient()
         m_pFiffSimulatorProducer->start();
     }
 
-    m_pRtCmdClient->connectToHost(m_sFiffSimulatorIP,m_iDefaultPort);
+    m_pRtCmdClient->connectToHost(m_sFiffSimulatorIP, m_iDefaultPortCmdClient);
     m_pRtCmdClient->waitForConnected(1000);
 
     if(m_pRtCmdClient->state() == QTcpSocket::ConnectedState)
@@ -343,9 +343,9 @@ void FiffSimulator::requestInfo()
         (*m_pRtCmdClient)["measinfo"].pValues()[0].setValue(m_pFiffSimulatorProducer->m_iDataClientId);
         (*m_pRtCmdClient)["measinfo"].send();
 
-        m_pFiffSimulatorProducer->producerMutex.lock();
+        m_pFiffSimulatorProducer->m_producerMutex.lock();
         m_pFiffSimulatorProducer->m_bFlagInfoRequest = true;
-        m_pFiffSimulatorProducer->producerMutex.unlock();
+        m_pFiffSimulatorProducer->m_producerMutex.unlock();
     } else {
         qWarning() << "FiffSimulatorProducer is not connected!";
     }

--- a/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.h
+++ b/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.h
@@ -201,13 +201,14 @@ protected:
 
     qint32                  m_iActiveConnectorId;           /**< The active connector.*/
     qint32                  m_iBufferSize;                  /**< The raw data buffer size.*/
+    quint16                 m_iDefaultPortCmdClient;        /**< The default port for the rt command client. */
 
     QMap<qint32, QString>   m_qMapConnectors;               /**< Connector map.*/
 
     QTimer                  m_cmdConnectionTimer;           /**< Timer for convinient command client connection. When timer times out a connection is tried to be established. */
 
-    QMutex                  m_qMutex;
-    quint16                 m_iDefaultPort;
+    QMutex                  m_qMutex;                       /**< The mutex to ensure thread safety.*/
+
 signals:
     //=========================================================================================================
     /**

--- a/applications/mne_scan/plugins/fiffsimulator/fiffsimulatorproducer.h
+++ b/applications/mne_scan/plugins/fiffsimulator/fiffsimulatorproducer.h
@@ -132,16 +132,17 @@ protected:
     virtual void run();
 
 private:
-
-    QMutex producerMutex;
-
-    FiffSimulator*  m_pFiffSimulator;                               /**< Holds a pointer to corresponding MneRtClient.*/
+    QMutex                  m_producerMutex;                        /**< The mutex to ensure thread safety.*/
 
     QSharedPointer<COMMUNICATIONLIB::RtDataClient> m_pRtDataClient; /**< The data client.*/
-    bool                    m_bDataClientIsConnected;                                  /**< If the data client is connected.*/
-    qint32                  m_iDataClientId;
-    bool                    m_bFlagInfoRequest;    /**< Read Fiff Info flag */
-    quint16                 m_iDefaultPort;
+
+    FiffSimulator*          m_pFiffSimulator;                       /**< Holds a pointer to corresponding MneRtClient.*/
+
+    bool                    m_bDataClientIsConnected;               /**< If the data client is connected.*/
+    bool                    m_bFlagInfoRequest;                     /**< Read Fiff Info flag */
+
+    qint32                  m_iDataClientId;                        /**< The client id */
+    quint16                 m_iDefaultPortDataClient;               /**< The default port for the rt data client. */
 };
 } // NAMESPACE
 

--- a/libraries/communication/rtClient/rtcmdclient.cpp
+++ b/libraries/communication/rtClient/rtcmdclient.cpp
@@ -61,8 +61,8 @@ using namespace COMMUNICATIONLIB;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-RtCmdClient::RtCmdClient(QObject *parent) :
-        QTcpSocket(parent)
+RtCmdClient::RtCmdClient(QObject *parent)
+: QTcpSocket(parent)
 {
     QObject::connect(&m_commandManager, &CommandManager::triggered, this,
             &RtCmdClient::sendCommandJSON);


### PR DESCRIPTION
This PR includes:

- Fix missing default port for rt data clients (port = 4218)
- Add some documentation and enforce coding conventions
- Improve operator precedence as pointed out by @juangpc 