### PR TITLE
[Fix] Solve init event id/trigger problem in Source Loc. plugin

### DIFF
--- a/applications/mne_scan/plugins/rtcmne/rtcmne.cpp
+++ b/applications/mne_scan/plugins/rtcmne/rtcmne.cpp
@@ -484,6 +484,10 @@ void RtcMne::updateRTE(SCMEASLIB::Measurement::SPtr pMeasurement)
         QStringList lResponsibleTriggerTypes = pRTES->getResponsibleTriggerTypes();
         emit responsibleTriggerTypesChanged(lResponsibleTriggerTypes);
 
+        if(!m_bPluginControlWidgetsInit) {
+            initPluginControlWidgets();
+        }
+
         if(!this->isRunning() || !lResponsibleTriggerTypes.contains(m_sAvrType)) {
             return;
         }
@@ -502,10 +506,6 @@ void RtcMne::updateRTE(SCMEASLIB::Measurement::SPtr pMeasurement)
             }
 
             m_bEvokedInput = true;
-        }
-
-        if(!m_bPluginControlWidgetsInit) {
-            initPluginControlWidgets();
         }
 
         if(this->isRunning()) {


### PR DESCRIPTION
This PR initializes the control widget before checking if the initialized event id equals the incoming event. Hence you can choose your trigger and are not dependent on having the in rtcmne initialized event type in your data. 

This PR closes #620 .