### PR TITLE
[MAINT] Fix meta data loading when building statically

### DIFF
--- a/applications/mne_rt_server/mne_rt_server.pro
+++ b/applications/mne_rt_server/mne_rt_server.pro
@@ -43,6 +43,6 @@ SUBDIRS += \
     plugins \
     mne_rt_server \
 
-# Specify dependencies because of packaging on MacOS
+# Specify dependencies because of packaging on MacOS and when building a static version of MNE-CPP
 plugins.depends =
 mne_rt_server.depends = plugins

--- a/applications/mne_scan/mne_scan.pro
+++ b/applications/mne_scan/mne_scan.pro
@@ -43,7 +43,7 @@ SUBDIRS += \
     plugins \
     mne_scan \
 
-# Specify dependencies because of packaging on MacOS
+# Specify dependencies because of packaging on MacOS and when building a static version of MNE-CPP
 libs.depends =
 plugins.depends = libs
 mne_scan.depends = libs plugins


### PR DESCRIPTION
Use the [QStaticPlugin struct](https://doc.qt.io/qt-5/qstaticplugin.html) to fix meta data handling in mne_rt_Server plugins when building statically.