### PR TITLE
[ENH,FIX] MNE Analyze improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -706,7 +706,7 @@ jobs:
         rm -r bin/mne-cpp-test-data
         rm -r bin/MNE-sample-data
         # Replace logo
-        cp -RT tools/design/logos/qtlogo.svg qtlogo.svg
+        cp -RT tools/design/logos/qtlogo.svg bin/qtlogo.svg
         # Clone repo and update with new wasm versions
         git config --global user.email lorenzesch@hotmail.com
         git config --global user.name LorenzE

--- a/applications/mne_analyze/extensions/annotationmanager/annotationmanager.cpp
+++ b/applications/mne_analyze/extensions/annotationmanager/annotationmanager.cpp
@@ -85,26 +85,18 @@ void AnnotationManager::init()
 {
     m_pCommu = new Communicator(this);
 
-    m_pAnnotationView = QSharedPointer<AnnotationView>(new AnnotationView());
+    m_pAnnotationView = new AnnotationView();
 
-    connect(m_pAnnotationView.data(), &AnnotationView::triggerRedraw,
+    connect(m_pAnnotationView, &AnnotationView::triggerRedraw,
             this, &AnnotationManager::onTriggerRedraw);
 
-    connect(m_pAnnotationView.data(), &AnnotationView::activeEventsChecked,
+    connect(m_pAnnotationView, &AnnotationView::activeEventsChecked,
             this, &AnnotationManager::toggleDisplayEvent);
 
     //connect(m_pAnalyzeData.data(), &AnalyzeData::newModelAvailable,
     //        this, &AnnotationManager::onModelChanged);
     connect(m_pAnalyzeData.data(), &AnalyzeData::selectedModelChanged,
             this, &AnnotationManager::onModelChanged);
-
-//    m_pAnnotationManagerControl = new AnnotationManagerControl();
-
-//    connect(m_pAnnotationManagerControl.data(), &AnnotationManagerControl::loadFiffFile,
-//            this, &AnnotationManager::onLoadFiffFilePressed);
-
-//    connect(m_pAnnotationManagerControl.data(), &AnnotationManagerControl::saveFiffFile,
-//            this, &AnnotationManager::onSaveFiffFilePressed);
 }
 
 //=============================================================================================================
@@ -132,13 +124,11 @@ QMenu *AnnotationManager::getMenu()
 
 QDockWidget *AnnotationManager::getControl()
 {
-    if(!m_pControl) {
-        m_pControl = new QDockWidget(tr("Annotation Manager"));
-        m_pControl->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea);
-        m_pControl->setWidget(m_pAnnotationView.data());
-    }
+    QDockWidget* pControl = new QDockWidget(tr("Annotation Manager"));
+    pControl->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea);
+    pControl->setWidget(m_pAnnotationView);
 
-    return m_pControl;
+    return pControl;
 }
 
 //=============================================================================================================
@@ -188,9 +178,6 @@ void AnnotationManager::onModelChanged(QSharedPointer<ANSHAREDLIB::AbstractModel
             }
         }
 
-//        m_pAnnotationView.reset();
-//        m_pAnnotationView = QSharedPointer<AnnotationView>(new AnnotationView());
-
         m_pAnnotationView->disconnectFromModel();
         m_pFiffRawModel = qSharedPointerCast<FiffRawViewModel>(pNewModel);
         m_pAnnotationModel = m_pFiffRawModel->getAnnotationModel();
@@ -205,7 +192,7 @@ void AnnotationManager::onModelChanged(QSharedPointer<ANSHAREDLIB::AbstractModel
 
 void AnnotationManager::setUpControls()
 {
-    connect(m_pAnnotationView.data(), &AnnotationView::activeEventsChecked,
+    connect(m_pAnnotationView, &AnnotationView::activeEventsChecked,
             this, &AnnotationManager::toggleDisplayEvent);
 }
 
@@ -214,7 +201,6 @@ void AnnotationManager::setUpControls()
 void AnnotationManager::toggleDisplayEvent(const int& iToggle)
 {
     int m_iToggle = iToggle;
-    //qDebug() << "toggleDisplayEvent" << iToggle;
     m_pFiffRawModel->toggleDispAnn(m_iToggle);
     m_pCommu->publishEvent(TRIGGER_REDRAW);
 }

--- a/applications/mne_analyze/extensions/annotationmanager/annotationmanager.h
+++ b/applications/mne_analyze/extensions/annotationmanager/annotationmanager.h
@@ -142,12 +142,9 @@ public:
     void onTriggerRedraw();
 
 private:
-
-    QPointer<QDockWidget>                                   m_pControl;                 /**< Dock Control Widget */
-
     QPointer<ANSHAREDLIB::Communicator>                     m_pCommu;                   /**< To broadcst signals */
 
-    QSharedPointer<AnnotationView>                          m_pAnnotationView;          /**< Pointer to associated View for this extension */
+    AnnotationView*                                         m_pAnnotationView;          /**< Pointer to associated View for this extension */
 
     QSharedPointer<ANSHAREDLIB::AnnotationModel>            m_pAnnotationModel;         /**< Pointer to associated Model for this extension */
 

--- a/applications/mne_analyze/extensions/dataloader/dataloader.cpp
+++ b/applications/mne_analyze/extensions/dataloader/dataloader.cpp
@@ -170,7 +170,9 @@ void DataLoader::onLoadFiffFilePressed()
                                                     QDir::currentPath()+"/MNE-sample-data",
                                                     tr("Fiff file(*.fif *.fiff)"));
 
-    if(!filePath.isNull()) {
+    QFileInfo fileInfo(filePath);
+
+    if(fileInfo.exists() && (fileInfo.completeSuffix() == "fif")) {
         m_pAnalyzeData->loadModel<FiffRawViewModel>(filePath);
     }
 #endif
@@ -189,7 +191,9 @@ void DataLoader::onSaveFiffFilePressed()
                                                     QDir::currentPath()+"/MNE-sample-data",
                                                     tr("Fiff file(*.fif *.fiff)"));
 
-    if(!filePath.isNull()) {
+    QFileInfo fileInfo(filePath);
+
+    if(fileInfo.exists() && (fileInfo.completeSuffix() == "fif")) {
         m_pAnalyzeData->saveModel(m_sCurrentlySelectedModel, filePath);
     }
 #endif

--- a/applications/mne_analyze/libs/anShared/Management/analyzedata.h
+++ b/applications/mne_analyze/libs/anShared/Management/analyzedata.h
@@ -160,10 +160,14 @@ public:
             QSharedPointer<AbstractModel> temp = qSharedPointerCast<AbstractModel>(sm);
             temp->setModelPath(sPath);
 
-            // add to record, and tell others about the new model
-            m_data.insert(sPath, temp);
-            emit this->newModelAvailable(temp);
-            return sm;
+            if(temp->isInit()) {
+                // add to record, and tell others about the new model
+                m_data.insert(sPath, temp);
+                emit this->newModelAvailable(temp);
+                return sm;
+            } else {
+                return Q_NULLPTR;
+            }
         }
     }
 

--- a/applications/mne_analyze/libs/anShared/Management/extensionmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/extensionmanager.cpp
@@ -93,20 +93,19 @@ void ExtensionManager::loadExtensionsFromDirectory(const QString& dir)
 #else
     QDir extensionsDir(dir);
 
-    foreach(const QString &file, extensionsDir.entryList(QDir::Files))
-    {
-        qDebug() << "[ExtensionManager::loadExtension] Loading Extension " << file.toUtf8().constData() << "... ";
+    foreach(const QString &file, extensionsDir.entryList(QDir::Files)) {
+        // Exclude .exp and .lib files (only relevant for windows builds)
+        if(!file.contains(".exp") && !file.contains(".lib")) {
+            this->setFileName(extensionsDir.absoluteFilePath(file));
+            QObject *pExtension = this->instance();
 
-        this->setFileName(extensionsDir.absoluteFilePath(file));
-        QObject *pExtension = this->instance();
-
-        // IExtension
-        if(pExtension) {
-            qDebug() << "[ExtensionManager::loadExtension] Extension " << file.toUtf8().constData() << " loaded.";
-            m_qVecExtensions.push_back(qobject_cast<IExtension*>(pExtension));
-        }
-        else {
-            qDebug() << "[ExtensionManager::loadExtension] Extension " << file.toUtf8().constData() << " could not be instantiated!";
+            // IExtension
+            if(pExtension) {
+                qDebug() << "[ExtensionManager::loadExtension] Loading Extension" << file.toUtf8().constData() << "succeeded.";
+                m_qVecExtensions.push_back(qobject_cast<IExtension*>(pExtension));
+            } else {
+                qDebug() << "[ExtensionManager::loadExtension] Loading Extension" << file.toUtf8().constData() << "failed.";
+            }
         }
     }
 #endif

--- a/applications/mne_analyze/libs/anShared/Model/abstractmodel.h
+++ b/applications/mne_analyze/libs/anShared/Model/abstractmodel.h
@@ -170,6 +170,14 @@ public:
     virtual inline bool saveToFile(const QString& sPath);
 
     //=========================================================================================================
+    /**
+     * Whether the model has been initialized.
+     *
+     * @returns Tru or false flag whether the model has been initialized or not.
+     */
+    virtual inline bool isInit();
+
+    //=========================================================================================================
     // Inherited by QAbstractItemModel:
     virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override = 0;
     virtual Qt::ItemFlags flags(const QModelIndex &index) const override = 0;
@@ -179,8 +187,9 @@ public:
     virtual int columnCount(const QModelIndex &parent = QModelIndex()) const override = 0;
 
 protected:
+    ModelPath   m_modelPath;
 
-    ModelPath m_modelPath;
+    bool        m_bIsInit = false;          /**< Whether the model has been initialized. */
 };
 
 //=============================================================================================================
@@ -212,6 +221,13 @@ bool AbstractModel::saveToFile(const QString& sPath)
 {
     qDebug() << "[AbstractModel::saveToFile] Saving data to" << sPath << "is not implemented for MODELTYPE = " << getType();
     return false;
+}
+
+//=============================================================================================================
+
+bool AbstractModel::isInit()
+{
+    return m_bIsInit;
 }
 
 } // namespace ANSHAREDLIB

--- a/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.cpp
+++ b/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.cpp
@@ -216,6 +216,8 @@ void FiffRawViewModel::initFiffData(QIODevice& p_IODevice)
 
     // need to close the file manually
     p_IODevice.close();
+
+    m_bIsInit = true;
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
+++ b/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
@@ -438,7 +438,6 @@ public:
     void addTimeMark(int iLastClicked);
 
 private:
-
     //=========================================================================================================
     /**
      * This is a helper method thats is meant to correctly set the endOfFile / startOfFile flags whenever needed
@@ -484,15 +483,12 @@ private:
      */
     void updateDisplayData();
 
-
-
 signals:
-
     //=========================================================================================================
     /**
       * Emits that new block data is loaded
       */
-     void newBlocksLoaded();
+    void newBlocksLoaded();
 
 private:
 

--- a/libraries/fiff/fiff_io.cpp
+++ b/libraries/fiff/fiff_io.cpp
@@ -111,19 +111,29 @@ bool FiffIO::read(QIODevice& p_IODevice)
     //Read dirTree from fiff data (raw,evoked,fwds,cov)
     FiffInfo t_fiffInfo;
     FiffDirNode::SPtr t_dirTree;
-    bool hasRaw=false,hasEvoked=false; // hasFwds=false;
+    bool hasRaw = false;
+    bool hasEvoked = false; // hasFwds=false;
 
-    FiffIO::setup_read(p_IODevice,t_fiffInfo,t_dirTree);
+    FiffIO::setup_read(p_IODevice, t_fiffInfo, t_dirTree);
     p_IODevice.close(); //file can be closed, since IODevice is already read
 
+    if(!t_dirTree) {
+        qWarning() << "[FiffIO::read] Dir tree could not be read";
+        return false;
+    }
+
     //Search dirTree for specific data types
-    if(t_dirTree->has_kind(FIFFB_EVOKED))
+    if(t_dirTree->has_kind(FIFFB_EVOKED)) {
         hasEvoked = true;
+    }
+
     if(t_dirTree->has_kind(FIFFB_RAW_DATA) ||
        t_dirTree->has_kind(FIFFB_PROCESSED_DATA) ||
        t_dirTree->has_kind(FIFFB_CONTINUOUS_DATA) ||
-       t_dirTree->has_kind(FIFFB_SMSH_RAW_DATA))
+       t_dirTree->has_kind(FIFFB_SMSH_RAW_DATA)) {
         hasRaw = true;
+    }
+
    // if(t_Tree.has_kind(FIFFB_MNE_FORWARD_SOLUTION))
    //     hasFwds = true;
 

--- a/libraries/fiff/fiff_io.h
+++ b/libraries/fiff/fiff_io.h
@@ -1,7 +1,8 @@
 //=============================================================================================================
 /**
  * @file     fiff_io.h
- * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
+ * @author   Florian Schlembach <Florian.Schlembach@tu-ilmenau.de>;
+ *           Lorenz Esch <lesch@mgh.harvard.edu>;
  *           Matti Hamalainen <msh@nmr.mgh.harvard.edu>;
  *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
  * @since    0.1.0
@@ -9,7 +10,7 @@
  *
  * @section  LICENSE
  *
- * Copyright (C) 2012, Lorenz Esch, Matti Hamalainen, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2012, Florian Schlembach, Lorenz Esch, Matti Hamalainen, Christoph Dinh. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
@@ -117,7 +118,6 @@ public:
     FiffIO(const FiffIO& p_FiffIO);
 
     //=========================================================================================================
-
     /**
      * Setup a FiffStream
      *
@@ -127,7 +127,6 @@ public:
      *
      * @return true if succeeded, false otherwise
      */
-
     static bool setup_read(QIODevice& p_IODevice, FiffInfo& info, FiffDirNode::SPtr& dirTree);
 
     //=========================================================================================================
@@ -161,9 +160,9 @@ public:
     /**
      * Write whole data of a type to a fiff file.
      *
-     * @param[in] filename    filename including the path but not the type, e.g. ./sample_date/sample_audvis.fif -> will be extended to ./sample_date/sample_audvis-type-1.fif
-     * @param[in] type of data to write  fiff constants types, e.g. FIFFB_RAW_DATA
-     * @param[in] idx                    index of type, -1 for all entities of this type
+     * @param[in] p_QFile                   filename including the path but not the type, e.g. ./sample_date/sample_audvis.fif -> will be extended to ./sample_date/sample_audvis-type-1.fif
+     * @param[in] type of data to write     fiff constants types, e.g. FIFFB_RAW_DATA
+     * @param[in] idx                       index of type, -1 for all entities of this type
      */
     bool write(QFile& p_QFile, const fiff_int_t type, const fiff_int_t idx) const;
 
@@ -195,8 +194,8 @@ public:
     }
 
 public:
-    QList<QSharedPointer<FiffRawData> > m_qlistRaw;
-    QList<QSharedPointer<FiffEvoked> > m_qlistEvoked;
+    QList<QSharedPointer<FiffRawData> >     m_qlistRaw;
+    QList<QSharedPointer<FiffEvoked> >      m_qlistEvoked;
 //    QList<QSharedPointer<MNEForwardSolution> > m_qlistFwd;
     //FiffCov, MNEInverseOperator, AnnotationSet,
 };


### PR DESCRIPTION
This PR includes:

- Fix crashing when a fif file without raw data was loaded
- Only load .dll plugin files on windows and improve command line output (MNE Scan and MNE Analzye)
- Fix memory leaks when closing MNE Analyze
- Change logo which shows up when loading WASM version of MNE Analyze
- Fix authors in FiffIO class