### PR TITLE
[MAINT]: Fix datatype in fiff_info and fiff_stream

### DIFF
--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -125,10 +125,10 @@ int main(int argc, char *argv[])
     fiff_int_t iQuantum = ceil(fQuantumSec*pFiffInfo->sfreq);
 
     // create time vector that specifies when to fit
-    float dTSec = 0.1;                              // time between hpi fits
-    int iQuantumT = floor(dTSec*pFiffInfo->sfreq);   // samples between fits
+    float fTSec = 0.1;                              // time between hpi fits
+    int iQuantumT = floor(fTSec*pFiffInfo->sfreq);   // samples between fits
     int iN = floor((last-first)/iQuantumT);
-    RowVectorXf vecTime = RowVectorXf::LinSpaced(iN, 0, iN-1) * dTSec;
+    RowVectorXf vecTime = RowVectorXf::LinSpaced(iN, 0, iN-1) * fTSec;
 
     // To fit at specific times outcommend the following block
     // Read Quaternion File

--- a/libraries/communication/rtClient/rtdataclient.cpp
+++ b/libraries/communication/rtClient/rtdataclient.cpp
@@ -336,7 +336,7 @@ FiffInfo::SPtr RtDataClient::readInfo()
             p_pFiffInfo->description = t_pTag->toString();
             break;
         case FIFF_GANTRY_ANGLE:
-            p_pFiffInfo->gantry_angle = *t_pTag->toFloat();
+            p_pFiffInfo->gantry_angle = *t_pTag->toInt();
             break;
         case FIFF_UTC_OFFSET:
             p_pFiffInfo->utc_offset = t_pTag->toString();

--- a/libraries/fiff/fiff_info.cpp
+++ b/libraries/fiff/fiff_info.cpp
@@ -62,7 +62,7 @@ FiffInfo::FiffInfo()
 , linefreq(-1.0)
 , highpass(-1.0)
 , lowpass(-1.0)
-, gantry_angle(-1.0)
+, gantry_angle(-1)
 , acq_pars("")
 , acq_stim("")
 {
@@ -83,7 +83,7 @@ FiffInfo::FiffInfo(const FiffInfo& p_FiffInfo)
 , xplotter_layout(p_FiffInfo.xplotter_layout)
 , experimenter(p_FiffInfo.experimenter)
 , description(p_FiffInfo.description)
-, utc_offset(p_FiffInfo.utc_offset)         /**< UTC offset of related meas_date (sHH:MM).*/
+, utc_offset(p_FiffInfo.utc_offset)
 , gantry_angle(p_FiffInfo.gantry_angle)
 , dev_ctf_t(p_FiffInfo.dev_ctf_t)
 , dig(p_FiffInfo.dig)
@@ -120,7 +120,7 @@ void FiffInfo::clear()
     experimenter = "";
     description = "";
     utc_offset = "";         /**< UTC offset of related meas_date (sHH:MM).*/
-    gantry_angle = -1.0;
+    gantry_angle = -1;
     dev_ctf_t.clear();
     dig.clear();
     dig_trans.clear();
@@ -452,7 +452,7 @@ void FiffInfo::writeToStream(FiffStream* p_pStream) const
     p_pStream->write_string(FIFF_UNIT_C,this->utc_offset);
     p_pStream->write_string(FIFF_PROJ_NAME,this->proj_name);
     p_pStream->write_int(FIFF_PROJ_ID,&this->proj_id);
-    p_pStream->write_float(FIFF_GANTRY_ANGLE,&this->gantry_angle);
+    p_pStream->write_int(FIFF_GANTRY_ANGLE,&this->gantry_angle);
     p_pStream->write_int(FIFF_NCHAN,&nchan);
     p_pStream->write_int(FIFF_DATA_PACK,&data_type);
     if (this->meas_date[0] != -1)

--- a/libraries/fiff/fiff_info.h
+++ b/libraries/fiff/fiff_info.h
@@ -246,26 +246,26 @@ private:
     bool make_compensator(fiff_int_t kind, Eigen::MatrixXd& this_comp) const;
 
 public: //Public because it's a mne struct
-    FiffId file_id;             /**< File ID. */
-    fiff_int_t  meas_date[2];   /**< Measurement date. TODO: use fiffTime instead to be MNE-C consistent*/
-    float sfreq;                /**< Sample frequency. */
-    float linefreq;             /**< Power line frequency. */
-    float highpass;             /**< Highpass frequency. */
-    float lowpass;              /**< Lowpass frequency. */
-    int proj_id;                /**< Project ID */
-    QString proj_name;          /**< Project name */
-    QString xplotter_layout;    /**< xplotter layout tag */
-    QString experimenter;       /**< Experimenter name. */
-    QString description;        /**< (Textual) Description of an object.*/
-    QString utc_offset;         /**< UTC offset of related meas_date (sHH:MM).*/
-    float gantry_angle;         /**< Tilt angle of the dewar in degrees.*/
-    FiffCoordTrans dev_ctf_t;   /**< Coordinate transformation ToDo... */
-    QList<FiffDigPoint> dig;    /**< List of all digitization point descriptors. */
-    FiffCoordTrans dig_trans;   /**< Coordinate transformation ToDo... */
-    QList<FiffProj> projs;      /**< List of available SSP projectors. */
-    QList<FiffCtfComp> comps;   /**< List of available CTF software compensators. */
-    QString acq_pars;           /**< Acquisition information ToDo... */
-    QString acq_stim;           /**< Acquisition information ToDo... */
+    FiffId file_id;                 /**< File ID. */
+    fiff_int_t  meas_date[2];       /**< Measurement date. TODO: use fiffTime instead to be MNE-C consistent*/
+    float sfreq;                    /**< Sample frequency. */
+    float linefreq;                 /**< Power line frequency. */
+    float highpass;                 /**< Highpass frequency. */
+    float lowpass;                  /**< Lowpass frequency. */
+    int proj_id;                    /**< Project ID */
+    QString proj_name;              /**< Project name */
+    QString xplotter_layout;        /**< xplotter layout tag */
+    QString experimenter;           /**< Experimenter name. */
+    QString description;            /**< (Textual) Description of an object.*/
+    QString utc_offset;             /**< UTC offset of related meas_date (sHH:MM).*/
+    fiff_int_t gantry_angle;        /**< Tilt angle of the dewar in degrees.*/
+    FiffCoordTrans dev_ctf_t;       /**< Coordinate transformation ToDo... */
+    QList<FiffDigPoint> dig;        /**< List of all digitization point descriptors. */
+    FiffCoordTrans dig_trans;       /**< Coordinate transformation ToDo... */
+    QList<FiffProj> projs;          /**< List of available SSP projectors. */
+    QList<FiffCtfComp> comps;       /**< List of available CTF software compensators. */
+    QString acq_pars;               /**< Acquisition information ToDo... */
+    QString acq_stim;               /**< Acquisition information ToDo... */
 };
 
 //=============================================================================================================

--- a/libraries/fiff/fiff_stream.cpp
+++ b/libraries/fiff/fiff_stream.cpp
@@ -978,8 +978,8 @@ bool FiffStream::read_meas_info(const FiffDirNode::SPtr& p_Node, FiffInfo& info,
     QString proj_name = "";
     QString xplotter_layout = "";
 
-    QString utc_offset = "";         /**< UTC offset of related meas_date (sHH:MM).*/
-    float gantry_angle = -1.0;
+    QString utc_offset = "";
+    fiff_int_t gantry_angle = -1;
 
     QString experimenter = "";
     QString description = "";
@@ -1063,7 +1063,7 @@ bool FiffStream::read_meas_info(const FiffDirNode::SPtr& p_Node, FiffInfo& info,
                 break;
             case FIFF_GANTRY_ANGLE:
                 this->read_tag(t_pTag,pos);
-                gantry_angle = *t_pTag->toFloat();
+                gantry_angle = *t_pTag->toInt();
                 break;
             case FIFF_UTC_OFFSET:
                 this->read_tag(t_pTag,pos);
@@ -2153,7 +2153,7 @@ FiffStream::SPtr FiffStream::start_writing_raw(QIODevice &p_IODevice,
     t_pStream->write_float(FIFF_HIGHPASS,&info.highpass);
     t_pStream->write_float(FIFF_LOWPASS,&info.lowpass);
     t_pStream->write_float(FIFF_LINE_FREQ,&info.linefreq);
-    t_pStream->write_float(FIFF_GANTRY_ANGLE,&info.gantry_angle);
+    t_pStream->write_int(FIFF_GANTRY_ANGLE,&info.gantry_angle);
     t_pStream->write_int(FIFF_NCHAN,&nchan);
     t_pStream->write_int(FIFF_DATA_PACK,&data_type);
     t_pStream->write_int(FIFF_PROJ_ID,&info.proj_id);


### PR DESCRIPTION
This PR fixes a wrong datatype (float -> fiff_int_t) used in fiff_info and fiff_stream. This was most likely the reason for file reading problems.