### PR TITLE
[MAINT] Add libbluetooth3 install to Linux workflow

### DIFF
--- a/.github/workflows/devbuilds.yml
+++ b/.github/workflows/devbuilds.yml
@@ -87,6 +87,7 @@ jobs:
         cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. lib/
         # Install libxkbcommon so linuxdeployqt can find it
         sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libbluetooth3
         # Downloading linuxdeployqt from continious release
         wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
         sudo chmod a+x linuxdeployqt-continuous-x86_64.AppImage


### PR DESCRIPTION
The devbuilds workflow is currently failing due to linuxdeployqt not finding libbluetooth3, which was introduced during the last PR #562. This PR should fix it.