### PR TITLE
[ENH, MAINT] MNE Analyze state saving, bugfixes, cleanup, linux icon. MNE Scan linux icon

### DIFF
--- a/applications/mne_analyze/libs/anShared/Management/statusbar.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/statusbar.cpp
@@ -90,14 +90,15 @@ void StatusBar::onNewMessageReceived(const QSharedPointer<Event> pEvent)
 {
     switch(pEvent->getType()) {
         case EVENT_TYPE::STATUS_BAR_MSG: {
-        if(pEvent->getData().canConvert<QString>()) {
-            showMessage(pEvent->getData().toString(), m_iMsgTimeout);
+            if(pEvent->getData().canConvert<QString>()) {
+                showMessage(pEvent->getData().toString(), m_iMsgTimeout);
+                break;
+            }
+            qWarning() << "[StatusBar::onNewMessageReceived] Received a message/event that cannot be parsed";
             break;
         }
-
-        }
         default:
-            qDebug() << "[StatusBar::onNewMessageReceived] Received a message/event that is not handled by switch-cases";
+            qWarning() << "[StatusBar::onNewMessageReceived] Received a message/event that is not handled by switch-cases";
             break;
     }
 }

--- a/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.cpp
+++ b/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.cpp
@@ -664,6 +664,8 @@ void FiffRawViewModel::setWindowSize(const int& iNumSeconds,
                                      const int& iColWidth,
                                      const int& iScrollPos)
 {
+    Q_UNUSED(iScrollPos);
+
     beginResetModel();
 
     m_iVisibleWindowSize = iNumSeconds;

--- a/applications/mne_analyze/mne_analyze/mainwindow.cpp
+++ b/applications/mne_analyze/mne_analyze/mainwindow.cpp
@@ -120,7 +120,8 @@ MainWindow::~MainWindow()
 void MainWindow::closeEvent(QCloseEvent *event)
 {
     //Save GUI gemoetry and state;
-    saveSettings();
+    m_pMultiView->saveSettings();
+    this->saveSettings();
 
     emit mainWindowClosed();
 
@@ -300,7 +301,6 @@ void MainWindow::createPluginViews(QSharedPointer<PluginManager> pPluginManager)
 
             if(sCurPluginName == "RawDataViewer") {
                 pWindow = m_pMultiView->addWidgetBottom(pView, sCurPluginName);
-                pView->setObjectName("RawDataViewer");
             } else {
                 pWindow = m_pMultiView->addWidgetTop(pView, sCurPluginName);
             }
@@ -312,6 +312,7 @@ void MainWindow::createPluginViews(QSharedPointer<PluginManager> pPluginManager)
             qInfo() << "[MainWindow::createPluginViews] Found and added subwindow for " << pPlugin->getName();
         }
     }
+    m_pMultiView->restoreSettings();
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/mne_analyze/mainwindow.cpp
+++ b/applications/mne_analyze/mne_analyze/mainwindow.cpp
@@ -300,6 +300,7 @@ void MainWindow::createPluginViews(QSharedPointer<PluginManager> pPluginManager)
 
             if(sCurPluginName == "RawDataViewer") {
                 pWindow = m_pMultiView->addWidgetBottom(pView, sCurPluginName);
+                pView->setObjectName("RawDataViewer");
             } else {
                 pWindow = m_pMultiView->addWidgetTop(pView, sCurPluginName);
             }

--- a/applications/mne_analyze/mne_analyze/mainwindow.cpp
+++ b/applications/mne_analyze/mne_analyze/mainwindow.cpp
@@ -103,6 +103,9 @@ MainWindow::MainWindow(QSharedPointer<ANSHAREDLIB::PluginManager> pPluginManager
     qInfo() << "Loading icon...";
     QMainWindow::setWindowIcon(QIcon("../applications/mne_analyze/mne_analyze/resources/images/appIcons/icon_mne-analyze_256x256.png"));
 #endif
+
+    //Load saved GUI geometry and state
+    restoreSettings();
 }
 
 //=============================================================================================================
@@ -116,6 +119,9 @@ MainWindow::~MainWindow()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
+    //Save GUI gemoetry and state;
+    saveSettings();
+
     emit mainWindowClosed();
 
     // default implementation does this, so its probably a good idea
@@ -219,6 +225,7 @@ void MainWindow::createPluginMenus(QSharedPointer<ANSHAREDLIB::PluginManager> pP
 
     // add plugins menus
     for(IPlugin* pPlugin : pPluginManager->getPlugins()) {
+        pPlugin->setObjectName(pPlugin->getName());
         if(pPlugin) {
             if (QMenu* pMenu = pPlugin->getMenu()) {
                 // Check if the menu already exists. If it does add the actions to the exisiting menu.
@@ -433,4 +440,28 @@ void MainWindow::about()
     }
 
     m_pAboutWindow->show();
+}
+
+//=============================================================================================================
+
+void MainWindow::saveSettings()
+{
+    QSettings settings("MNECPP", "ANALYZEWINDOW");
+
+    settings.beginGroup("layout");
+    settings.setValue("geometry", saveGeometry());
+    settings.setValue("state", saveState());
+    settings.endGroup();
+}
+
+//=============================================================================================================
+
+void MainWindow::restoreSettings()
+{
+    QSettings settings("MNECPP", "ANALYZEWINDOW");
+
+    settings.beginGroup("layout");
+    restoreGeometry(settings.value("geometry").toByteArray());
+    restoreState(settings.value("state").toByteArray());
+    settings.endGroup();
 }

--- a/applications/mne_analyze/mne_analyze/mainwindow.cpp
+++ b/applications/mne_analyze/mne_analyze/mainwindow.cpp
@@ -102,11 +102,12 @@ MainWindow::MainWindow(QSharedPointer<ANSHAREDLIB::PluginManager> pPluginManager
     //Load application icon for linux builds only, mac and win executables have built in icons from .pro file
 #ifdef __linux__
     qInfo() << "Loading icon...";
-    QMainWindow::setWindowIcon(QIcon(":/images/appIcons/icon_mne-analyze_256x256.png"));
+    QMainWindow::setWindowIcon(QIcon(":/images/resources/images/appIcons/icon_mne-analyze_256x256.png"));
 #endif
 
     //Load saved GUI geometry and state
     restoreSettings();
+    m_pMultiView->restoreSettings();
 }
 
 //=============================================================================================================
@@ -313,7 +314,7 @@ void MainWindow::createPluginViews(QSharedPointer<PluginManager> pPluginManager)
             qInfo() << "[MainWindow::createPluginViews] Found and added subwindow for " << pPlugin->getName();
         }
     }
-    m_pMultiView->restoreSettings();
+    //m_pMultiView->restoreSettings();
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/mne_analyze/mainwindow.cpp
+++ b/applications/mne_analyze/mne_analyze/mainwindow.cpp
@@ -99,9 +99,10 @@ MainWindow::MainWindow(QSharedPointer<ANSHAREDLIB::PluginManager> pPluginManager
 
     this->setStatusBar(new StatusBar());
 
+    //Load application icon for linux builds only, mac and win executables have built in icons from .pro file
 #ifdef __linux__
     qInfo() << "Loading icon...";
-    QMainWindow::setWindowIcon(QIcon("../applications/mne_analyze/mne_analyze/resources/images/appIcons/icon_mne-analyze_256x256.png"));
+    QMainWindow::setWindowIcon(QIcon(":/images/appIcons/icon_mne-analyze_256x256.png"));
 #endif
 
     //Load saved GUI geometry and state

--- a/applications/mne_analyze/mne_analyze/mainwindow.h
+++ b/applications/mne_analyze/mne_analyze/mainwindow.h
@@ -154,7 +154,16 @@ private:
     void tabifyDockWindows();                                                                   /**< Tabify all dock windows */
     void about();                                                                               /**< Implements about action.*/
 
+    //=========================================================================================================
+    /**
+     * Saves geometry and state of GUI dock widgets that have given a name with setObjectName()
+     */
     void saveSettings();
+
+    //=========================================================================================================
+    /**
+     * Restores geometry and state as saved by saveSettings()
+     */
     void restoreSettings();
 
     QPointer<DISPLIB::MultiView>        m_pMultiView;       /**< The central View.*/

--- a/applications/mne_analyze/mne_analyze/mainwindow.h
+++ b/applications/mne_analyze/mne_analyze/mainwindow.h
@@ -51,6 +51,7 @@
 #include <QString>
 #include <QPointer>
 #include <QTextBrowser>
+#include <QSettings>
 
 //=============================================================================================================
 // FORWARD DECLARATIONS
@@ -152,6 +153,9 @@ private:
     void createPluginViews(QSharedPointer<ANSHAREDLIB::PluginManager> pPluginManager);      /**< Creates all Windows within the MultiView for user interface of MainWindow class. */
     void tabifyDockWindows();                                                                   /**< Tabify all dock windows */
     void about();                                                                               /**< Implements about action.*/
+
+    void saveSettings();
+    void restoreSettings();
 
     QPointer<DISPLIB::MultiView>        m_pMultiView;       /**< The central View.*/
 

--- a/applications/mne_analyze/mne_analyze/mne_analyze.qrc
+++ b/applications/mne_analyze/mne_analyze/mne_analyze.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/images">
         <file alias="splashscreen_mne_analyze.png">resources/images/splashscreen/splashscreen_mne_analyze.png</file>
+        <file>resources/images/appIcons/icon_mne-analyze_256x256.png</file>
     </qresource>
     <qresource prefix="/fonts">
         <file alias="Lato-Black.ttf">fonts/Lato-Black.ttf</file>

--- a/applications/mne_analyze/plugins/annotationmanager/annotationmanager.cpp
+++ b/applications/mne_analyze/plugins/annotationmanager/annotationmanager.cpp
@@ -140,6 +140,7 @@ QDockWidget *AnnotationManager::getControl()
     QDockWidget* pControl = new QDockWidget(getName());
     pControl->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea);
     pControl->setWidget(pAnnotationSettingsView);
+    pControl->setObjectName("Annotation Manager");
 
     return pControl;
 }

--- a/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.cpp
+++ b/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.cpp
@@ -213,8 +213,7 @@ void AnnotationSettingsView::removeAnnotationfromModel()
     m_pUi->m_tableView_eventTableView->setSelectionMode(QAbstractItemView::SingleSelection);
     //QModelIndexList indexList = m_pUi->m_tableView_eventTableView->selectionModel()->selectedIndexes();
     QModelIndexList indexList = m_pUi->m_tableView_eventTableView->selectionModel()->selectedRows();
-    qDebug() << indexList;
-    int iLastDeleted();
+
     for(int i = 0; i<indexList.size(); i++) {
         //qDebug() << "Index List" << indexList.at(i).row();
         //qDebug() << "With Modifier" << indexList.at(i).row() - i;

--- a/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.cpp
+++ b/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.cpp
@@ -210,18 +210,14 @@ void AnnotationSettingsView::passFiffParams(int iFirst,int iLast,float fFreq)
 
 void AnnotationSettingsView::removeAnnotationfromModel()
 {
-    m_pUi->m_tableView_eventTableView->setSelectionMode(QAbstractItemView::SingleSelection);
     //QModelIndexList indexList = m_pUi->m_tableView_eventTableView->selectionModel()->selectedIndexes();
     QModelIndexList indexList = m_pUi->m_tableView_eventTableView->selectionModel()->selectedRows();
 
     for(int i = 0; i<indexList.size(); i++) {
-        //qDebug() << "Index List" << indexList.at(i).row();
-        //qDebug() << "With Modifier" << indexList.at(i).row() - i;
         m_pAnnModel->removeRow(indexList.at(i).row() - i);
     }
-    emit triggerRedraw();
-    m_pUi->m_tableView_eventTableView->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
+    emit triggerRedraw();
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.h
+++ b/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.h
@@ -194,8 +194,20 @@ private slots:
      */
     void onSaveButton();
 
+    //=========================================================================================================
+    /**
+     * Update selected annotation with new sample value iValue
+     *
+     * @param [in] iValue   new sample value for selected annotation
+     */
     void realTimeDataSample(int iValue);
 
+    //=========================================================================================================
+    /**
+     * Update selected annotation with new time value dValue
+     *
+     * @param [in] dValue   new time value for selected annotation
+     */
     void realTimeDataTime(double dValue);
 
 private:

--- a/applications/mne_analyze/plugins/datamanager/datamanager.cpp
+++ b/applications/mne_analyze/plugins/datamanager/datamanager.cpp
@@ -125,6 +125,7 @@ QDockWidget *DataManager::getControl()
         m_pControlDock = new QDockWidget(getName());
         m_pControlDock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
         m_pControlDock->setWidget(m_pDataManagerView);
+        m_pControlDock->setObjectName("Data Manager");
     }
 
     return m_pControlDock;

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
@@ -265,9 +265,8 @@ void FiffRawView::setZoom(double zoomFac)
 
 void FiffRawView::setWindowSize(int T)
 {
-    int iNewPos, iNewSize;
+    int iNewPos;
     iNewPos = ((m_pTableView->horizontalScrollBar()->value() * m_iT) / T);
-    iNewSize = ((m_pTableView->horizontalScrollBar()->maximum() * m_iT) / T);
 
     if (iNewPos < 0) {
         iNewPos = m_pTableView->horizontalScrollBar()->value();

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
@@ -265,7 +265,6 @@ void FiffRawViewDelegate::createPlotPath(const QStyleOptionViewItem &option,
     double dScaleY = option.rect.height()/(2*dMaxValue);
     double y_base = path.currentPosition().y();
     double dValue, newY;
-    double diff;
 
     QPointF qSamplePosition;
 
@@ -274,7 +273,7 @@ void FiffRawViewDelegate::createPlotPath(const QStyleOptionViewItem &option,
         iPaintStep = 1;
     }
 
-    for(int j = 0; j < data.size(); j = j + iPaintStep) {
+    for(unsigned int j = 0; j < data.size(); j = j + iPaintStep) {
         dValue = data[j] * dScaleY;
 
         //Reverse direction -> plot the right way
@@ -311,6 +310,8 @@ void FiffRawViewDelegate::createTimeSpacersPath(const QModelIndex &index,
                                                 QPainterPath& path,
                                                 ANSHAREDLIB::ChannelData &data) const
 {
+    Q_UNUSED(data);
+
     const FiffRawViewModel* t_pModel = static_cast<const FiffRawViewModel*>(index.model());
 
     double dDx = t_pModel->pixelDifference();
@@ -352,7 +353,8 @@ void FiffRawViewDelegate::createMarksPath(const QModelIndex &index,
     QMap<int, QColor> typeColor = t_pAnnModel->getTypeColors();
 
     for(int i = 0; i < t_pModel->getTimeListSize(); i++) {
-        if ((t_pModel->getTimeMarks(i) > iStart) && (t_pModel->getTimeMarks(i) < (iStart + data.size()))) {
+        unsigned int uiTime = t_pModel->getTimeMarks(i);
+        if ((t_pModel->getTimeMarks(i) > iStart) && (uiTime < (iStart + data.size()))) {
             int type = t_pAnnModel->data(t_pAnnModel->index(i,2)).toInt();
             painter->setPen(QPen(typeColor.value(type), Qt::black));
             painter->drawLine(fInitX + static_cast<float>(t_pModel->getTimeMarks(i) - iStart) * dDx,

--- a/applications/mne_analyze/plugins/rawdataviewer/rawdataviewer.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/rawdataviewer.cpp
@@ -128,6 +128,7 @@ QDockWidget *RawDataViewer::getControl()
 {
     QDockWidget* pControlDock = new QDockWidget(getName());
     pControlDock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+    pControlDock->setObjectName("Data View Controls");
 
     QVBoxLayout* pLayout = new QVBoxLayout;
 

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -121,9 +121,10 @@ MainWindow::MainWindow(QWidget *parent)
     setupPlugins();
     setupUI();
 
+    //Load application icon for linux builds only, mac and win executables have built in icons from .pro file
 #ifdef __linux__
     qInfo() << "Loading icon...";
-    QMainWindow::setWindowIcon(QIcon("../applications/mne_scan/mne_scan/images/appIcons/icon_mne_scan_256x256.png"));
+    QMainWindow::setWindowIcon(QIcon(":/images/appIcons/icon_mne_scan_256x256.png"));
 #endif
 }
 

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -124,7 +124,7 @@ MainWindow::MainWindow(QWidget *parent)
     //Load application icon for linux builds only, mac and win executables have built in icons from .pro file
 #ifdef __linux__
     qInfo() << "Loading icon...";
-    QMainWindow::setWindowIcon(QIcon(":/images/appIcons/icon_mne_scan_256x256.png"));
+    QMainWindow::setWindowIcon(QIcon(":/images/images/appIcons/icon_mne_scan_256x256.png"));
 #endif
 }
 

--- a/applications/mne_scan/mne_scan/mne_scan.qrc
+++ b/applications/mne_scan/mne_scan/mne_scan.qrc
@@ -18,6 +18,7 @@
         <file alias="linepointer.png">images/icons/linepointer.png</file>
         <file alias="sendtoback.png">images/icons/sendtoback.png</file>
         <file alias="pointer.png">images/icons/pointer.png</file>
+        <file>images/appIcons/icon_mne_scan_256x256.png</file>
     </qresource>
     <qresource prefix="/qss">
         <file>QtStyleSheets/plastique.qss</file>

--- a/libraries/disp/viewers/multiview.cpp
+++ b/libraries/disp/viewers/multiview.cpp
@@ -143,7 +143,7 @@ void MultiView::saveSettings()
 {
     QSettings settings("MNECPP", "ANALYZEWINDOW");
 
-    settings.beginGroup("layout");
+    settings.beginGroup("multiview");
     settings.setValue("geometry", saveGeometry());
     settings.setValue("state", saveState());
     settings.endGroup();
@@ -155,7 +155,7 @@ void MultiView::restoreSettings()
 {
     QSettings settings("MNECPP", "ANALYZEWINDOW");
 
-    settings.beginGroup("layout");
+    settings.beginGroup("multiview");
     restoreGeometry(settings.value("geometry").toByteArray());
     restoreState(settings.value("state").toByteArray());
     settings.endGroup();

--- a/libraries/disp/viewers/multiview.cpp
+++ b/libraries/disp/viewers/multiview.cpp
@@ -47,6 +47,7 @@
 
 #include <QHBoxLayout>
 #include <QDebug>
+#include <QSettings>
 
 //=============================================================================================================
 // USED NAMESPACES
@@ -80,6 +81,7 @@ MultiViewWindow* MultiView::addWidgetTop(QWidget* pWidget,
                                          const QString& sName)
 {
     MultiViewWindow* pDockWidget = new MultiViewWindow();
+    pDockWidget->setObjectName(sName);
     pDockWidget->setWindowTitle(sName);
     pDockWidget->setWidget(pWidget);
 
@@ -106,6 +108,7 @@ MultiViewWindow* MultiView::addWidgetBottom(QWidget* pWidget,
                                             const QString& sName)
 {
     MultiViewWindow* pDockWidget = new MultiViewWindow();
+    pDockWidget->setObjectName(sName);
     pDockWidget->setWindowTitle(sName);
     pDockWidget->setWidget(pWidget);
 
@@ -132,4 +135,28 @@ MultiViewWindow* MultiView::addWidgetBottom(QWidget* pWidget,
     });
 
     return pDockWidget;
+}
+
+//=============================================================================================================
+
+void MultiView::saveSettings()
+{
+    QSettings settings("MNECPP", "ANALYZEWINDOW");
+
+    settings.beginGroup("layout");
+    settings.setValue("geometry", saveGeometry());
+    settings.setValue("state", saveState());
+    settings.endGroup();
+}
+
+//=============================================================================================================
+
+void MultiView::restoreSettings()
+{
+    QSettings settings("MNECPP", "ANALYZEWINDOW");
+
+    settings.beginGroup("layout");
+    restoreGeometry(settings.value("geometry").toByteArray());
+    restoreState(settings.value("state").toByteArray());
+    settings.endGroup();
 }

--- a/libraries/disp/viewers/multiview.cpp
+++ b/libraries/disp/viewers/multiview.cpp
@@ -80,7 +80,7 @@ MultiView::~MultiView()
 MultiViewWindow* MultiView::addWidgetTop(QWidget* pWidget,
                                          const QString& sName)
 {
-    MultiViewWindow* pDockWidget = new MultiViewWindow();
+    MultiViewWindow* pDockWidget = new MultiViewWindow(this);
     pDockWidget->setObjectName(sName);
     pDockWidget->setWindowTitle(sName);
     pDockWidget->setWidget(pWidget);
@@ -107,7 +107,7 @@ MultiViewWindow* MultiView::addWidgetTop(QWidget* pWidget,
 MultiViewWindow* MultiView::addWidgetBottom(QWidget* pWidget,
                                             const QString& sName)
 {
-    MultiViewWindow* pDockWidget = new MultiViewWindow();
+    MultiViewWindow* pDockWidget = new MultiViewWindow(this);
     pDockWidget->setObjectName(sName);
     pDockWidget->setWindowTitle(sName);
     pDockWidget->setWidget(pWidget);

--- a/libraries/disp/viewers/multiview.h
+++ b/libraries/disp/viewers/multiview.h
@@ -115,6 +115,18 @@ public:
     MultiViewWindow* addWidgetBottom(QWidget* pWidget,
                                      const QString& sName);
 
+    //=========================================================================================================
+    /**
+     * Saves geometry and state of GUI dock widgets that have given a name with setObjectName()
+     */
+    void saveSettings();
+
+    //=========================================================================================================
+    /**
+     * Restores geometry and state as saved by saveSettings()
+     */
+    void restoreSettings();
+
 private:
     QList<MultiViewWindow *> m_lDockWidgets;
 

--- a/libraries/disp/viewers/multiviewwindow.cpp
+++ b/libraries/disp/viewers/multiviewwindow.cpp
@@ -62,7 +62,7 @@ MultiViewWindow::MultiViewWindow(QWidget *parent,
                                  Qt::WindowFlags flags)
 : QDockWidget(parent, flags)
 {
-    this->setWidget(parent);
+    //this->setWidget(parent);
 }
 
 //=============================================================================================================


### PR DESCRIPTION
- MNE analyze now remembers which plugins were open/closed and location on screen from last session.
- deleting annotations now consistent whether selecting bottom to top or top to bottom 
- linux icons now in resource files, adjusted path in both Scan and Analyze
- clean up syntax/variable typing to reduce compilation warnings

Closes #606