### PR TITLE
[FIX] MNE_RT_SERVER issue when reading default config file on mac(?)

### DIFF
--- a/applications/mne_rt_server/mne_rt_server/connectormanager.cpp
+++ b/applications/mne_rt_server/mne_rt_server/connectormanager.cpp
@@ -269,7 +269,7 @@ IConnector* ConnectorManager::getActiveConnector()
             return *it;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 //=============================================================================================================
@@ -383,7 +383,7 @@ void ConnectorManager::loadConnectors(const QString& dir)
         this->setFileName(ConnectorsDir.absoluteFilePath(fileName));
         QObject *pConnector = this->instance();
 
-        printf("\tLoading %s... ", fileName.toUtf8().constData() );
+        printf("Loading %s... \n", fileName.toUtf8().constData() );
 
         // IModule
         if(pConnector)

--- a/applications/mne_rt_server/plugins/fiffsimulator/fiffsimulator.cpp
+++ b/applications/mne_rt_server/plugins/fiffsimulator/fiffsimulator.cpp
@@ -81,11 +81,11 @@ const QString FiffSimulator::Commands::SIMFILE      = "simfile";
 
 FiffSimulator::FiffSimulator()
 : m_pFiffProducer(new FiffProducer(this))
+, m_pRawMatrixBuffer(nullptr)
 , m_sResourceDataPath(QString("%1/MNE-sample-data/MEG/sample/sample_audvis_raw.fif").arg(QCoreApplication::applicationDirPath()))
 , m_uiBufferSampleSize(200)//(4)
 , m_AccelerationFactor(1.0)
 , m_TrueSamplingRate(0.0)
-, m_pRawMatrixBuffer(NULL)
 , m_bIsRunning(false)
 {
     this->init();
@@ -146,7 +146,7 @@ void FiffSimulator::comGetBufsize(Command p_command)
         //create JSON help object
         //
         QJsonObject t_qJsonObjectRoot;
-        t_qJsonObjectRoot.insert(Commands::BUFSIZE, QJsonValue((double)m_uiBufferSampleSize));
+        t_qJsonObjectRoot.insert(Commands::BUFSIZE, QJsonValue(static_cast<double>(m_uiBufferSampleSize)));
         QJsonDocument p_qJsonDocument(t_qJsonObjectRoot);
 
         m_commandManager[Commands::GETBUFSIZE].reply(p_qJsonDocument.toJson());
@@ -183,7 +183,7 @@ void FiffSimulator::comAccel(Command p_command)
             if(t_bWasRunning)
                 this->start();
 
-        QString str = QString("\tSet acceleration factor to %0.3f\r\n\n").arg(t_uiAccel);
+        QString str = QString("\tSet acceleration factor to %0.3f\r\n\n").arg(static_cast<double>(t_uiAccel));
 
         m_commandManager[Commands::ACCEL].reply(str);
     }
@@ -202,14 +202,14 @@ void FiffSimulator::comGetAccel(Command p_command)
         //create JSON help object
         //
         QJsonObject t_qJsonObjectRoot;
-        t_qJsonObjectRoot.insert(Commands::ACCEL, QJsonValue((double)m_AccelerationFactor));
+        t_qJsonObjectRoot.insert(Commands::ACCEL, QJsonValue(static_cast<double>(m_AccelerationFactor)));
         QJsonDocument p_qJsonDocument(t_qJsonObjectRoot);
 
         m_commandManager[Commands::GETACCEL].reply(p_qJsonDocument.toJson());
     }
     else
     {
-        QString str = QString("\t%0.3f\r\n\n").arg(m_AccelerationFactor);
+        QString str = QString("\t%0.3f\r\n\n").arg(static_cast<double>(m_AccelerationFactor));
         m_commandManager[Commands::GETACCEL].reply(str);
     }
 }
@@ -485,9 +485,9 @@ void FiffSimulator::run()
     m_bIsRunning = true;
 
     float t_fSamplingFrequency = m_RawInfo.info.sfreq;
-    float t_fBuffSampleSize = (float)m_uiBufferSampleSize;
+    float t_fBuffSampleSize = static_cast<float>(m_uiBufferSampleSize);
 
-    quint32 uiSamplePeriod = (unsigned int) ((t_fBuffSampleSize/t_fSamplingFrequency)*1000000.0f);
+    quint32 uiSamplePeriod = static_cast<unsigned int>(((t_fBuffSampleSize/t_fSamplingFrequency)*1000000.0f));
 
 //    quint32 count = 0;
     Eigen::MatrixXf matData;

--- a/applications/mne_rt_server/plugins/fiffsimulator/fiffsimulator.cpp
+++ b/applications/mne_rt_server/plugins/fiffsimulator/fiffsimulator.cpp
@@ -299,6 +299,10 @@ void FiffSimulator::init()
                 idx += key.size();
 
                 QString sFileName = line.mid(idx, line.size()-idx);
+                if(sFileName.contains("<pathTo>"))
+                {
+                    sFileName.replace("<pathTo>",QCoreApplication::applicationDirPath());
+                }
 
                 QFile t_qFileMeas(sFileName);
 
@@ -317,7 +321,7 @@ void FiffSimulator::init()
 
     if(m_pRawMatrixBuffer)
         delete m_pRawMatrixBuffer;
-    m_pRawMatrixBuffer = NULL;
+    m_pRawMatrixBuffer = nullptr;
 
     if(!m_RawInfo.isEmpty())
         m_pRawMatrixBuffer = new CircularBuffer_Matrix_float(RAW_BUFFFER_SIZE);


### PR DESCRIPTION
Hi, 

Changes: 
1. Main change. The pr basically patches a "<pathTo>" key that remains in the configuration file and makes the loading of the default files not work properly. 
2. da sind wir hier. warnings....

Overall I find the app to be quite confusing. Maybe it is just me... Probably it is just me, but let me explain. Regarding the naming and distribution of assets across folders. At least in mac, I find the following. 

May I recommend some popcorn for while you're reading the following? Cheers. 🤣 

When you compile the app you get a ```mne_rt_server.app```, inside of which (apps in mac are kind of folders (or "packages"), there are several folders. One is named ```Resources```, another named ```PlugIns``` and the main one is named ```MacOs```, where the actual binary executable is kept. Inside of ```MacOs``` there is another folder named ```resources``` and another one named ```mne_rt_server_plugins```. Inside the previous ```resources``` there is another folder named ```mne_rt_server_plugins```... yes, amazing isn't it. Inside this last folder, there is a file named ```FiffSimulation.cfg``` where there is a text path to a default fif file to feed the simulation. 

Amazing as it is so far, I've found that none of the previous files and folders are actually used by the app to load the plugins nor the default simulation file. 

In the ```bin/``` folder of the project there is a folder named (would you want to guess...) yes! ```mne_rt_server_plugins``` which is the one(!) from where the plugins are loaded. 
And, also in ```bin/``` there is a folder named ```resources``` where there is yet another folder named ... yes: ```mne_rt_server_plugins``` inside of which there is this text file where you can set the file which will actually be feeding the simulator.

So...
```
<project-base> / bin / mne_rt_server.app / Resources
                                         / PlugIns  <-- NOT THIS ONE -- 
                                         / MacOs / mne_rt_server (executable!)  
                                                 / mne_rt_server_plugins <-- NOPE. KEEP PUSHING
                                                 / resources / mne_rt_server_plugins <-- NOPE
                                                                                    / FiffSimulation.cfg <-- NOPE. Could be... but no.
                     
                     / resources / mne_rt_server_plugins / <-- Will the plugins be here? No. But.... inside...
                                                           FiffSimulation.cfg <-- YESSS!! This is the file to edit!!
                     / mne_rt_server_plugins  <-- YES!! This is the folder where the plugins are stored!!

```

I really don't know how many of the previous files and folders are linked or created during installation, however, I know that modifying them does not alter the rest. So my question is: is this really necessary?

Apart from that the call of copy constructor several times when using (this) as input for many objects even before the first instance (the constructor call) is just starting. And also the communication between threads. I find all this to be quite confusing. 

Thank you for reading this far. At least the app now loads the default file on the first try for each plugin.




