### PR TITLE
[ENH] MNE_ANONYMIZE show help in case of invaild option parsing

### DIFF
--- a/applications/mne_anonymize/settingscontroller.cpp
+++ b/applications/mne_anonymize/settingscontroller.cpp
@@ -74,8 +74,12 @@ SettingsController::SettingsController(const QStringList& arguments,
 , m_bMultipleInFiles(false)
 {
     initParser();
-    if(parseInputs(arguments)) {
+    bool exitCode = parseInputs(arguments);
+    if(exitCode) {
         execute();
+    } else
+    {
+        m_parser.showHelp(exitCode);
     }
 }
 


### PR DESCRIPTION
I just want to show the help text whenever thee input parse did not work. 

Compiles and runs just fine. should've been implemented from the beginning.