### PR TITLE
[MAINT,DOCU] Fix static windows builds and add them to CI

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -25,7 +25,7 @@ jobs:
           COVERITY_SCAN_NOTIFICATION_EMAIL="lorenzesch@hotmail.com,gbmotta@mgh.harvard.edu"
           COVERITY_SCAN_BRANCH_PATTERN="master"
           COVERITY_SCAN_BUILD_COMMAND_PREPEND="qmake -r MNECPP_CONFIG+=noTests"
-          COVERITY_SCAN_BUILD_COMMAND="make -j2"
+          COVERITY_SCAN_BUILD_COMMAND="make -j4"
           COVERITY_SCAN_TOKEN=$COVTOKEN
           PLATFORM=`uname`
           TOOL_ARCHIVE=/tmp/cov-analysis-${PLATFORM}.tgz

--- a/.github/workflows/devbuilds.yml
+++ b/.github/workflows/devbuilds.yml
@@ -3,258 +3,130 @@ name: Linux|Win|MacOS
 on:
   push:
     branches:
-    - master
+    - static
 
 jobs:
-  UpdateDevTag:
-    runs-on: ubuntu-16.04
+  # UpdateDevTag:
+  #   runs-on: ubuntu-16.04
     
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2  
-    - name: Install hub
-      uses: geertvdc/setup-hub@master
-    - name: Setup Github credentials
-      uses: fusion-engineering/setup-git-credentials@v2
-      with:
-        credentials: ${{secrets.GIT_CREDENTIALS}}
-    - name: Update dev_build tag and release
-      env:
-        GITHUB_USER: LorenzE
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      run: |
-        git config --global user.email lorenzesch@hotmail.com
-        git config --global user.name $GITHUB_USER
-        # Delete current dev_build release remotley. 
-        # Must be done before deleting the remote tag associated with the dev_build release. 
-        # This prevents a draft release to be left over after we delete the tag remotley. 
-        hub release delete dev_build
-        # Delete current tag remotley
-        git push origin :refs/tags/dev_build
-        # Change dev_build tag to point to newest commit
-        git tag dev_build -f -a -m "Development Builds"
-        # Send the new tag
-        git push -f --tag
-        # Create new dev_build release
-        hub release create -m "Development Builds" dev_build --prerelease
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2  
+  #   - name: Install hub
+  #     uses: geertvdc/setup-hub@master
+  #   - name: Setup Github credentials
+  #     uses: fusion-engineering/setup-git-credentials@v2
+  #     with:
+  #       credentials: ${{secrets.GIT_CREDENTIALS}}
+  #   - name: Update dev_build tag and release
+  #     env:
+  #       GITHUB_USER: LorenzE
+  #       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  #     run: |
+  #       git config --global user.email lorenzesch@hotmail.com
+  #       git config --global user.name $GITHUB_USER
+  #       # Delete current dev_build release remotley. 
+  #       # Must be done before deleting the remote tag associated with the dev_build release. 
+  #       # This prevents a draft release to be left over after we delete the tag remotley. 
+  #       hub release delete dev_build
+  #       # Delete current tag remotley
+  #       git push origin :refs/tags/dev_build
+  #       # Change dev_build tag to point to newest commit
+  #       git tag dev_build -f -a -m "Development Builds"
+  #       # Send the new tag
+  #       git push -f --tag
+  #       # Create new dev_build release
+  #       hub release create -m "Development Builds" dev_build --prerelease
 
-  LinuxStatic:
-    runs-on: ubuntu-16.04
-    needs: UpdateDevTag
+  # LinuxStatic:
+  #   runs-on: ubuntu-16.04
+  #   needs: UpdateDevTag
     
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Compile static Qt version
-      run: |
-        # Install OpenGL
-        sudo apt-get install build-essential libgl1-mesa-dev
-        # Clone Qt5 repo
-        cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
-        cd qt5
-        ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
-        # Create shadow build folder
-        cd ..
-        mkdir qt5_shadow
-        cd qt5_shadow
-        # Configure Qt5
-        ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
-        make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
-        make install -j2
-    - name: Configure and compile MNE-CPP
-      run: |
-        ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
-        make -j2
-    - name: Package binaries
-      run: |
-        # Delete folders which we do not want to ship
-        rm -r bin/mne_rt_server_plugins
-        rm -r bin/mne_scan_plugins
-        # Creating archive of everything in the bin directory
-        tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/.
-    - name: Deploy binaries with dev_build release on Github
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GH_TOKEN }}
-        file: mne-cpp-linux-static-x86_64.tar.gz
-        asset_name: mne-cpp-linux-static-x86_64.tar.gz
-        tag: dev_build
-        overwrite: true
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Compile static Qt version
+  #     run: |
+  #       # Install OpenGL
+  #       sudo apt-get install build-essential libgl1-mesa-dev
+  #       # Clone Qt5 repo
+  #       cd ..
+  #       git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+  #       cd qt5
+  #       ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+  #       # Create shadow build folder
+  #       cd ..
+  #       mkdir qt5_shadow
+  #       cd qt5_shadow
+  #       # Configure Qt5
+  #       ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
+  #       make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
+  #       make install -j2
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
+  #       make -j2
+  #   - name: Package binaries
+  #     run: |
+  #       # Delete folders which we do not want to ship
+  #       rm -r bin/mne_rt_server_plugins
+  #       rm -r bin/mne_scan_plugins
+  #       # Creating archive of everything in the bin directory
+  #       tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/.
+  #   - name: Deploy binaries with dev_build release on Github
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GH_TOKEN }}
+  #       file: mne-cpp-linux-static-x86_64.tar.gz
+  #       asset_name: mne-cpp-linux-static-x86_64.tar.gz
+  #       tag: dev_build
+  #       overwrite: true
 
-  MacOSStatic:
-    runs-on: macos-latest
-    needs: UpdateDevTag
+  # MacOSStatic:
+  #   runs-on: macos-latest
+  #   needs: UpdateDevTag
     
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Compile static Qt version
-      run: |
-        # Clone Qt5 repo
-        cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
-        cd qt5
-        ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
-        # Create shadow build folder
-        cd ..
-        mkdir qt5_shadow
-        cd qt5_shadow
-        # Configure Qt5
-        ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
-        make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
-        make install -j2
-    - name: Configure and compile MNE-CPP
-      run: |
-        ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
-        make -j2
-    - name: Package binaries
-      run: |
-        # Delete folders which we do not want to ship
-        rm -r bin/mne_rt_server_plugins
-        rm -r bin/mne_scan_plugins
-        # Creating archive of all macos deployed applications
-        tar cfvz mne-cpp-macos-static-x86_64.tar.gz bin/.
-    - name: Deploy MNE Scan binaries with dev_build release on Github
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GH_TOKEN }}
-        file: mne-cpp-macos-static-x86_64.tar.gz
-        asset_name: mne-cpp-macos-static-x86_64.tar.gz
-        tag: dev_build
-        overwrite: true
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Compile static Qt version
+  #     run: |
+  #       # Clone Qt5 repo
+  #       cd ..
+  #       git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+  #       cd qt5
+  #       ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+  #       # Create shadow build folder
+  #       cd ..
+  #       mkdir qt5_shadow
+  #       cd qt5_shadow
+  #       # Configure Qt5
+  #       ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
+  #       make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
+  #       make install -j2
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
+  #       make -j2
+  #   - name: Package binaries
+  #     run: |
+  #       # Delete folders which we do not want to ship
+  #       rm -r bin/mne_rt_server_plugins
+  #       rm -r bin/mne_scan_plugins
+  #       # Creating archive of all macos deployed applications
+  #       tar cfvz mne-cpp-macos-static-x86_64.tar.gz bin/.
+  #   - name: Deploy MNE Scan binaries with dev_build release on Github
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GH_TOKEN }}
+  #       file: mne-cpp-macos-static-x86_64.tar.gz
+  #       asset_name: mne-cpp-macos-static-x86_64.tar.gz
+  #       tag: dev_build
+  #       overwrite: true
 
-  LinuxDynamic:
-    runs-on: ubuntu-16.04
-    needs: UpdateDevTag
-    
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Install Python 3.7 version
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-        architecture: 'x64'
-    - name: Install BrainFlow and LSL submodules
-      run: |
-        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
-        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2
-      with:
-        version: 5.14.2
-        modules: qtcharts
-    - name: Compile BrainFlow submodule
-      run: |
-        cd applications/mne_scan/plugins/brainflowboard/brainflow
-        mkdir build
-        cd build
-        cmake -DCMAKE_INSTALL_PREFIX=../installed ..
-        make
-        make install
-    - name: Compile LSL submodule
-      run: |
-        cd applications/mne_scan/plugins/lsladapter/liblsl
-        mkdir build
-        cd build
-        cmake ..
-        make
-        make install
-    - name: Configure and compile MNE-CPP
-      run: |
-        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-        make -j2
-    - name: Package binaries
-      run: |
-        # Copy additional brainflow libs
-        cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. lib/
-        # Copy additional LSL libs
-        cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. lib/
-        # Install libxkbcommon and libbluetooth3 so linuxdeployqt can find it
-        sudo apt-get install libxkbcommon-x11-0
-        sudo apt-get install libbluetooth3
-        # Downloading linuxdeployqt from continious release
-        wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-        sudo chmod a+x linuxdeployqt-continuous-x86_64.AppImage
-        # Creating a directory for linuxdeployqt to create results 
-        sudo mkdir -p -m777 mne-cpp
-        # Copying built data to folder for easy packaging   
-        cp -r ./bin ./lib mne-cpp/
-        # linuxdeployqt uses mne_scan binary to resolve dependencies in current directory. 
-        cd mne-cpp
-        ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2
-        # Creating archive of everything in current directory
-        tar cfvz ../mne-cpp-linux-dynamic-x86_64.tar.gz ./*
-    - name: Deploy binaries with dev_build release on Github
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GH_TOKEN }}
-        file: mne-cpp-linux-dynamic-x86_64.tar.gz
-        asset_name: mne-cpp-linux-dynamic-x86_64.tar.gz
-        tag: dev_build
-        overwrite: true
-
-  MacOSDynamic:
-    runs-on: macos-latest
-    needs: UpdateDevTag
-
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Install Python 3.7 version
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-        architecture: 'x64'
-    - name: Install BrainFlow and LSL submodules
-      run: |
-        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
-        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2
-      with:
-        version: 5.14.2
-        modules: qtcharts
-    - name: Compile BrainFlow submodule 
-      run: |
-        mkdir applications/mne_scan/plugins/brainflowboard/brainflow/build
-        cd applications/mne_scan/plugins/brainflowboard/brainflow/build
-        cmake -DCMAKE_INSTALL_PREFIX=../installed ..
-        make
-        make install
-    - name: Compile LSL submodule
-      run: |
-        cd applications/mne_scan/plugins/lsladapter/liblsl
-        mkdir build
-        cd build
-        cmake ..
-        make
-        make install
-    - name: Configure and compile MNE-CPP
-      run: |
-        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-        make -j2
-    - name: Package binaries
-      run: |
-        # Copy additional brainflow libs
-        cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. bin/mne_scan.app/Contents/Frameworks
-        # Copy additional LSL libs
-        cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. bin/mne_scan.app/Contents/Frameworks
-        # Creating archive of all macos deployed applications
-        tar cfvz mne-cpp-macos-dynamic-x86_64.tar.gz bin/. lib/.
-    - name: Deploy MNE Scan binaries with dev_build release on Github
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GH_TOKEN }}
-        file: mne-cpp-macos-dynamic-x86_64.tar.gz
-        asset_name: mne-cpp-macos-dynamic-x86_64.tar.gz
-        tag: dev_build
-        overwrite: true
-
-  WinDynamic:
+  WinStatic:
     runs-on: windows-2016
-    needs: UpdateDevTag
+  #  needs: UpdateDevTag
 
     steps:
     - name: Clone repository
@@ -263,169 +135,353 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: '3.7'
-        architecture: 'x64'   
-    - name: Install BrainFlow and LSL submodules
-      run: |
-        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
-        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2
-      with:
-        version: 5.14.2
-        arch: win64_msvc2017_64
-        modules: qtcharts
+        architecture: 'x64'
     - name: Install jom (Windows)
       run: |
         Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
         echo "::add-path::$HOME\jom"
-    - name: Compile BrainFlow submodule
+    - name: Compile static Qt version
       run: |
-        cd applications\mne_scan\plugins\brainflowboard\brainflow
-        mkdir build
-        cd build
-        cmake -G "Visual Studio 15 2017" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
-        cmake --build . --target install --config Release
-    - name: Compile LSL submodule
-      run: |
-        cd applications\mne_scan\plugins\lsladapter\liblsl
-        mkdir build
-        cd build
-        cmake .. -G "Visual Studio 15 2017" -A x64
-        cmake --build . --config Release --target install
+        # Clone Qt5 repo
+        cd ..
+        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        cd qt5
+        perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+        # Create shadow build folder
+        cd ..
+        mkdir qt5_shadow
+        cd qt5_shadow
+        # Setup the compiler 
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+        # Configure Qt5
+        ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
+        jom -j2
+        nmake install
     - name: Configure and compile MNE-CPP
       run: |
         cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
-        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
         jom -j2
     - name: Package binaries
       run: |
-        # Copy additional brainflow libs
-        xcopy .\applications\mne_scan\plugins\brainflowboard\brainflow\installed\lib\* .\bin\ /s /i
-        # Copy additional LSL libs
-        xcopy .\applications\mne_scan\plugins\lsladapter\liblsl\build\install\bin\lsl.dll .\bin\ /i
-        7z a mne-cpp-windows-dynamic-x86_64.zip ./bin
+        # Delete folders which we do not want to ship
+        Remove-Item 'bin/mne_rt_server_plugins' -Recurse
+        Remove-Item 'bin/mne_scan_plugins' -Recurse
+        7z a mne-cpp-windows-static-x86_64.zip ./bin
     - name: Deploy binaries with dev_build release on Github
       uses: svenstaro/upload-release-action@v1-release
       with:
         repo_token: ${{ secrets.GH_TOKEN }}
-        file: mne-cpp-windows-dynamic-x86_64.zip
-        asset_name: mne-cpp-windows-dynamic-x86_64.zip
+        file: mne-cpp-windows-static-x86_64.zip
+        asset_name: mne-cpp-windows-static-x86_64.zip
         tag: dev_build
         overwrite: true
+
+  # LinuxDynamic:
+  #   runs-on: ubuntu-16.04
+  #   needs: UpdateDevTag
+    
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Install Python 3.7 version
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: '3.7'
+  #       architecture: 'x64'
+  #   - name: Install BrainFlow and LSL submodules
+  #     run: |
+  #       git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+  #       git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+  #   - name: Install Qt
+  #     uses: jurplel/install-qt-action@v2
+  #     with:
+  #       version: 5.14.2
+  #       modules: qtcharts
+  #   - name: Compile BrainFlow submodule
+  #     run: |
+  #       cd applications/mne_scan/plugins/brainflowboard/brainflow
+  #       mkdir build
+  #       cd build
+  #       cmake -DCMAKE_INSTALL_PREFIX=../installed ..
+  #       make
+  #       make install
+  #   - name: Compile LSL submodule
+  #     run: |
+  #       cd applications/mne_scan/plugins/lsladapter/liblsl
+  #       mkdir build
+  #       cd build
+  #       cmake ..
+  #       make
+  #       make install
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+  #       make -j2
+  #   - name: Package binaries
+  #     run: |
+  #       # Copy additional brainflow libs
+  #       cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. lib/
+  #       # Copy additional LSL libs
+  #       cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. lib/
+  #       # Install libxkbcommon and libbluetooth3 so linuxdeployqt can find it
+  #       sudo apt-get install libxkbcommon-x11-0
+  #       sudo apt-get install libbluetooth3
+  #       # Downloading linuxdeployqt from continious release
+  #       wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  #       sudo chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  #       # Creating a directory for linuxdeployqt to create results 
+  #       sudo mkdir -p -m777 mne-cpp
+  #       # Copying built data to folder for easy packaging   
+  #       cp -r ./bin ./lib mne-cpp/
+  #       # linuxdeployqt uses mne_scan binary to resolve dependencies in current directory. 
+  #       cd mne-cpp
+  #       ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2
+  #       # Creating archive of everything in current directory
+  #       tar cfvz ../mne-cpp-linux-dynamic-x86_64.tar.gz ./*
+  #   - name: Deploy binaries with dev_build release on Github
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GH_TOKEN }}
+  #       file: mne-cpp-linux-dynamic-x86_64.tar.gz
+  #       asset_name: mne-cpp-linux-dynamic-x86_64.tar.gz
+  #       tag: dev_build
+  #       overwrite: true
+
+  # MacOSDynamic:
+  #   runs-on: macos-latest
+  #   needs: UpdateDevTag
+
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Install Python 3.7 version
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: '3.7'
+  #       architecture: 'x64'
+  #   - name: Install BrainFlow and LSL submodules
+  #     run: |
+  #       git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+  #       git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+  #   - name: Install Qt
+  #     uses: jurplel/install-qt-action@v2
+  #     with:
+  #       version: 5.14.2
+  #       modules: qtcharts
+  #   - name: Compile BrainFlow submodule 
+  #     run: |
+  #       mkdir applications/mne_scan/plugins/brainflowboard/brainflow/build
+  #       cd applications/mne_scan/plugins/brainflowboard/brainflow/build
+  #       cmake -DCMAKE_INSTALL_PREFIX=../installed ..
+  #       make
+  #       make install
+  #   - name: Compile LSL submodule
+  #     run: |
+  #       cd applications/mne_scan/plugins/lsladapter/liblsl
+  #       mkdir build
+  #       cd build
+  #       cmake ..
+  #       make
+  #       make install
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+  #       make -j2
+  #   - name: Package binaries
+  #     run: |
+  #       # Copy additional brainflow libs
+  #       cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. bin/mne_scan.app/Contents/Frameworks
+  #       # Copy additional LSL libs
+  #       cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. bin/mne_scan.app/Contents/Frameworks
+  #       # Creating archive of all macos deployed applications
+  #       tar cfvz mne-cpp-macos-dynamic-x86_64.tar.gz bin/. lib/.
+  #   - name: Deploy MNE Scan binaries with dev_build release on Github
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GH_TOKEN }}
+  #       file: mne-cpp-macos-dynamic-x86_64.tar.gz
+  #       asset_name: mne-cpp-macos-dynamic-x86_64.tar.gz
+  #       tag: dev_build
+  #       overwrite: true
+
+  # WinDynamic:
+  #   runs-on: windows-2016
+  #   needs: UpdateDevTag
+
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Install Python 3.7 version
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: '3.7'
+  #       architecture: 'x64'   
+  #   - name: Install BrainFlow and LSL submodules
+  #     run: |
+  #       git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+  #       git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+  #   - name: Install Qt
+  #     uses: jurplel/install-qt-action@v2
+  #     with:
+  #       version: 5.14.2
+  #       arch: win64_msvc2017_64
+  #       modules: qtcharts
+  #   - name: Install jom (Windows)
+  #     run: |
+  #       Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
+  #       expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
+  #       echo "::add-path::$HOME\jom"
+  #   - name: Compile BrainFlow submodule
+  #     run: |
+  #       cd applications\mne_scan\plugins\brainflowboard\brainflow
+  #       mkdir build
+  #       cd build
+  #       cmake -G "Visual Studio 15 2017" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+  #       cmake --build . --target install --config Release
+  #   - name: Compile LSL submodule
+  #     run: |
+  #       cd applications\mne_scan\plugins\lsladapter\liblsl
+  #       mkdir build
+  #       cd build
+  #       cmake .. -G "Visual Studio 15 2017" -A x64
+  #       cmake --build . --config Release --target install
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+  #       Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+  #       qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+  #       jom -j2
+  #   - name: Package binaries
+  #     run: |
+  #       # Copy additional brainflow libs
+  #       xcopy .\applications\mne_scan\plugins\brainflowboard\brainflow\installed\lib\* .\bin\ /s /i
+  #       # Copy additional LSL libs
+  #       xcopy .\applications\mne_scan\plugins\lsladapter\liblsl\build\install\bin\lsl.dll .\bin\ /i
+  #       7z a mne-cpp-windows-dynamic-x86_64.zip ./bin
+  #   - name: Deploy binaries with dev_build release on Github
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GH_TOKEN }}
+  #       file: mne-cpp-windows-dynamic-x86_64.zip
+  #       asset_name: mne-cpp-windows-dynamic-x86_64.zip
+  #       tag: dev_build
+  #       overwrite: true
         
-  Tests:
-    runs-on: ubuntu-16.04
-    needs: UpdateDevTag
+  # Tests:
+  #   runs-on: ubuntu-16.04
+  #   needs: UpdateDevTag
 
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Install Python 3.7 version
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-        architecture: 'x64'
-    - name: Install Codecov
-      run: |
-        sudo pip install codecov 
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2
-      with:
-        version: 5.14.2
-        modules: qtcharts
-    - name: Configure and compile MNE-CPP
-      run: |
-        qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
-        make -j2
-    - name: Run tests and upload results to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        QTEST_FUNCTION_TIMEOUT: 900000
-      run: |
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
-        git clone https://github.com/mne-tools/mne-cpp-test-data.git ./bin/mne-cpp-test-data
-        for test in ./bin/test_*;
-        do
-          # Run all tests and call gcov on all cpp files after each test run. Then upload to codecov for every test run.
-          # Codecov is able to process multiple uploads and merge them as soon as the CI job is done.          
-          echo ">> Starting $test"
-          $test
-          find ./libraries -type f -name "*.cpp" -execdir gcov {} \; > /dev/null
-          # Hide codecov output since it corrupts the log too much
-          codecov > /dev/null
-        done
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Install Python 3.7 version
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: '3.7'
+  #       architecture: 'x64'
+  #   - name: Install Codecov
+  #     run: |
+  #       sudo pip install codecov 
+  #   - name: Install Qt
+  #     uses: jurplel/install-qt-action@v2
+  #     with:
+  #       version: 5.14.2
+  #       modules: qtcharts
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
+  #       make -j2
+  #   - name: Run tests and upload results to Codecov
+  #     env:
+  #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  #       QTEST_FUNCTION_TIMEOUT: 900000
+  #     run: |
+  #       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
+  #       git clone https://github.com/mne-tools/mne-cpp-test-data.git ./bin/mne-cpp-test-data
+  #       for test in ./bin/test_*;
+  #       do
+  #         # Run all tests and call gcov on all cpp files after each test run. Then upload to codecov for every test run.
+  #         # Codecov is able to process multiple uploads and merge them as soon as the CI job is done.          
+  #         echo ">> Starting $test"
+  #         $test
+  #         find ./libraries -type f -name "*.cpp" -execdir gcov {} \; > /dev/null
+  #         # Hide codecov output since it corrupts the log too much
+  #         codecov > /dev/null
+  #       done
         
-  Doxygen:
-    runs-on: ubuntu-latest
-    needs: UpdateDevTag
+  # Doxygen:
+  #   runs-on: ubuntu-latest
+  #   needs: UpdateDevTag
 
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Install Qt Dev Tools, Doxygen and Graphviz
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -qq qttools5-dev-tools doxygen graphviz
-    - name: Run Doxygen and package result
-      run: |
-        cd doc/doxygen
-        doxygen mne-cpp_doxyfile
-    - name: Setup Github credentials
-      uses: fusion-engineering/setup-git-credentials@v2
-      with:
-        credentials: ${{secrets.GIT_CREDENTIALS}}    
-    - name: Deploy qch docu data base with dev_build release on Github
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GH_TOKEN }}
-        file: doc/doxygen/qt-creator_doc/mne-cpp.qch
-        asset_name: mne-cpp-doc-qtcreator.qch
-        tag: dev_build
-        overwrite: true
-    - name: Update documentation at Github pages
-      run: |
-        cd doc/doxygen
-        git config --global user.email lorenzesch@hotmail.com
-        git config --global user.name LorenzE
-        git clone -b gh-pages https://github.com/mne-cpp/doxygen-api gh-pages
-        cd gh-pages
-        # Remove all files first
-        git rm * -r
-        git commit --amend -a -m 'Update docu' --allow-empty
-        touch .nojekyll        
-        # Copy doxygen files
-        cp -r ../html/* .
-        # Add all new files, commit and push
-        git add *
-        git add .nojekyll
-        git commit --amend -a -m 'Update docu'
-        git push -f --all
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Install Qt Dev Tools, Doxygen and Graphviz
+  #     run: |
+  #       sudo apt-get update -qq
+  #       sudo apt-get install -qq qttools5-dev-tools doxygen graphviz
+  #   - name: Run Doxygen and package result
+  #     run: |
+  #       cd doc/doxygen
+  #       doxygen mne-cpp_doxyfile
+  #   - name: Setup Github credentials
+  #     uses: fusion-engineering/setup-git-credentials@v2
+  #     with:
+  #       credentials: ${{secrets.GIT_CREDENTIALS}}    
+  #   - name: Deploy qch docu data base with dev_build release on Github
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GH_TOKEN }}
+  #       file: doc/doxygen/qt-creator_doc/mne-cpp.qch
+  #       asset_name: mne-cpp-doc-qtcreator.qch
+  #       tag: dev_build
+  #       overwrite: true
+  #   - name: Update documentation at Github pages
+  #     run: |
+  #       cd doc/doxygen
+  #       git config --global user.email lorenzesch@hotmail.com
+  #       git config --global user.name LorenzE
+  #       git clone -b gh-pages https://github.com/mne-cpp/doxygen-api gh-pages
+  #       cd gh-pages
+  #       # Remove all files first
+  #       git rm * -r
+  #       git commit --amend -a -m 'Update docu' --allow-empty
+  #       touch .nojekyll        
+  #       # Copy doxygen files
+  #       cp -r ../html/* .
+  #       # Add all new files, commit and push
+  #       git add *
+  #       git add .nojekyll
+  #       git commit --amend -a -m 'Update docu'
+  #       git push -f --all
 
-  gh-pages:
-    runs-on: ubuntu-latest
-    needs: UpdateDevTag
+  # gh-pages:
+  #   runs-on: ubuntu-latest
+  #   needs: UpdateDevTag
 
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Setup Github credentials
-      uses: fusion-engineering/setup-git-credentials@v2
-      with:
-        credentials: ${{secrets.GIT_CREDENTIALS}}
-    - name: Clone doc/gh-pages into gh-pages branch
-      run: |
-        git config --global user.email lorenzesch@hotmail.com
-        git config --global user.name LorenzE
-        git clone -b master --single-branch https://github.com/mne-cpp/mne-cpp.github.io.git
-        cd mne-cpp.github.io
-        # Remove all files first
-        git rm * -r
-        git commit --amend -a -m 'Update docu' --allow-empty
-        cd ..
-        cp -RT doc/gh-pages mne-cpp.github.io
-        cd mne-cpp.github.io
-        git add .
-        git commit --amend -a -m 'Update docu'
-        git push -f --all
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Setup Github credentials
+  #     uses: fusion-engineering/setup-git-credentials@v2
+  #     with:
+  #       credentials: ${{secrets.GIT_CREDENTIALS}}
+  #   - name: Clone doc/gh-pages into gh-pages branch
+  #     run: |
+  #       git config --global user.email lorenzesch@hotmail.com
+  #       git config --global user.name LorenzE
+  #       git clone -b master --single-branch https://github.com/mne-cpp/mne-cpp.github.io.git
+  #       cd mne-cpp.github.io
+  #       # Remove all files first
+  #       git rm * -r
+  #       git commit --amend -a -m 'Update docu' --allow-empty
+  #       cd ..
+  #       cp -RT doc/gh-pages mne-cpp.github.io
+  #       cd mne-cpp.github.io
+  #       git add .
+  #       git commit --amend -a -m 'Update docu'
+  #       git push -f --all

--- a/.github/workflows/devbuilds.yml
+++ b/.github/workflows/devbuilds.yml
@@ -3,132 +3,132 @@ name: Linux|Win|MacOS
 on:
   push:
     branches:
-    - static
+    - master
 
 jobs:
-  # UpdateDevTag:
-  #   runs-on: ubuntu-16.04
+  UpdateDevTag:
+    runs-on: ubuntu-16.04
     
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2  
-  #   - name: Install hub
-  #     uses: geertvdc/setup-hub@master
-  #   - name: Setup Github credentials
-  #     uses: fusion-engineering/setup-git-credentials@v2
-  #     with:
-  #       credentials: ${{secrets.GIT_CREDENTIALS}}
-  #   - name: Update dev_build tag and release
-  #     env:
-  #       GITHUB_USER: LorenzE
-  #       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-  #     run: |
-  #       git config --global user.email lorenzesch@hotmail.com
-  #       git config --global user.name $GITHUB_USER
-  #       # Delete current dev_build release remotley. 
-  #       # Must be done before deleting the remote tag associated with the dev_build release. 
-  #       # This prevents a draft release to be left over after we delete the tag remotley. 
-  #       hub release delete dev_build
-  #       # Delete current tag remotley
-  #       git push origin :refs/tags/dev_build
-  #       # Change dev_build tag to point to newest commit
-  #       git tag dev_build -f -a -m "Development Builds"
-  #       # Send the new tag
-  #       git push -f --tag
-  #       # Create new dev_build release
-  #       hub release create -m "Development Builds" dev_build --prerelease
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2  
+    - name: Install hub
+      uses: geertvdc/setup-hub@master
+    - name: Setup Github credentials
+      uses: fusion-engineering/setup-git-credentials@v2
+      with:
+        credentials: ${{secrets.GIT_CREDENTIALS}}
+    - name: Update dev_build tag and release
+      env:
+        GITHUB_USER: LorenzE
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      run: |
+        git config --global user.email lorenzesch@hotmail.com
+        git config --global user.name $GITHUB_USER
+        # Delete current dev_build release remotley. 
+        # Must be done before deleting the remote tag associated with the dev_build release. 
+        # This prevents a draft release to be left over after we delete the tag remotley. 
+        hub release delete dev_build
+        # Delete current tag remotley
+        git push origin :refs/tags/dev_build
+        # Change dev_build tag to point to newest commit
+        git tag dev_build -f -a -m "Development Builds"
+        # Send the new tag
+        git push -f --tag
+        # Create new dev_build release
+        hub release create -m "Development Builds" dev_build --prerelease
 
-  # LinuxStatic:
-  #   runs-on: ubuntu-16.04
-  #   needs: UpdateDevTag
+  LinuxStatic:
+    runs-on: ubuntu-16.04
+    needs: UpdateDevTag
     
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Compile static Qt version
-  #     run: |
-  #       # Install OpenGL
-  #       sudo apt-get install build-essential libgl1-mesa-dev
-  #       # Clone Qt5 repo
-  #       cd ..
-  #       git clone https://code.qt.io/qt/qt5.git -b 5.14.2
-  #       cd qt5
-  #       ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
-  #       # Create shadow build folder
-  #       cd ..
-  #       mkdir qt5_shadow
-  #       cd qt5_shadow
-  #       # Configure Qt5
-  #       ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
-  #       make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
-  #       make install -j2
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
-  #       make -j2
-  #   - name: Package binaries
-  #     run: |
-  #       # Delete folders which we do not want to ship
-  #       rm -r bin/mne_rt_server_plugins
-  #       rm -r bin/mne-cpp-test-data
-  #       rm -r bin/mne_scan_plugins
-  #       # Creating archive of everything in the bin directory
-  #       tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/.
-  #   - name: Deploy binaries with dev_build release on Github
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GH_TOKEN }}
-  #       file: mne-cpp-linux-static-x86_64.tar.gz
-  #       asset_name: mne-cpp-linux-static-x86_64.tar.gz
-  #       tag: dev_build
-  #       overwrite: true
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Compile static Qt version
+      run: |
+        # Install OpenGL
+        sudo apt-get install build-essential libgl1-mesa-dev
+        # Clone Qt5 repo
+        cd ..
+        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        cd qt5
+        ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+        # Create shadow build folder
+        cd ..
+        mkdir qt5_shadow
+        cd qt5_shadow
+        # Configure Qt5
+        ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
+        make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
+        make install -j2
+    - name: Configure and compile MNE-CPP
+      run: |
+        ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
+        make -j2
+    - name: Package binaries
+      run: |
+        # Delete folders which we do not want to ship
+        rm -r bin/mne_rt_server_plugins
+        rm -r bin/mne-cpp-test-data
+        rm -r bin/mne_scan_plugins
+        # Creating archive of everything in the bin directory
+        tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/.
+    - name: Deploy binaries with dev_build release on Github
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GH_TOKEN }}
+        file: mne-cpp-linux-static-x86_64.tar.gz
+        asset_name: mne-cpp-linux-static-x86_64.tar.gz
+        tag: dev_build
+        overwrite: true
 
-  # MacOSStatic:
-  #   runs-on: macos-latest
-  #   needs: UpdateDevTag
+  MacOSStatic:
+    runs-on: macos-latest
+    needs: UpdateDevTag
     
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Compile static Qt version
-  #     run: |
-  #       # Clone Qt5 repo
-  #       cd ..
-  #       git clone https://code.qt.io/qt/qt5.git -b 5.14.2
-  #       cd qt5
-  #       ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
-  #       # Create shadow build folder
-  #       cd ..
-  #       mkdir qt5_shadow
-  #       cd qt5_shadow
-  #       # Configure Qt5
-  #       ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
-  #       make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
-  #       make install -j2
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
-  #       make -j2
-  #   - name: Package binaries
-  #     run: |
-  #       # Delete folders which we do not want to ship
-  #       rm -r bin/mne_rt_server_plugins
-  #       rm -r bin/mne-cpp-test-data
-  #       rm -r bin/mne_scan_plugins
-  #       # Creating archive of all macos deployed applications
-  #       tar cfvz mne-cpp-macos-static-x86_64.tar.gz bin/.
-  #   - name: Deploy binaries with dev_build release on Github
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GH_TOKEN }}
-  #       file: mne-cpp-macos-static-x86_64.tar.gz
-  #       asset_name: mne-cpp-macos-static-x86_64.tar.gz
-  #       tag: dev_build
-  #       overwrite: true
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Compile static Qt version
+      run: |
+        # Clone Qt5 repo
+        cd ..
+        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        cd qt5
+        ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+        # Create shadow build folder
+        cd ..
+        mkdir qt5_shadow
+        cd qt5_shadow
+        # Configure Qt5
+        ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
+        make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
+        make install -j2
+    - name: Configure and compile MNE-CPP
+      run: |
+        ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
+        make -j2
+    - name: Package binaries
+      run: |
+        # Delete folders which we do not want to ship
+        rm -r bin/mne_rt_server_plugins
+        rm -r bin/mne-cpp-test-data
+        rm -r bin/mne_scan_plugins
+        # Creating archive of all macos deployed applications
+        tar cfvz mne-cpp-macos-static-x86_64.tar.gz bin/.
+    - name: Deploy binaries with dev_build release on Github
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GH_TOKEN }}
+        file: mne-cpp-macos-static-x86_64.tar.gz
+        asset_name: mne-cpp-macos-static-x86_64.tar.gz
+        tag: dev_build
+        overwrite: true
 
   WinStatic:
     runs-on: windows-2016
-  #  needs: UpdateDevTag
+    needs: UpdateDevTag
 
     steps:
     - name: Clone repository
@@ -182,313 +182,309 @@ jobs:
         asset_name: mne-cpp-windows-static-x86_64.zip
         tag: dev_build
         overwrite: true
-    - uses: actions/upload-artifact@v1
-      with:
-        name: mne-cpp-windows-static-x86_64.zip
-        path: mne-cpp-windows-static-x86_64.zip
 
-  # LinuxDynamic:
-  #   runs-on: ubuntu-16.04
-  #   needs: UpdateDevTag
+  LinuxDynamic:
+    runs-on: ubuntu-16.04
+    needs: UpdateDevTag
     
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Install Python 3.7 version
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: '3.7'
-  #       architecture: 'x64'
-  #   - name: Install BrainFlow and LSL submodules
-  #     run: |
-  #       git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
-  #       git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
-  #   - name: Install Qt
-  #     uses: jurplel/install-qt-action@v2
-  #     with:
-  #       version: 5.14.2
-  #       modules: qtcharts
-  #   - name: Compile BrainFlow submodule
-  #     run: |
-  #       cd applications/mne_scan/plugins/brainflowboard/brainflow
-  #       mkdir build
-  #       cd build
-  #       cmake -DCMAKE_INSTALL_PREFIX=../installed ..
-  #       make
-  #       make install
-  #   - name: Compile LSL submodule
-  #     run: |
-  #       cd applications/mne_scan/plugins/lsladapter/liblsl
-  #       mkdir build
-  #       cd build
-  #       cmake ..
-  #       make
-  #       make install
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-  #       make -j2
-  #   - name: Package binaries
-  #     run: |
-  #       # Copy additional brainflow libs
-  #       cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. lib/
-  #       # Copy additional LSL libs
-  #       cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. lib/
-  #       # Install libxkbcommon and libbluetooth3 so linuxdeployqt can find it
-  #       sudo apt-get install libxkbcommon-x11-0
-  #       sudo apt-get install libbluetooth3
-  #       # Downloading linuxdeployqt from continious release
-  #       wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-  #       sudo chmod a+x linuxdeployqt-continuous-x86_64.AppImage
-  #       # Creating a directory for linuxdeployqt to create results 
-  #       sudo mkdir -p -m777 mne-cpp
-  #       # Copying built data to folder for easy packaging   
-  #       cp -r ./bin ./lib mne-cpp/
-  #       # linuxdeployqt uses mne_scan binary to resolve dependencies in current directory. 
-  #       cd mne-cpp
-  #       ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2
-  #       # Creating archive of everything in current directory
-  #       tar cfvz ../mne-cpp-linux-dynamic-x86_64.tar.gz ./*
-  #   - name: Deploy binaries with dev_build release on Github
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GH_TOKEN }}
-  #       file: mne-cpp-linux-dynamic-x86_64.tar.gz
-  #       asset_name: mne-cpp-linux-dynamic-x86_64.tar.gz
-  #       tag: dev_build
-  #       overwrite: true
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install BrainFlow and LSL submodules
+      run: |
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: 5.14.2
+        modules: qtcharts
+    - name: Compile BrainFlow submodule
+      run: |
+        cd applications/mne_scan/plugins/brainflowboard/brainflow
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=../installed ..
+        make
+        make install
+    - name: Compile LSL submodule
+      run: |
+        cd applications/mne_scan/plugins/lsladapter/liblsl
+        mkdir build
+        cd build
+        cmake ..
+        make
+        make install
+    - name: Configure and compile MNE-CPP
+      run: |
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        make -j2
+    - name: Package binaries
+      run: |
+        # Copy additional brainflow libs
+        cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. lib/
+        # Copy additional LSL libs
+        cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. lib/
+        # Install libxkbcommon and libbluetooth3 so linuxdeployqt can find it
+        sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libbluetooth3
+        # Downloading linuxdeployqt from continious release
+        wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+        sudo chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+        # Creating a directory for linuxdeployqt to create results 
+        sudo mkdir -p -m777 mne-cpp
+        # Copying built data to folder for easy packaging   
+        cp -r ./bin ./lib mne-cpp/
+        # linuxdeployqt uses mne_scan binary to resolve dependencies in current directory. 
+        cd mne-cpp
+        ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2
+        # Creating archive of everything in current directory
+        tar cfvz ../mne-cpp-linux-dynamic-x86_64.tar.gz ./*
+    - name: Deploy binaries with dev_build release on Github
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GH_TOKEN }}
+        file: mne-cpp-linux-dynamic-x86_64.tar.gz
+        asset_name: mne-cpp-linux-dynamic-x86_64.tar.gz
+        tag: dev_build
+        overwrite: true
 
-  # MacOSDynamic:
-  #   runs-on: macos-latest
-  #   needs: UpdateDevTag
+  MacOSDynamic:
+    runs-on: macos-latest
+    needs: UpdateDevTag
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Install Python 3.7 version
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: '3.7'
-  #       architecture: 'x64'
-  #   - name: Install BrainFlow and LSL submodules
-  #     run: |
-  #       git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
-  #       git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
-  #   - name: Install Qt
-  #     uses: jurplel/install-qt-action@v2
-  #     with:
-  #       version: 5.14.2
-  #       modules: qtcharts
-  #   - name: Compile BrainFlow submodule 
-  #     run: |
-  #       mkdir applications/mne_scan/plugins/brainflowboard/brainflow/build
-  #       cd applications/mne_scan/plugins/brainflowboard/brainflow/build
-  #       cmake -DCMAKE_INSTALL_PREFIX=../installed ..
-  #       make
-  #       make install
-  #   - name: Compile LSL submodule
-  #     run: |
-  #       cd applications/mne_scan/plugins/lsladapter/liblsl
-  #       mkdir build
-  #       cd build
-  #       cmake ..
-  #       make
-  #       make install
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-  #       make -j2
-  #   - name: Package binaries
-  #     run: |
-  #       # Copy additional brainflow libs
-  #       cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. bin/mne_scan.app/Contents/Frameworks
-  #       # Copy additional LSL libs
-  #       cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. bin/mne_scan.app/Contents/Frameworks
-  #       # Creating archive of all macos deployed applications
-  #       tar cfvz mne-cpp-macos-dynamic-x86_64.tar.gz bin/. lib/.
-  #   - name: Deploy binaries with dev_build release on Github
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GH_TOKEN }}
-  #       file: mne-cpp-macos-dynamic-x86_64.tar.gz
-  #       asset_name: mne-cpp-macos-dynamic-x86_64.tar.gz
-  #       tag: dev_build
-  #       overwrite: true
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install BrainFlow and LSL submodules
+      run: |
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: 5.14.2
+        modules: qtcharts
+    - name: Compile BrainFlow submodule 
+      run: |
+        mkdir applications/mne_scan/plugins/brainflowboard/brainflow/build
+        cd applications/mne_scan/plugins/brainflowboard/brainflow/build
+        cmake -DCMAKE_INSTALL_PREFIX=../installed ..
+        make
+        make install
+    - name: Compile LSL submodule
+      run: |
+        cd applications/mne_scan/plugins/lsladapter/liblsl
+        mkdir build
+        cd build
+        cmake ..
+        make
+        make install
+    - name: Configure and compile MNE-CPP
+      run: |
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        make -j2
+    - name: Package binaries
+      run: |
+        # Copy additional brainflow libs
+        cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. bin/mne_scan.app/Contents/Frameworks
+        # Copy additional LSL libs
+        cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. bin/mne_scan.app/Contents/Frameworks
+        # Creating archive of all macos deployed applications
+        tar cfvz mne-cpp-macos-dynamic-x86_64.tar.gz bin/. lib/.
+    - name: Deploy binaries with dev_build release on Github
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GH_TOKEN }}
+        file: mne-cpp-macos-dynamic-x86_64.tar.gz
+        asset_name: mne-cpp-macos-dynamic-x86_64.tar.gz
+        tag: dev_build
+        overwrite: true
 
-  # WinDynamic:
-  #   runs-on: windows-2016
-  #   needs: UpdateDevTag
+  WinDynamic:
+    runs-on: windows-2016
+    needs: UpdateDevTag
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Install Python 3.7 version
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: '3.7'
-  #       architecture: 'x64'   
-  #   - name: Install BrainFlow and LSL submodules
-  #     run: |
-  #       git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
-  #       git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
-  #   - name: Install Qt
-  #     uses: jurplel/install-qt-action@v2
-  #     with:
-  #       version: 5.14.2
-  #       arch: win64_msvc2017_64
-  #       modules: qtcharts
-  #   - name: Install jom
-  #     run: |
-  #       Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
-  #       expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
-  #       echo "::add-path::$HOME\jom"
-  #   - name: Compile BrainFlow submodule
-  #     run: |
-  #       cd applications\mne_scan\plugins\brainflowboard\brainflow
-  #       mkdir build
-  #       cd build
-  #       cmake -G "Visual Studio 15 2017" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
-  #       cmake --build . --target install --config Release
-  #   - name: Compile LSL submodule
-  #     run: |
-  #       cd applications\mne_scan\plugins\lsladapter\liblsl
-  #       mkdir build
-  #       cd build
-  #       cmake .. -G "Visual Studio 15 2017" -A x64
-  #       cmake --build . --config Release --target install
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
-  #       Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
-  #       qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-  #       jom -j2
-  #   - name: Package binaries
-  #     run: |
-  #       # Copy additional brainflow libs
-  #       xcopy .\applications\mne_scan\plugins\brainflowboard\brainflow\installed\lib\* .\bin\ /s /i
-  #       # Copy additional LSL libs
-  #       xcopy .\applications\mne_scan\plugins\lsladapter\liblsl\build\install\bin\lsl.dll .\bin\ /i
-  #       7z a mne-cpp-windows-dynamic-x86_64.zip ./bin
-  #   - name: Deploy binaries with dev_build release on Github
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GH_TOKEN }}
-  #       file: mne-cpp-windows-dynamic-x86_64.zip
-  #       asset_name: mne-cpp-windows-dynamic-x86_64.zip
-  #       tag: dev_build
-  #       overwrite: true
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'   
+    - name: Install BrainFlow and LSL submodules
+      run: |
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: 5.14.2
+        arch: win64_msvc2017_64
+        modules: qtcharts
+    - name: Install jom
+      run: |
+        Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
+        expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
+        echo "::add-path::$HOME\jom"
+    - name: Compile BrainFlow submodule
+      run: |
+        cd applications\mne_scan\plugins\brainflowboard\brainflow
+        mkdir build
+        cd build
+        cmake -G "Visual Studio 15 2017" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake --build . --target install --config Release
+    - name: Compile LSL submodule
+      run: |
+        cd applications\mne_scan\plugins\lsladapter\liblsl
+        mkdir build
+        cd build
+        cmake .. -G "Visual Studio 15 2017" -A x64
+        cmake --build . --config Release --target install
+    - name: Configure and compile MNE-CPP
+      run: |
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        jom -j2
+    - name: Package binaries
+      run: |
+        # Copy additional brainflow libs
+        xcopy .\applications\mne_scan\plugins\brainflowboard\brainflow\installed\lib\* .\bin\ /s /i
+        # Copy additional LSL libs
+        xcopy .\applications\mne_scan\plugins\lsladapter\liblsl\build\install\bin\lsl.dll .\bin\ /i
+        7z a mne-cpp-windows-dynamic-x86_64.zip ./bin
+    - name: Deploy binaries with dev_build release on Github
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GH_TOKEN }}
+        file: mne-cpp-windows-dynamic-x86_64.zip
+        asset_name: mne-cpp-windows-dynamic-x86_64.zip
+        tag: dev_build
+        overwrite: true
         
-  # Tests:
-  #   runs-on: ubuntu-16.04
-  #   needs: UpdateDevTag
+  Tests:
+    runs-on: ubuntu-16.04
+    needs: UpdateDevTag
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Install Python 3.7 version
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: '3.7'
-  #       architecture: 'x64'
-  #   - name: Install Codecov
-  #     run: |
-  #       sudo pip install codecov 
-  #   - name: Install Qt
-  #     uses: jurplel/install-qt-action@v2
-  #     with:
-  #       version: 5.14.2
-  #       modules: qtcharts
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
-  #       make -j2
-  #   - name: Run tests and upload results to Codecov
-  #     env:
-  #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  #       QTEST_FUNCTION_TIMEOUT: 900000
-  #     run: |
-  #       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
-  #       git clone https://github.com/mne-tools/mne-cpp-test-data.git ./bin/mne-cpp-test-data
-  #       for test in ./bin/test_*;
-  #       do
-  #         # Run all tests and call gcov on all cpp files after each test run. Then upload to codecov for every test run.
-  #         # Codecov is able to process multiple uploads and merge them as soon as the CI job is done.          
-  #         echo ">> Starting $test"
-  #         $test
-  #         find ./libraries -type f -name "*.cpp" -execdir gcov {} \; > /dev/null
-  #         # Hide codecov output since it corrupts the log too much
-  #         codecov > /dev/null
-  #       done
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install Codecov
+      run: |
+        sudo pip install codecov 
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: 5.14.2
+        modules: qtcharts
+    - name: Configure and compile MNE-CPP
+      run: |
+        qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
+        make -j2
+    - name: Run tests and upload results to Codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        QTEST_FUNCTION_TIMEOUT: 900000
+      run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
+        git clone https://github.com/mne-tools/mne-cpp-test-data.git ./bin/mne-cpp-test-data
+        for test in ./bin/test_*;
+        do
+          # Run all tests and call gcov on all cpp files after each test run. Then upload to codecov for every test run.
+          # Codecov is able to process multiple uploads and merge them as soon as the CI job is done.          
+          echo ">> Starting $test"
+          $test
+          find ./libraries -type f -name "*.cpp" -execdir gcov {} \; > /dev/null
+          # Hide codecov output since it corrupts the log too much
+          codecov > /dev/null
+        done
         
-  # Doxygen:
-  #   runs-on: ubuntu-latest
-  #   needs: UpdateDevTag
+  Doxygen:
+    runs-on: ubuntu-latest
+    needs: UpdateDevTag
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Install Qt Dev Tools, Doxygen and Graphviz
-  #     run: |
-  #       sudo apt-get update -qq
-  #       sudo apt-get install -qq qttools5-dev-tools doxygen graphviz
-  #   - name: Run Doxygen and package result
-  #     run: |
-  #       cd doc/doxygen
-  #       doxygen mne-cpp_doxyfile
-  #   - name: Setup Github credentials
-  #     uses: fusion-engineering/setup-git-credentials@v2
-  #     with:
-  #       credentials: ${{secrets.GIT_CREDENTIALS}}    
-  #   - name: Deploy qch docu data base with dev_build release on Github
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GH_TOKEN }}
-  #       file: doc/doxygen/qt-creator_doc/mne-cpp.qch
-  #       asset_name: mne-cpp-doc-qtcreator.qch
-  #       tag: dev_build
-  #       overwrite: true
-  #   - name: Update documentation at Github pages
-  #     run: |
-  #       cd doc/doxygen
-  #       git config --global user.email lorenzesch@hotmail.com
-  #       git config --global user.name LorenzE
-  #       git clone -b gh-pages https://github.com/mne-cpp/doxygen-api gh-pages
-  #       cd gh-pages
-  #       # Remove all files first
-  #       git rm * -r
-  #       git commit --amend -a -m 'Update docu' --allow-empty
-  #       touch .nojekyll        
-  #       # Copy doxygen files
-  #       cp -r ../html/* .
-  #       # Add all new files, commit and push
-  #       git add *
-  #       git add .nojekyll
-  #       git commit --amend -a -m 'Update docu'
-  #       git push -f --all
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Qt Dev Tools, Doxygen and Graphviz
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -qq qttools5-dev-tools doxygen graphviz
+    - name: Run Doxygen and package result
+      run: |
+        cd doc/doxygen
+        doxygen mne-cpp_doxyfile
+    - name: Setup Github credentials
+      uses: fusion-engineering/setup-git-credentials@v2
+      with:
+        credentials: ${{secrets.GIT_CREDENTIALS}}    
+    - name: Deploy qch docu data base with dev_build release on Github
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GH_TOKEN }}
+        file: doc/doxygen/qt-creator_doc/mne-cpp.qch
+        asset_name: mne-cpp-doc-qtcreator.qch
+        tag: dev_build
+        overwrite: true
+    - name: Update documentation at Github pages
+      run: |
+        cd doc/doxygen
+        git config --global user.email lorenzesch@hotmail.com
+        git config --global user.name LorenzE
+        git clone -b gh-pages https://github.com/mne-cpp/doxygen-api gh-pages
+        cd gh-pages
+        # Remove all files first
+        git rm * -r
+        git commit --amend -a -m 'Update docu' --allow-empty
+        touch .nojekyll        
+        # Copy doxygen files
+        cp -r ../html/* .
+        # Add all new files, commit and push
+        git add *
+        git add .nojekyll
+        git commit --amend -a -m 'Update docu'
+        git push -f --all
 
-  # gh-pages:
-  #   runs-on: ubuntu-latest
-  #   needs: UpdateDevTag
+  gh-pages:
+    runs-on: ubuntu-latest
+    needs: UpdateDevTag
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Setup Github credentials
-  #     uses: fusion-engineering/setup-git-credentials@v2
-  #     with:
-  #       credentials: ${{secrets.GIT_CREDENTIALS}}
-  #   - name: Clone doc/gh-pages into gh-pages branch
-  #     run: |
-  #       git config --global user.email lorenzesch@hotmail.com
-  #       git config --global user.name LorenzE
-  #       git clone -b master --single-branch https://github.com/mne-cpp/mne-cpp.github.io.git
-  #       cd mne-cpp.github.io
-  #       # Remove all files first
-  #       git rm * -r
-  #       git commit --amend -a -m 'Update docu' --allow-empty
-  #       cd ..
-  #       cp -RT doc/gh-pages mne-cpp.github.io
-  #       cd mne-cpp.github.io
-  #       git add .
-  #       git commit --amend -a -m 'Update docu'
-  #       git push -f --all
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Setup Github credentials
+      uses: fusion-engineering/setup-git-credentials@v2
+      with:
+        credentials: ${{secrets.GIT_CREDENTIALS}}
+    - name: Clone doc/gh-pages into gh-pages branch
+      run: |
+        git config --global user.email lorenzesch@hotmail.com
+        git config --global user.name LorenzE
+        git clone -b master --single-branch https://github.com/mne-cpp/mne-cpp.github.io.git
+        cd mne-cpp.github.io
+        # Remove all files first
+        git rm * -r
+        git commit --amend -a -m 'Update docu' --allow-empty
+        cd ..
+        cp -RT doc/gh-pages mne-cpp.github.io
+        cd mne-cpp.github.io
+        git add .
+        git commit --amend -a -m 'Update docu'
+        git push -f --all

--- a/.github/workflows/devbuilds.yml
+++ b/.github/workflows/devbuilds.yml
@@ -70,6 +70,7 @@ jobs:
   #     run: |
   #       # Delete folders which we do not want to ship
   #       rm -r bin/mne_rt_server_plugins
+  #       rm -r bin/mne-cpp-test-data
   #       rm -r bin/mne_scan_plugins
   #       # Creating archive of everything in the bin directory
   #       tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/.
@@ -112,10 +113,11 @@ jobs:
   #     run: |
   #       # Delete folders which we do not want to ship
   #       rm -r bin/mne_rt_server_plugins
+  #       rm -r bin/mne-cpp-test-data
   #       rm -r bin/mne_scan_plugins
   #       # Creating archive of all macos deployed applications
   #       tar cfvz mne-cpp-macos-static-x86_64.tar.gz bin/.
-  #   - name: Deploy MNE Scan binaries with dev_build release on Github
+  #   - name: Deploy binaries with dev_build release on Github
   #     uses: svenstaro/upload-release-action@v1-release
   #     with:
   #       repo_token: ${{ secrets.GH_TOKEN }}
@@ -136,7 +138,7 @@ jobs:
       with:
         python-version: '3.7'
         architecture: 'x64'
-    - name: Install jom (Windows)
+    - name: Install jom
       run: |
         Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
@@ -169,6 +171,7 @@ jobs:
       run: |
         # Delete folders which we do not want to ship
         Remove-Item 'bin/mne_rt_server_plugins' -Recurse
+        Remove-Item 'bin/mne-cpp-test-data' -Recurse
         Remove-Item 'bin/mne_scan_plugins' -Recurse
         7z a mne-cpp-windows-static-x86_64.zip ./bin
     - name: Deploy binaries with dev_build release on Github
@@ -179,6 +182,10 @@ jobs:
         asset_name: mne-cpp-windows-static-x86_64.zip
         tag: dev_build
         overwrite: true
+    - uses: actions/upload-artifact@v1
+      with:
+        name: mne-cpp-windows-static-x86_64.zip
+        path: mne-cpp-windows-static-x86_64.zip
 
   # LinuxDynamic:
   #   runs-on: ubuntu-16.04
@@ -299,7 +306,7 @@ jobs:
   #       cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. bin/mne_scan.app/Contents/Frameworks
   #       # Creating archive of all macos deployed applications
   #       tar cfvz mne-cpp-macos-dynamic-x86_64.tar.gz bin/. lib/.
-  #   - name: Deploy MNE Scan binaries with dev_build release on Github
+  #   - name: Deploy binaries with dev_build release on Github
   #     uses: svenstaro/upload-release-action@v1-release
   #     with:
   #       repo_token: ${{ secrets.GH_TOKEN }}
@@ -330,7 +337,7 @@ jobs:
   #       version: 5.14.2
   #       arch: win64_msvc2017_64
   #       modules: qtcharts
-  #   - name: Install jom (Windows)
+  #   - name: Install jom
   #     run: |
   #       Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
   #       expand-archive -path "jom.zip" -destinationpath "$HOME\jom"

--- a/.github/workflows/devbuilds.yml
+++ b/.github/workflows/devbuilds.yml
@@ -60,12 +60,12 @@ jobs:
         cd qt5_shadow
         # Configure Qt5
         ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
-        make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
-        make install -j2
+        make module-qtbase module-qtsvg module-qtcharts module-qt3d -j4
+        make install -j4
     - name: Configure and compile MNE-CPP
       run: |
         ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
-        make -j2
+        make -j4
     - name: Package binaries
       run: |
         # Delete folders which we do not want to ship
@@ -103,12 +103,12 @@ jobs:
         cd qt5_shadow
         # Configure Qt5
         ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
-        make module-qtbase module-qtsvg module-qtcharts module-qt3d -j2
-        make install -j2
+        make module-qtbase module-qtsvg module-qtcharts module-qt3d -j4
+        make install -j4
     - name: Configure and compile MNE-CPP
       run: |
         ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
-        make -j2
+        make -j4
     - name: Package binaries
       run: |
         # Delete folders which we do not want to ship
@@ -159,14 +159,14 @@ jobs:
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         # Configure Qt5
         ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
-        jom -j2
+        jom -j4
         nmake install
     - name: Configure and compile MNE-CPP
       run: |
         cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
-        jom -j2
+        jom -j4
     - name: Package binaries
       run: |
         # Delete folders which we do not want to ship
@@ -223,7 +223,7 @@ jobs:
     - name: Configure and compile MNE-CPP
       run: |
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-        make -j2
+        make -j4
     - name: Package binaries
       run: |
         # Copy additional brainflow libs
@@ -293,7 +293,7 @@ jobs:
     - name: Configure and compile MNE-CPP
       run: |
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-        make -j2
+        make -j4
     - name: Package binaries
       run: |
         # Copy additional brainflow libs
@@ -357,7 +357,7 @@ jobs:
         cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-        jom -j2
+        jom -j4
     - name: Package binaries
       run: |
         # Copy additional brainflow libs
@@ -397,7 +397,7 @@ jobs:
     - name: Configure and compile MNE-CPP
       run: |
         qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
-        make -j2
+        make -j4
     - name: Run tests and upload results to Codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -85,7 +85,7 @@ jobs:
       if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
       run: |
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-        make -j2
+        make -j4
     - name: Configure and compile MNE-CPP (Windows)
       if: matrix.os == 'windows-2016'
       run: |
@@ -93,7 +93,7 @@ jobs:
         cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-        jom -j2
+        jom -j4
         
   Tests:
     runs-on: ${{ matrix.os }}
@@ -141,12 +141,12 @@ jobs:
       if: matrix.os == 'ubuntu-16.04'
       run: |
         qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
-        make -j2
+        make -j4
     - name: Configure and compile MNE-CPP (MacOS)
       if: matrix.os == 'macos-latest'
       run: |
         qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
-        make -j2
+        make -j4
     - name: Configure and compile MNE-CPP (Windows)
       if: matrix.os == 'windows-2016'
       run: |
@@ -154,7 +154,7 @@ jobs:
         cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
-        jom -j2
+        jom -j4
     - name: Run tests (Linux)
       if: matrix.os == 'ubuntu-16.04'
       env:
@@ -210,7 +210,7 @@ jobs:
     - name: Configure and compile MNE-CPP
       run: |
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=minimalVersion
-        make -j2
+        make -j4
 
   Doxygen:
     runs-on: ubuntu-latest

--- a/applications/mne_anonymize/mne_anonymize.pro
+++ b/applications/mne_anonymize/mne_anonymize.pro
@@ -48,6 +48,7 @@ CONFIG   += console
 
 contains(MNECPP_CONFIG, static) {
     CONFIG += static
+    DEFINES += STATICBUILD
 }
 
 TARGET = mne_anonymize
@@ -81,7 +82,7 @@ INCLUDEPATH += $${MNE_FIFF_ANONYMIZER_DIR}
 
 unix: QMAKE_CXXFLAGS += -isystem $$EIGEN_INCLUDE_DIR
 
-win32 {
+win32:!contains(MNECPP_CONFIG, static) {
     EXTRA_ARGS =
     DEPLOY_CMD = $$winDeployAppArgs($${TARGET},$${TARGET_EXT},$${MNE_BINARY_DIR},$${LIBS},$${EXTRA_ARGS})
     QMAKE_POST_LINK += $${DEPLOY_CMD}

--- a/applications/mne_rt_server/mne_rt_server/mne_rt_server.pro
+++ b/applications/mne_rt_server/mne_rt_server/mne_rt_server.pro
@@ -43,7 +43,7 @@ TEMPLATE = app
 QT += network concurrent
 QT -= gui
 
-CONFIG   += console
+CONFIG += console
 
 TARGET = mne_rt_server
 CONFIG(debug, debug|release) {
@@ -82,7 +82,6 @@ SOURCES += \
     commandthread.cpp
 
 HEADERS += \
-# has to be moved to connectors
     IConnector.h \
     connectormanager.h \
     mne_rt_server.h \

--- a/applications/mne_scan/mne_scan/mne_scan.pro
+++ b/applications/mne_scan/mne_scan/mne_scan.pro
@@ -45,13 +45,22 @@ qtHaveModule(3dextras) {
     QT += 3dextras
 }
 
+CONFIG += console
+
+TARGET = mne_scan
+CONFIG(debug, debug|release) {
+    TARGET = $$join(TARGET,,,d)
+}
+
+DESTDIR = $${MNE_BINARY_DIR}
+
 contains(MNECPP_CONFIG, dispOpenGL) {
     qtHaveModule(opengl): QT += opengl
     DEFINES += USE_OPENGL
 }
 
 contains(MNECPP_CONFIG, static) {
-    CONFIG += staticlib
+    CONFIG += static
     DEFINES += STATICBUILD
     # For static builds we need to link against the plugins
     # because we cannot load them dynamically during runtime
@@ -97,14 +106,6 @@ contains(MNECPP_CONFIG, static) {
     CONFIG += shared
 }
 
-TARGET = mne_scan
-
-CONFIG(debug, debug|release) {
-    TARGET = $$join(TARGET,,,d)
-}
-
-CONFIG += console
-
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \
@@ -137,8 +138,6 @@ CONFIG(debug, debug|release) {
             -lMNE$${MNE_LIB_VERSION}Fs \
             -lMNE$${MNE_LIB_VERSION}Utils \
 }
-
-DESTDIR = $${MNE_BINARY_DIR}
 
 SOURCES += \
     main.cpp \

--- a/applications/mne_scan/plugins/averaging/averaging.pro
+++ b/applications/mne_scan/plugins/averaging/averaging.pro
@@ -50,6 +50,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/babymeg/babymeg.pro
+++ b/applications/mne_scan/plugins/babymeg/babymeg.pro
@@ -50,6 +50,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/brainflowboard/brainflowboard.pro
+++ b/applications/mne_scan/plugins/brainflowboard/brainflowboard.pro
@@ -52,6 +52,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/covariance/covariance.pro
+++ b/applications/mne_scan/plugins/covariance/covariance.pro
@@ -50,6 +50,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.pro
+++ b/applications/mne_scan/plugins/fiffsimulator/fiffsimulator.pro
@@ -50,6 +50,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/hpi/hpi.pro
+++ b/applications/mne_scan/plugins/hpi/hpi.pro
@@ -51,6 +51,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/natus/natus.pro
+++ b/applications/mne_scan/plugins/natus/natus.pro
@@ -50,6 +50,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.pro
+++ b/applications/mne_scan/plugins/neuronalconnectivity/neuronalconnectivity.pro
@@ -50,6 +50,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/noisereduction/noisereduction.pro
+++ b/applications/mne_scan/plugins/noisereduction/noisereduction.pro
@@ -50,6 +50,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/rtcmne/rtcmne.pro
+++ b/applications/mne_scan/plugins/rtcmne/rtcmne.pro
@@ -50,6 +50,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/applications/mne_scan/plugins/writetofile/writetofile.pro
+++ b/applications/mne_scan/plugins/writetofile/writetofile.pro
@@ -51,6 +51,13 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_scan_plugins
 
+contains(MNECPP_CONFIG, static) {
+    CONFIG += staticlib
+    DEFINES += STATICBUILD
+} else {
+    CONFIG += shared
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lscSharedd \

--- a/doc/gh-pages/pages/development/qtwasmtutorial.md
+++ b/doc/gh-pages/pages/development/qtwasmtutorial.md
@@ -78,7 +78,7 @@ Build Qt from source. This is needed since we want to have threading support whi
   ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
   ```
 
-  * Navigate to parent directory, create new shadow build folder and cd into it:
+  * Navigate to the parent directory, create a new shadow build folder and cd into it:
 
   ```
   cd ..
@@ -86,7 +86,7 @@ Build Qt from source. This is needed since we want to have threading support whi
   cd qt5_shadow
   ```
 
-  * Call configure from new working directory in order to perform a shadow build.
+  * Call configure from the new working directory in order to setup a shadow build.
 
   With thread support:
 

--- a/doc/gh-pages/pages/development/qtwasmtutorial.md
+++ b/doc/gh-pages/pages/development/qtwasmtutorial.md
@@ -117,7 +117,7 @@ MNE-CPP needs to be build statically. This is automatically done if the `wasm` f
 MNECPP_CONFIG += wasm
 ```
 
-Create a shadow build folder, run qmake and build MNE-CPP:
+Create a shadow build folder, run `qmake` and build MNE-CPP:
 
 ```
 mkdir mne-cpp_shadow

--- a/doc/gh-pages/pages/development/qtwasmtutorial.md
+++ b/doc/gh-pages/pages/development/qtwasmtutorial.md
@@ -24,19 +24,18 @@ Git/
 
 ## Setup Qt Wasm to work with MNE-CPP on Ubuntu 18.04.03 64bit
 
- * According to the official Qt Wasm (WebAssembly) guide, the preferred emscripten versions are:
+According to the official Qt Wasm (WebAssembly) guide, the preferred emscripten versions are:
 
-   Qt 5.12: 1.38.16
-
-   Qt 5.13: 1.38.27 (multithreading: 1.38.30)
-
-   Qt 5.14: it's complicated (1.38.27)
-
-   Qt 5.15: 1.39.8
+```
+Qt 5.12: 1.38.16
+Qt 5.13: 1.38.27 (multithreading: 1.38.30)
+Qt 5.14: it's complicated (1.38.27)
+Qt 5.15: 1.39.8
+```
 
  | **Please note:** With the versions above some functions are not able to be linked and produce errors. It is possible that some MNE-CPP functions are not compatible with these emscripten versions. However, emscripten version 1.39.3 and 1.39.8 seem to be working with MNE-CPP code. The following setups should work: **Qt5.13.2 compiled with em++ 1.39.3 with thread support**, **Qt5.14.2 compiled with em++ 1.39.3 with thread support** and  **Qt5.15.0 compiled with em++ 1.39.8 with thread support**. | 
 
-* Get the [emscripten](https://emscripten.org/){:target="_blank" rel="noopener"} compiler:
+Get the [emscripten](https://emscripten.org/){:target="_blank" rel="noopener"} compiler:
 
   ```
   # Get the emsdk repo
@@ -56,92 +55,92 @@ Git/
   source ./emsdk_env.sh
   ```
 
- * Build Qt from source. This is needed since we want to have threading support which is deactivated for the pre-built QtWasm build. Also, the pre-built QtWasm binaries are build with emscripten version 1.38.30 which does not work with MNE-CPP code.
+Build Qt from source. This is needed since we want to have threading support which is deactivated for the pre-built QtWasm build. Also, the pre-built QtWasm binaries are build with emscripten version 1.38.30 which does not work with MNE-CPP code.
 
-    * Make sure to activate and source the correct emscripten version since the compiler will be used when building qt against wasm. You could also add this to your .basrc file. For example:
+  * Make sure to activate and source the correct emscripten version since the compiler will be used when building qt against wasm. You could also add this to your .basrc file. For example:
 
-      ```
-      ./emsdk activate 1.39.3
-      source ./emsdk_env.sh
-      ```
+  ```
+  ./emsdk activate 1.39.3
+  source ./emsdk_env.sh
+  ```
 
-    * Install some dependencies (just to make sure)
+  * Install some dependencies (just to make sure)
 
-      ```
-      sudo apt-get install build-essential libgl1-mesa-dev python
-      ```
+  ```
+  sudo apt-get install build-essential libgl1-mesa-dev python
+  ```
 
-    * Clone current Qt version. For example Qt 5.14.2:
+  * Clone the current Qt version. For example Qt 5.14.2:
 
-      ```
-      git clone https://code.qt.io/qt/qt5.git -b 5.14.2      
-      cd qt5
-      ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
-      ```
+  ```
+  git clone https://code.qt.io/qt/qt5.git -b 5.14.2      
+  cd qt5
+  ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
+  ```
 
-    * Navigate to parent directory, create new shadow build folder and cd into it:
+  * Navigate to parent directory, create new shadow build folder and cd into it:
 
-      ```
-      cd ..
-      mkdir qt5_shadow
-      cd qt5_shadow
-      ```
+  ```
+  cd ..
+  mkdir qt5_shadow
+  cd qt5_shadow
+  ```
 
-    * Call configure from new working directory in order to perform a shadow build.
+  * Call configure from new working directory in order to perform a shadow build.
 
-      With thread support:
+  With thread support:
 
-      ```
-      ../qt5/configure -opensource -confirm-license -xplatform wasm-emscripten -feature-thread -nomake examples -no-dbus -no-ssl -prefix ../qt5_wasm_binaries
-      ```
+  ```
+  ../qt5/configure -opensource -confirm-license -xplatform wasm-emscripten -feature-thread -nomake examples -no-dbus -no-ssl -prefix ../qt5_wasm_binaries
+  ```
 
-      Without thread support:
+  Without thread support:
 
-      ```
-      ../qt5/configure -opensource -confirm-license -xplatform wasm-emscripten -nomake examples -no-dbus -no-ssl -prefix ../qt5_wasm_binaries
-      ```
+  ```
+  ../qt5/configure -opensource -confirm-license -xplatform wasm-emscripten -nomake examples -no-dbus -no-ssl -prefix ../qt5_wasm_binaries
+  ```
 
-    * Build Qt and install to target (prefix) location afterwards. For MNE-CPP we only need the qt charts, qtsvg and qtbase module (see [https://wiki.qt.io/Qt_for_WebAssembly](https://wiki.qt.io/Qt_for_WebAssembly){:target="_blank" rel="noopener"} for officially supported modules):
+  * Build Qt and install to target (prefix) location afterwards. For MNE-CPP we only need the qt charts, qtsvg and qtbase module (see [https://wiki.qt.io/Qt_for_WebAssembly](https://wiki.qt.io/Qt_for_WebAssembly){:target="_blank" rel="noopener"} for officially supported modules):
 
-      ```
-      make module-qtbase module-qtsvg module-qtcharts -j8
-      make install -j8
-      ```
+  ```
+  make module-qtbase module-qtsvg module-qtcharts -j8
+  make install -j8
+  ```
 
   * A static Qt Wasm version should now be setup in the `qt5_wasm_binaries` folder.
 
 ## Building MNE-CPP against QtWasm
 
- * MNE-CPP needs to be build statically. This is automatically done if the `wasm` flag is set. Navigate to mne-cpp/mne-cpp.pri and add the wasm flag. This will build MNE-CPP statically and configure only wasm supported MNE-CPP code.
+MNE-CPP needs to be build statically. This is automatically done if the `wasm` flag is set. Navigate to mne-cpp/mne-cpp.pri and add the wasm flag. This will build MNE-CPP statically and configure only wasm supported MNE-CPP code.
 
-  ```
-  MNECPP_CONFIG += wasm
-  ```
+```
+MNECPP_CONFIG += wasm
+```
 
- * Create a shadow build folder, run qmake and build MNE-CPP:
+Create a shadow build folder, run qmake and build MNE-CPP:
 
-  ```
-  mkdir mne-cpp_shadow
-  cd mne-cpp_shadow
-  ../qt5_wasm_binaries/bin/qmake ../mne-cpp/mne-cpp.pro
-  make -j8
-  ```
+```
+mkdir mne-cpp_shadow
+cd mne-cpp_shadow
+../qt5_wasm_binaries/bin/qmake ../mne-cpp/mne-cpp.pro
+make -j8
+```
 
- * This should create the applications featured under applications, e.g. MNE Browse, to be build to mne-cpp/bin
+This should create the applications featured under applications, e.g. MNE Browse, to be build to mne-cpp/bin
 
 ## Running an application
 
- * Navigate to `mne-cpp/bin` and start a server
+Navigate to `mne-cpp/bin` and start a server
 
-  ```
-  python3 -m http.server
-  ```
+```
+python3 -m http.server
+```
 
- * Go to a suitable web browser (Chromium based and Mozilla browsers seem to work the best) and type:
+Start to a suitable web browser (Chromium based browsers and Mozilla seem to work the best) and type:
 
-  ```
-  http://localhost:8000/mne_browse.html
-  ```
+```
+http://localhost:8000/mne_browse.html
+```
 
 ## Example builds
 

--- a/doc/gh-pages/pages/development/qtwasmtutorial.md
+++ b/doc/gh-pages/pages/development/qtwasmtutorial.md
@@ -1,9 +1,9 @@
 ---
-title: MNE-CPP with QtWasm
+title: WebAssembly Build Guide
 parent: Develop
 nav_order: 3
 ---
-# MNE-CPP with QtWasm
+# WebAssembly Build Guide
 
 This tutorial will show you how to build a Wasm (WebAssembly) version of MNE-CPP. In order to build a Wasm version we need to do three things:
 

--- a/doc/gh-pages/pages/development/staticbuild.md
+++ b/doc/gh-pages/pages/development/staticbuild.md
@@ -69,7 +69,7 @@ Setup the following tools:
 * Install [Python](https://www.python.org/downloads/){:target="_blank" rel="noopener"} and add it to `PATH`
 * Isntall MSVC 2015 or higher (We recommend the [MSVC 2017 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"}
 * Install the Windows 10 SDK 
-* If you want to use multiple cores (nmake does not support multicore usage), install the [jom compiler](http://download.qt.io/official_releases/jom/jom.zip){:target="_blank" rel="noopener"} and add it to `PATH`
+* If you want to use multiple cores (`nmake` does not support multicore usage), install the [jom compiler](http://download.qt.io/official_releases/jom/jom.zip){:target="_blank" rel="noopener"} and add it to `PATH`
 
 Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase includes most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 you would type:
 
@@ -107,9 +107,9 @@ jom -j8
 nmake install
 ```
 
-## Compile MNE-CPP with the static flag
+## Compile MNE-CPP with the `static` flag
 
-Create a shadow build folder, run qmake and build MNE-CPP (on Windows use `nmake` or `jom` instead of `make`):
+Create a shadow build folder, run `qmake` and build MNE-CPP (on Windows use `nmake` or `jom` instead of `make`):
 
 ```
 mkdir mne-cpp_shadow

--- a/doc/gh-pages/pages/development/staticbuild.md
+++ b/doc/gh-pages/pages/development/staticbuild.md
@@ -22,6 +22,16 @@ Git/
 
 ## Build a static version of Qt
 
+### Get the Qt source code
+
+Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase subdivides in other modules reflecting most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 you would type:
+
+```
+git clone https://code.qt.io/qt/qt5.git -b 5.14.2  
+cd qt5
+perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+```
+
 ### Linux/MacOS
 
 Install OpenGL dependencies (just to make sure). This is only needed on Linux:
@@ -30,11 +40,9 @@ Install OpenGL dependencies (just to make sure). This is only needed on Linux:
 sudo apt-get install build-essential libgl1-mesa-dev
 ```
 
-Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase subdivides in other modules reflecting most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 you would type:
+Navigate to the `qt5` folder and init the repository:
 
 ```
-git clone https://code.qt.io/qt/qt5.git -b 5.14.2  
-cd qt5
 ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
 ```
 
@@ -67,15 +75,13 @@ Setup the following tools:
 
 * Install [Perl](https://www.activestate.com/products/perl/downloads/){:target="_blank" rel="noopener"} and add it to `PATH`
 * Install [Python](https://www.python.org/downloads/){:target="_blank" rel="noopener"} and add it to `PATH`
-* Isntall MSVC 2015 or higher (We recommend the [MSVC 2017 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"}
+* Install MSVC 2015 or higher (We recommend the [MSVC 2017 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"})
 * Install the Windows 10 SDK 
 * If you want to use multiple cores (`nmake` does not support multicore usage), install the [jom compiler](http://download.qt.io/official_releases/jom/jom.zip){:target="_blank" rel="noopener"} and add it to `PATH`
 
-Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase includes most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 you would type:
+Navigate to the `qt5` folder and init the repository:
 
 ```
-git clone https://code.qt.io/qt/qt5.git -b 5.14.2  
-cd qt5
 perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
 ```
 
@@ -87,7 +93,7 @@ mkdir qt5_shadow
 cd qt5_shadow
 ```
 
-Setup the visual studio compiler bz starting the `VS2015 x64 Native Tools Command Prompt` or by typing (the following assumes your are using MSVC 2015):
+Setup the visual studio compiler by starting the `VS2015 x64 Native Tools Command Prompt` or by typing (the following assumes your are using MSVC 2015):
     
 ```
 cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"

--- a/doc/gh-pages/pages/development/staticbuild.md
+++ b/doc/gh-pages/pages/development/staticbuild.md
@@ -24,56 +24,98 @@ Git/
 
 ### Linux/MacOS
 
-* Install OpenGL dependencies (just to make sure). This is only needed on Linux:
+Install OpenGL dependencies (just to make sure). This is only needed on Linux:
 
-    ```
-    sudo apt-get install build-essential libgl1-mesa-dev
-    ```
+```
+sudo apt-get install build-essential libgl1-mesa-dev
+```
 
-* Clone current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase includes most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 you would type:
+Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase subdivides in other modules reflecting most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 you would type:
 
-    ```
-    git clone https://code.qt.io/qt/qt5.git -b 5.14.2  
-    cd qt5
-    ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
-    ```
+```
+git clone https://code.qt.io/qt/qt5.git -b 5.14.2  
+cd qt5
+./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+```
 
-* Navigate to parent directory, create new shadow build folder and cd into it:
+Navigate to parent directory, create new shadow build folder and cd into it:
 
-    ```
-    cd ..
-    mkdir qt5_shadow
-    cd qt5_shadow
-    ```
+```
+cd ..
+mkdir qt5_shadow
+cd qt5_shadow
+```
 
-* Call configure from new working directory in order to perform a shadow build.
+Call configure from new working directory in order to perform a shadow build.
 
-    ```
-    ../qt5/configure -static -release -prefix "../qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
-    ```
+```
+../qt5/configure -static -release -prefix "../qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
+```
 
-* Build Qt and install to target (prefix) location afterwards. You can change the `-j8` flag to the number of cores you want to use during compilation:
+Build Qt and install to target (prefix) location afterwards. You can change the `-j8` flag to the number of cores you want to use during compilation:
 
-    ```
-    make module-qtbase module-qtsvg module-qtcharts module-qt3d -j8
-    make install -j8
-    ```
+```
+make module-qtbase module-qtsvg module-qtcharts module-qt3d -j8
+make install -j8
+```
 
-* A static Qt version should now be setup in the `qt5_binaries` folder.
+A static Qt version should now be setup in the `qt5_binaries` folder.
 
 ### Windows
 
-It's complicated. A guide on how to build Qt statically on Windows wil follow soon.
+Setup the following tools:
+
+* Install [Perl](https://www.activestate.com/products/perl/downloads/){:target="_blank" rel="noopener"} and add it to `PATH`
+* Install [Python](https://www.python.org/downloads/){:target="_blank" rel="noopener"} and add it to `PATH`
+* Isntall MSVC 2015 or higher (We recommend the [MSVC 2017 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"}
+* Install the Windows 10 SDK 
+* If you want to use multiple cores (nmake does not support multicore usage), install the [jom compiler](http://download.qt.io/official_releases/jom/jom.zip){:target="_blank" rel="noopener"} and add it to `PATH`
+
+Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase includes most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 you would type:
+
+```
+git clone https://code.qt.io/qt/qt5.git -b 5.14.2  
+cd qt5
+perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+```
+
+Navigate to parent directory, create new shadow build folder and cd into it:
+
+```
+cd ..
+mkdir qt5_shadow
+cd qt5_shadow
+```
+
+Setup the visual studio compiler bz starting the `VS2015 x64 Native Tools Command Prompt` or by typing (the following assumes your are using MSVC 2015):
+    
+```
+cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+```
+
+Call configure from new working directory in order to perform a shadow build.
+
+```
+../qt5/configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "C:\qt5_static_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
+```
+    
+Build Qt and install to target (prefix) location afterwards. You can change the `-j8` flag to the number of cores you want to use during compilation:
+
+```
+jom -j8
+nmake install
+```
 
 ## Compile MNE-CPP with the static flag
 
-* Create a shadow build folder, run qmake and build MNE-CPP (on Windows use `nmake` or `jom` instead of `make`):
+Create a shadow build folder, run qmake and build MNE-CPP (on Windows use `nmake` or `jom` instead of `make`):
 
-    ```
-    mkdir mne-cpp_shadow
-    cd mne-cpp_shadow
-    ../qt5_binaries/bin/qmake ../mne-cpp/mne-cpp.pro MNECPP_CONFIG += static
-    make -j8
-    ```
+```
+mkdir mne-cpp_shadow
+cd mne-cpp_shadow
+../qt5_binaries/bin/qmake ../mne-cpp/mne-cpp.pro MNECPP_CONFIG += static
+make -j8
+```
 
-* All MNE-CPP applications (MNE Scan, examples, tests, etc.) should now be in the `mne-cpp/bin` folder.
+All MNE-CPP applications (MNE Scan, examples, tests, etc.) should now be in the `mne-cpp/bin` folder.

--- a/doc/gh-pages/pages/development/staticbuild.md
+++ b/doc/gh-pages/pages/development/staticbuild.md
@@ -5,7 +5,7 @@ nav_order: 4
 ---
 # Static Build Guide
 
-This tutorial will show you how to build a static version of MNE-CPP. In order to build statically we need to do two things:
+This tutorial will show you how to build a static version of MNE-CPP. In order to build statically we need to perform two steps:
 
  * Build a static version of Qt
  * Compile MNE-CPP with the `static` flag
@@ -24,12 +24,11 @@ Git/
 
 ### Get the Qt source code
 
-Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase subdivides in other modules reflecting most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 you would type:
+Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase subdivides in other modules reflecting most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 type:
 
 ```
 git clone https://code.qt.io/qt/qt5.git -b 5.14.2  
 cd qt5
-perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
 ```
 
 ### Linux/MacOS
@@ -46,7 +45,7 @@ Navigate to the `qt5` folder and init the repository:
 ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
 ```
 
-Navigate to parent directory, create new shadow build folder and cd into it:
+Navigate to the parent directory, create a new shadow build folder and cd into it:
 
 ```
 cd ..
@@ -54,7 +53,7 @@ mkdir qt5_shadow
 cd qt5_shadow
 ```
 
-Call configure from new working directory in order to perform a shadow build.
+Call configure from the new working directory in order to setup a shadow build:
 
 ```
 ../qt5/configure -static -release -prefix "../qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
@@ -69,15 +68,15 @@ make install -j8
 
 A static Qt version should now be setup in the `qt5_binaries` folder.
 
-### Windows
+### Windows 10
 
-Setup the following tools:
+Setup the following dependencies:
 
 * Install [Perl](https://www.activestate.com/products/perl/downloads/){:target="_blank" rel="noopener"} and add it to `PATH`
 * Install [Python](https://www.python.org/downloads/){:target="_blank" rel="noopener"} and add it to `PATH`
 * Install MSVC 2015 or higher (We recommend the [MSVC 2017 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"})
-* Install the Windows 10 SDK 
-* If you want to use multiple cores (`nmake` does not support multicore usage), install the [jom compiler](http://download.qt.io/official_releases/jom/jom.zip){:target="_blank" rel="noopener"} and add it to `PATH`
+* Install the [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk/){:target="_blank" rel="noopener"} (can also be installed via the MSVC community edition installer)
+* If you want to use multiple cores (MSVC's `nmake` does not support multicore usage), install the [jom compiler](http://download.qt.io/official_releases/jom/jom.zip){:target="_blank" rel="noopener"} and add it to `PATH`
 
 Navigate to the `qt5` folder and init the repository:
 
@@ -85,7 +84,7 @@ Navigate to the `qt5` folder and init the repository:
 perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
 ```
 
-Navigate to parent directory, create new shadow build folder and cd into it:
+Navigate to the parent directory, create a new shadow build folder and cd into it:
 
 ```
 cd ..
@@ -93,14 +92,14 @@ mkdir qt5_shadow
 cd qt5_shadow
 ```
 
-Setup the visual studio compiler by starting the `VS2015 x64 Native Tools Command Prompt` or by typing (the following assumes your are using MSVC 2015):
+Setup the visual studio compiler by starting the `VS2017 x64 Native Tools Command Prompt` or by typing (assuming you are using MSVC 2017):
     
 ```
-cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 15.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
 Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
 ```
 
-Call configure from new working directory in order to perform a shadow build.
+Call configure from the new working directory in order to setup a shadow build.
 
 ```
 ../qt5/configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "C:\qt5_static_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license

--- a/doc/gh-pages/pages/started/started.md
+++ b/doc/gh-pages/pages/started/started.md
@@ -7,11 +7,11 @@ nav_order: 2
 
 This is the quickest way to get MNE-CPP up and running on your machine:
 
-* Download the latest version of MNE-CPP.
-
-&nbsp; &nbsp; &nbsp; &nbsp; [Windows](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-windows-x86_64.zip){: .btn .btn-green } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-linux-x86_64.tar.gz){: .btn .btn-green } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-macos-x86_64.tar.gz){: .btn .btn-green }
-
 | **Please note:** Currently only a development version is available. |
+
+* Download MNE-CPP:
+
+&nbsp; &nbsp; &nbsp; &nbsp; [Windows](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-windows-static-x86_64.zip){: .btn .btn-green } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-linux-static-x86_64.tar.gz){: .btn .btn-green } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-macos-static-x86_64.tar.gz){: .btn .btn-green }
 
 * Unzip the downloaded file.
 

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -136,7 +136,7 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2019 Authors of mne-cpp. All rights reser
 ## To build MNE Scan with TMSI support: qmake MNECPP_CONFIG+=withTmsi
 
 # Default flags
-MNECPP_CONFIG += dispOpenGL
+MNECPP_CONFIG += dispOpenGL static
 
 # Minimal version needs at least qt version 5.2.1
 !minQtVersion(5, 2, 1) {

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -136,7 +136,7 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2019 Authors of mne-cpp. All rights reser
 ## To build MNE Scan with TMSI support: qmake MNECPP_CONFIG+=withTmsi
 
 # Default flags
-MNECPP_CONFIG += dispOpenGL static
+MNECPP_CONFIG += dispOpenGL
 
 # Minimal version needs at least qt version 5.2.1
 !minQtVersion(5, 2, 1) {

--- a/testframes/test_mne_anonymize/test_mne_anonymize.pro
+++ b/testframes/test_mne_anonymize/test_mne_anonymize.pro
@@ -50,6 +50,13 @@ CONFIG(debug, debug|release) {
     TARGET = $$join(TARGET,,,d)
 }
 
+DESTDIR =  $${MNE_BINARY_DIR}
+
+contains(MNECPP_CONFIG, static) {
+    CONFIG += static
+    DEFINES += STATICBUILD
+}
+
 LIBS += -L$${MNE_LIBRARY_DIR}
 CONFIG(debug, debug|release) {
     LIBS += -lMNE$${MNE_LIB_VERSION}Fiffd \
@@ -58,8 +65,6 @@ CONFIG(debug, debug|release) {
     LIBS += -lMNE$${MNE_LIB_VERSION}Fiff \
             -lMNE$${MNE_LIB_VERSION}Utils
 }
-
-DESTDIR =  $${MNE_BINARY_DIR}
 
 SOURCES += \
     test_mne_anonymize.cpp \
@@ -78,7 +83,7 @@ contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += -fprofile-arcs -ftest-coverage
 }
 
-win32 {
+win32:!contains(MNECPP_CONFIG, static) {
     EXTRA_ARGS =
     DEPLOY_CMD = $$winDeployAppArgs($${TARGET},$${TARGET_EXT},$${MNE_BINARY_DIR},$${LIBS},$${EXTRA_ARGS})
     QMAKE_POST_LINK += $${DEPLOY_CMD}


### PR DESCRIPTION
This PR adds the missing static builds for Windows. It includes the following changes:

- Some minor improvements to the "WebAssembly Build Guide" docu page , see [here](http://lorenze.github.io/mne-cpp/pages/development/qtwasmtutorial.html)
- Add windows guide to the static build guide docu page, see [here](http://lorenze.github.io/mne-cpp/pages/development/staticbuild.html)
- Add the Windows static builds to the Github action workflow, see [here](https://github.com/LorenzE/mne-cpp/blob/98aed624a92726ee9e4863793f05d4726fabf465/.github/workflows/devbuilds.yml#L129)
- Add missing static flags and defines to most of the MNE Scan plugins. This fixed building MNE Scan on Windows statically
- Fix static flag from `staticlib` to `static` in mne_scan.pro
- Prevent the call of `windeployqt` when building statically on Windows
- Set static builds as default in the "Getting started" page on the MNE-CPP website