### PR TITLE
[MAINT] Bump CI to Qt 5.15.0

### DIFF
--- a/.github/workflows/buildqtbinaries.yml
+++ b/.github/workflows/buildqtbinaries.yml
@@ -71,7 +71,7 @@ jobs:
         path: qt5_5150_static_binaries_macos.tar.gz
 
   GenerateWinStaticBinaries:
-    runs-on: windows-2016
+    runs-on: windows-2019
 
     steps:
     - name: Clone repository
@@ -98,7 +98,7 @@ jobs:
         mkdir qt5_shadow
         cd qt5_shadow
         # Setup the compiler 
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         # Configure Qt5
         ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license

--- a/.github/workflows/buildqtbinaries.yml
+++ b/.github/workflows/buildqtbinaries.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         # Clone Qt5 repo
         cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.0
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
         # Create shadow build folder
@@ -34,11 +34,11 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        tar cfvz qt5_5142_static_binaries_linux.tar.gz ../Qt5_binaries/.
+        tar cfvz qt5_5150_static_binaries_linux.tar.gz ../Qt5_binaries/.
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5142_static_binaries_linux.tar.gz
-        path: qt5_5142_static_binaries_linux.tar.gz
+        name: qt5_5150_static_binaries_linux.tar.gz
+        path: qt5_5150_static_binaries_linux.tar.gz
 
   GenerateMacOSStaticBinaries:
     runs-on: macos-latest
@@ -50,7 +50,7 @@ jobs:
       run: |
         # Clone Qt5 repo
         cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.0
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
         # Create shadow build folder
@@ -64,11 +64,11 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        tar cfvz qt5_5142_static_binaries_macos.tar.gz ../Qt5_binaries/.
+        tar cfvz qt5_5150_static_binaries_macos.tar.gz ../Qt5_binaries/.
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5142_static_binaries_macos.tar.gz
-        path: qt5_5142_static_binaries_macos.tar.gz
+        name: qt5_5150_static_binaries_macos.tar.gz
+        path: qt5_5150_static_binaries_macos.tar.gz
 
   GenerateWinStaticBinaries:
     runs-on: windows-2016
@@ -90,7 +90,7 @@ jobs:
       run: |
         # Clone Qt5 repo
         cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.0
         cd qt5
         perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
         # Create shadow build folder
@@ -107,11 +107,11 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        7z a qt5_5142_static_binaries_win.zip ..\Qt5_binaries
+        7z a qt5_5150_static_binaries_win.zip ..\Qt5_binaries
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5142_static_binaries_win.zip
-        path: qt5_5142_static_binaries_win.zip
+        name: qt5_5150_static_binaries_win.zip
+        path: qt5_5150_static_binaries_win.zip
 
   GenerateWasmBinaries:
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.0
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
         # Configure Qt5
@@ -147,8 +147,8 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        tar cfvz qt5_5142_static_binaries_wasm.tar.gz ../Qt5_binaries/.
+        tar cfvz qt5_5150_static_binaries_wasm.tar.gz ../Qt5_binaries/.
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5142_static_binaries_wasm.tar.gz
-        path: qt5_5142_static_binaries_wasm.tar.gz
+        name: qt5_5150_static_binaries_wasm.tar.gz
+        path: qt5_5150_static_binaries_wasm.tar.gz

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -252,7 +252,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-16.04, macos-latest, windows-2019]
+        os: [ubuntu-16.04, macos-latest, windows-2016]
 
     steps:
     - name: Clone repository
@@ -275,14 +275,14 @@ jobs:
         version: 5.15.0
         modules: qtcharts    
     - name: Install Qt (Windows)
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2016'
       uses: jurplel/install-qt-action@v2
       with:
         version: 5.15.0
         arch: win64_msvc2019_64
         modules: qtcharts
     - name: Install jom (Windows) 
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2016'
       run: |
         Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
@@ -298,10 +298,10 @@ jobs:
         qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
         make -j4
     - name: Configure and compile MNE-CPP (Windows)
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2016'
       run: |
         # Setup VS compiler   
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
         jom -j4
@@ -334,7 +334,7 @@ jobs:
           $test
         done
     - name: Run tests (Windows)
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2016'
       env:
         QTEST_FUNCTION_TIMEOUT: 900000
       run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,14 +6,14 @@ on:
     - master
 
 jobs:
-  QtDynamic:
+  MinQtDynamic:
     runs-on: ${{ matrix.os }}
 
     strategy: 
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 3
       matrix:
-        qt: [5.15.0, 5.10.1]
+        qt: [5.10.1]
         os: [ubuntu-16.04, macos-latest, windows-2016]
 
     steps:
@@ -95,6 +95,95 @@ jobs:
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
         jom -j4
 
+  MaxQtDynamic:
+    runs-on: ${{ matrix.os }}
+
+    strategy: 
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        qt: [5.15.0]
+        os: [ubuntu-16.04, macos-latest, windows-2019]
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install BrainFlow and LSL submodules
+      run: |
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+    - name: Install Qt (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: ${{ matrix.qt }}
+        modules: qtcharts
+    - name: Install Qt (Windows)
+      if: matrix.os == 'windows-2019'
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: ${{ matrix.qt }}
+        arch: win64_msvc2019_64
+        modules: qtcharts
+    - name: Install jom (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
+        expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
+        echo "::add-path::$HOME\jom"        
+    - name: Compile BrainFlow submodule (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        cd applications\mne_scan\plugins\brainflowboard\brainflow
+        mkdir build
+        cd build
+        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake --build . --target install --config Release
+    - name: Compile BrainFlow submodule (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
+      run: |
+        cd applications/mne_scan/plugins/brainflowboard/brainflow
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=../installed ..
+        make
+        make install
+    - name: Compile LSL submodule (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        cd applications\mne_scan\plugins\lsladapter\liblsl
+        mkdir build
+        cd build
+        cmake .. -G "Visual Studio 16 2019" -A x64
+        cmake --build . --config Release --target install
+    - name: Compile LSL submodule (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
+      run: |
+        cd applications/mne_scan/plugins/lsladapter/liblsl
+        mkdir build
+        cd build
+        cmake ..
+        make
+        make install
+    - name: Configure and compile MNE-CPP (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
+      run: |
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        make -j4
+    - name: Configure and compile MNE-CPP (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        # Setup VS compiler   
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        jom -j4
+
   QtStatic:
     runs-on: ${{ matrix.os }}
 
@@ -103,7 +192,7 @@ jobs:
       max-parallel: 3
       matrix:
         qt: [5.15.0]
-        os: [ubuntu-16.04, macos-latest, windows-2016]
+        os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -131,13 +220,13 @@ jobs:
         wget -O qt5_5150_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5150_static_binaries_macos.tar.gz?dl=1
         tar xvzf qt5_5150_static_binaries_macos.tar.gz -P
     - name: Install Qt (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
         Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5150_static_binaries_win.zip?dl=1 -OutFile .\qt5_5150_static_binaries_win.zip
         expand-archive -path "qt5_5150_static_binaries_win.zip" -destinationpath "..\"
     - name: Install jom (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
@@ -148,10 +237,10 @@ jobs:
         ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=static 
         make -j4
     - name: Configure and compile MNE-CPP (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         # Setup VS compiler   
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=static
         jom -j4
@@ -163,7 +252,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-16.04, macos-latest, windows-2016]
+        os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -186,14 +275,14 @@ jobs:
         version: 5.15.0
         modules: qtcharts    
     - name: Install Qt (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       uses: jurplel/install-qt-action@v2
       with:
         version: 5.15.0
-        arch: win64_msvc2017_64
+        arch: win64_msvc2019_64
         modules: qtcharts
     - name: Install jom (Windows) 
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
@@ -209,10 +298,10 @@ jobs:
         qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
         make -j4
     - name: Configure and compile MNE-CPP (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         # Setup VS compiler   
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
         jom -j4
@@ -245,7 +334,7 @@ jobs:
           $test
         done
     - name: Run tests (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       env:
         QTEST_FUNCTION_TIMEOUT: 900000
       run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        qt: [5.14.2, 5.10.1]
+        qt: [5.15.0, 5.10.1]
         os: [ubuntu-16.04, macos-latest, windows-2016]
 
     steps:
@@ -102,7 +102,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        qt: [5.14.2]
+        qt: [5.15.0]
         os: [ubuntu-16.04, macos-latest, windows-2016]
 
     steps:
@@ -121,21 +121,21 @@ jobs:
       if: matrix.os == 'ubuntu-16.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5142_static_binaries_linux.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5142_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5150_static_binaries_linux.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5150_static_binaries_linux.tar.gz?dl=1
         mkdir ../Qt5_binaries
-        tar xvzf qt5_5142_static_binaries_linux.tar.gz -C ../ -P
+        tar xvzf qt5_5150_static_binaries_linux.tar.gz -C ../ -P
     - name: Install Qt (MacOS)
       if: matrix.os == 'macos-latest'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5142_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5142_static_binaries_macos.tar.gz?dl=1
-        tar xvzf qt5_5142_static_binaries_macos.tar.gz -P
+        wget -O qt5_5150_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5150_static_binaries_macos.tar.gz?dl=1
+        tar xvzf qt5_5150_static_binaries_macos.tar.gz -P
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2016'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5142_static_binaries_win.zip?dl=1 -OutFile .\qt5_5142_static_binaries_win.zip
-        expand-archive -path "qt5_5142_static_binaries_win.zip" -destinationpath "..\"
+        Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5150_static_binaries_win.zip?dl=1 -OutFile .\qt5_5150_static_binaries_win.zip
+        expand-archive -path "qt5_5150_static_binaries_win.zip" -destinationpath "..\"
     - name: Install jom (Windows)
       if: matrix.os == 'windows-2016'
       run: |
@@ -183,13 +183,13 @@ jobs:
       if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.0
         modules: qtcharts    
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2016'
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.0
         arch: win64_msvc2017_64
         modules: qtcharts
     - name: Install jom (Windows) 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:        
     - v0.*
     branches:
-    - master
+    - qt515
 
 jobs:
   CreateRelease:
@@ -307,7 +307,10 @@ jobs:
         # Copy additional LSL libs
         cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. lib/
         # Install libxkbcommon and libbluetooth3 so linuxdeployqt can find it
+        sudo apt-get update
         sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-icccm4
+        sudo apt-get install libxcb-image0
         sudo apt-get install libbluetooth3
         # Downloading linuxdeployqt from continious release
         wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
         overwrite: true
         
   WinStatic:
-    runs-on: windows-2016
+    runs-on: windows-2019
     needs: CreateRelease
 
     steps:
@@ -218,7 +218,7 @@ jobs:
     #     mkdir qt5_shadow
     #     cd qt5_shadow
     #     # Setup the compiler 
-    #     cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+    #     cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
     #     Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
     #     # Configure Qt5
     #     ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
@@ -226,7 +226,7 @@ jobs:
     #     nmake install
     - name: Configure and compile MNE-CPP
       run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
         jom -j4
@@ -413,7 +413,7 @@ jobs:
         overwrite: true
 
   WinDynamic:
-    runs-on: windows-2016
+    runs-on: windows-2019
     needs: CreateRelease
 
     steps:
@@ -432,7 +432,7 @@ jobs:
       uses: jurplel/install-qt-action@v2
       with:
         version: 5.15.0
-        arch: win64_msvc2017_64
+        arch: win64_msvc2019_64
         modules: qtcharts
     - name: Install jom
       run: |
@@ -444,18 +444,18 @@ jobs:
         cd applications\mne_scan\plugins\brainflowboard\brainflow
         mkdir build
         cd build
-        cmake -G "Visual Studio 15 2017" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile LSL submodule
       run: |
         cd applications\mne_scan\plugins\lsladapter\liblsl
         mkdir build
         cd build
-        cmake .. -G "Visual Studio 15 2017" -A x64
+        cmake .. -G "Visual Studio 16 2019" -A x64
         cmake --build . --config Release --target install
     - name: Configure and compile MNE-CPP
       run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
         jom -j4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,15 +70,15 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        wget -O qt5_5142_static_binaries_linux.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5142_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5150_static_binaries_linux.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5150_static_binaries_linux.tar.gz?dl=1
         mkdir ../Qt5_binaries
-        tar xvzf qt5_5142_static_binaries_linux.tar.gz -C ../ -P
+        tar xvzf qt5_5150_static_binaries_linux.tar.gz -C ../ -P
     # Uncomment this if you want to build Qt statically in this workflow
     # - name: Compile static Qt version
     #   run: |
     #     # Clone Qt5 repo
     #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.0
     #     cd qt5
     #     ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
     #     # Create shadow build folder
@@ -132,14 +132,14 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        wget -O qt5_5142_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5142_static_binaries_macos.tar.gz?dl=1
-        tar xzf qt5_5142_static_binaries_macos.tar.gz -P
+        wget -O qt5_5150_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5150_static_binaries_macos.tar.gz?dl=1
+        tar xzf qt5_5150_static_binaries_macos.tar.gz -P
     # Uncomment this if you want to build Qt statically in this workflow
     # - name: Compile static Qt version
     #   run: |
     #     # Clone Qt5 repo
     #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.0
     #     cd qt5
     #     ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
     #     # Create shadow build folder
@@ -203,14 +203,14 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5142_static_binaries_win.zip?dl=1 -OutFile .\qt5_5142_static_binaries_win.zip
-        expand-archive -path "qt5_5142_static_binaries_win.zip" -destinationpath "..\"
+        Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5150_static_binaries_win.zip?dl=1 -OutFile .\qt5_5150_static_binaries_win.zip
+        expand-archive -path "qt5_5150_static_binaries_win.zip" -destinationpath "..\"
     # Uncomment this if you want to build Qt statically in this workflow
     # - name: Compile static Qt version
     #   run: |
     #     # Clone Qt5 repo
     #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.0
     #     cd qt5
     #     perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
     #     # Create shadow build folder
@@ -276,7 +276,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.0
         modules: qtcharts
     - name: Compile BrainFlow submodule
       run: |
@@ -359,7 +359,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.0
         modules: qtcharts
     - name: Compile BrainFlow submodule 
       run: |
@@ -431,7 +431,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.0
         arch: win64_msvc2017_64
         modules: qtcharts
     - name: Install jom
@@ -507,7 +507,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.0
         modules: qtcharts
     - name: Configure and compile MNE-CPP
       run: |
@@ -644,7 +644,7 @@ jobs:
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.0
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
         # Configure Qt5

--- a/.github/workflows/wasmtest.yml
+++ b/.github/workflows/wasmtest.yml
@@ -22,7 +22,7 @@ jobs:
         cd emsdk
         git pull
         # Download and install the latest SDK tools.
-        ./emsdk install 1.39.3     
+        ./emsdk install 1.39.8
     # - name: Install Qt
     #   run: |
     #     # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
@@ -34,11 +34,11 @@ jobs:
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.3
+        ./emsdk/emsdk activate 1.39.8
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
         # Configure Qt5
@@ -49,7 +49,7 @@ jobs:
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.3
+        ./emsdk/emsdk activate 1.39.8
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Compile MNE-CPP        

--- a/doc/gh-pages/pages/development/staticbuild.md
+++ b/doc/gh-pages/pages/development/staticbuild.md
@@ -24,10 +24,10 @@ Git/
 
 ### Get the Qt source code
 
-Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase subdivides in other modules reflecting most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 type:
+Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase subdivides in other modules reflecting most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.15.0 type:
 
 ```
-git clone https://code.qt.io/qt/qt5.git -b 5.14.2  
+git clone https://code.qt.io/qt/qt5.git -b 5.15
 cd qt5
 ```
 

--- a/doc/gh-pages/pages/development/wasmbuildguide.md
+++ b/doc/gh-pages/pages/development/wasmbuildguide.md
@@ -49,10 +49,10 @@ cd emsdk
 git pull
 
 # Download and install the latest SDK tools.
-./emsdk install 1.39.3
+./emsdk install 1.39.8
 
 # Make the "latest" SDK "active" for the current user. (writes ~/.emscripten file)
-./emsdk activate 1.39.3
+./emsdk activate 1.39.8
 
 # Activate PATH and other environment variables in the current terminal
 source ./emsdk_env.sh
@@ -65,7 +65,7 @@ This is needed since we want to have threading support which is deactivated for 
 Make sure to activate and source the correct emscripten version since the compiler will be used when building qt against wasm. You could also add this to your .basrc file. For example:
 
 ```
-./emsdk activate 1.39.3
+./emsdk activate 1.39.8
 source ./emsdk_env.sh
 ```
 
@@ -75,10 +75,10 @@ Install some dependencies (just to make sure)
 sudo apt-get install build-essential libgl1-mesa-dev python
 ```
 
-Clone the current Qt version. For example Qt 5.14.2:
+Clone the current Qt version. For example Qt 5.15.0:
 
 ```
-git clone https://code.qt.io/qt/qt5.git -b 5.14.2      
+git clone https://code.qt.io/qt/qt5.git -b 5.15   
 cd qt5
 ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
 ```

--- a/doc/gh-pages/pages/install/buildguide.md
+++ b/doc/gh-pages/pages/install/buildguide.md
@@ -13,7 +13,7 @@ Make sure you have one of the following compilers installed:
 
 | Windows | Linux | MacOS |
 |---------|-------|-------|
-| min. MSVC 2015 (We recommend the [MSVC 2019 Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16#){:target="_blank" rel="noopener"} compiler. During install exclude all optional items except for the MSVC C++-X86/x64-Buildtools and Windows 10 SDK) | min. [GCC 5.3.1](https://gcc.gnu.org/releases.html){:target="_blank" rel="noopener"} | min. [Clang 3.5](https://developer.apple.com/xcode/){:target="_blank" rel="noopener"}|
+| min. MSVC 2015 (We recommend the [MSVC 2019 Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16#){:target="_blank" rel="noopener"} compiler. During install exclude all optional items except for the MSVC C++-X86/x64-Buildtools, Windows 10 SDK and C++-ATL support) | min. [GCC 5.3.1](https://gcc.gnu.org/releases.html){:target="_blank" rel="noopener"} | min. [Clang 3.5](https://developer.apple.com/xcode/){:target="_blank" rel="noopener"}|
 
 ## Get Qt
 

--- a/doc/gh-pages/pages/install/buildguide.md
+++ b/doc/gh-pages/pages/install/buildguide.md
@@ -13,7 +13,7 @@ Make sure you have one of the following compilers installed:
 
 | Windows | Linux | MacOS |
 |---------|-------|-------|
-| min. MSVC 2015 (We recommend the [MSVC 2017 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"} compiler. During install exclude everything except for VC++, Win 10 SDK and ATL support) | min. [GCC 5.3.1](https://gcc.gnu.org/releases.html){:target="_blank" rel="noopener"} | min. [Clang 3.5](https://developer.apple.com/xcode/){:target="_blank" rel="noopener"}|
+| min. MSVC 2015 (We recommend the [MSVC 2019 Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16#){:target="_blank" rel="noopener"} compiler. During install exclude all optional items except for the MSVC C++-X86/x64-Buildtools and Windows 10 SDK) | min. [GCC 5.3.1](https://gcc.gnu.org/releases.html){:target="_blank" rel="noopener"} | min. [Clang 3.5](https://developer.apple.com/xcode/){:target="_blank" rel="noopener"}|
 
 ## Get Qt
 
@@ -25,10 +25,10 @@ Qt is the only dependency you will need to install. Go to the Qt download sectio
 
 Please note that Qt 5.10.0 or higher is needed in order to have full Qt3D support. Install the Qt version with the minimum of the following features (uncheck all other boxes) to a path without white spaces:
 
-- Qt/5.14.2/MSVC 2017 64-bit (Make sure to select the correct version based on your compiler)
-- Qt/5.14.2/QtCharts
+- Qt/5.15.0/MSVC 2019 64-bit (Make sure to select the correct version based on your compiler)
+- Qt/5.15.0/QtCharts
 
-After the installation is finished make sure to add the Qt bin folder (e.g. `<QtFolder>\5.14.2\msvc2017_64\bin`) to your `PATH` variable. On Linux and MacOS you might also need to add the Qt lib folder (e.g. `<QtFolder>\5.14.2\msvc2017_64\lib`) to the `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH`, respectivley.
+After the installation is finished make sure to add the Qt bin folder (e.g. `<QtFolder>\5.15.0\msvc2019_64\bin`) to your `PATH` variable. On Linux and MacOS you might also need to add the Qt lib folder (e.g. `<QtFolder>\5.15.0\msvc2019_64\lib`) to the `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH`, respectivley.
 
 ## Get the source code
 
@@ -60,7 +60,7 @@ git rebase upstream/master
 | **Please note:** If you are working on an operating system on a "non-western" system, i.e. Japan, you might encounter problems with unicode interpretation. Please do the  following: Go to Control Panel > Language and Region > Management tab > Language Settings for non-Unicode Programs > Set to English (U.S.) > Reboot your system. |
 
 1. Go to your cloned repository folder and run the `mne-cpp.pro` file with QtCreator.
-2. The first time you open the mne-cpp.pro file you will be prompted to configure the project with a pre-defined kit. Select the appropriate kit, e.g., `Desktop Qt 5.14.2 MSVC2017 64bit` and configure the project.
+2. The first time you open the mne-cpp.pro file you will be prompted to configure the project with a pre-defined kit. Select the appropriate kit, e.g., `Desktop Qt 5.15.0 MSVC2019 64bit` and configure the project.
 3. In QtCreator select the Release mode in the lower left corner.
 4. In the Qt Creator's Projects window, right mouse click on the top level MNE-CPP tree item and select Run qmake. Wait until progress bar in lower right corner turns green (this step may take some time).
 5. Right mouse click again and then hit Build (this step may take some time). Wait until progress bar in lower right corner turns green.
@@ -73,8 +73,8 @@ Create a shadow build folder, run `qmake` on `mne-cpp.pro` and build:
 ```
 mkdir mne-cpp_shadow
 cd mne-cpp_shadow
-<QtFolder>/5.14.2/msvc2017_64/bin/qmake ../mne-cpp/mne-cpp.pro
-<QtFolder>/5.14.2/msvc2017_64/bin/jom -j8 # On Windows
+<QtFolder>/5.15.0/msvc2019_64/bin/qmake ../mne-cpp/mne-cpp.pro
+<QtFolder>/5.15.0/msvc2019_64/bin/jom -j8 # On Windows
 make -j8 # On Linux and MacOS
 ```
 

--- a/libraries/disp3D/disp3D.pro
+++ b/libraries/disp3D/disp3D.pro
@@ -230,10 +230,13 @@ win32:!contains(MNECPP_CONFIG, static) {
     DEPLOY_CMD = $$winDeployLibArgs($${TARGET},$${MNE_BINARY_DIR},$${MNE_LIBRARY_DIR},$${EXTRA_ARGS})
     QMAKE_POST_LINK += $${DEPLOY_CMD}
 
-    # Create renderers folder and copy renderers manually. windeployqt does not care of them.
-    TRGTDIR = $$shell_path($$shell_path($${MNE_BINARY_DIR}/renderers))
-    QMAKE_POST_LINK += $$sprintf($${QMAKE_MKDIR_CMD}, "$${TRGTDIR}") $$escape_expand(\n\t)
-    QMAKE_POST_LINK += $${QMAKE_COPY_DIR} "$$shell_path($$[QT_INSTALL_PLUGINS]/renderers)" "$$shell_path($${MNE_BINARY_DIR}/renderers)" $$escape_expand(\\n\\t)
+    # If Qt3D plugins/renderers folder exisits, create and copy renderers folder to mne-cpp/bin manually.
+    # windeployqt does not deploy them.
+    exists($$shell_path($$[QT_INSTALL_PLUGINS]/renderers)) {
+        TRGTDIR = $$shell_path($$shell_path($${MNE_BINARY_DIR}/renderers))
+        QMAKE_POST_LINK += $$sprintf($${QMAKE_MKDIR_CMD}, "$${TRGTDIR}") $$escape_expand(\n\t)
+        QMAKE_POST_LINK += $${QMAKE_COPY_DIR} "$$shell_path($$[QT_INSTALL_PLUGINS]/renderers)" "$$shell_path($${MNE_BINARY_DIR}/renderers)" $$escape_expand(\\n\\t)
+    }
 }
 
 # Activate FFTW backend in Eigen for non-static builds only

--- a/libraries/disp3D/disp3D.pro
+++ b/libraries/disp3D/disp3D.pro
@@ -229,6 +229,11 @@ win32:!contains(MNECPP_CONFIG, static) {
     EXTRA_ARGS =
     DEPLOY_CMD = $$winDeployLibArgs($${TARGET},$${MNE_BINARY_DIR},$${MNE_LIBRARY_DIR},$${EXTRA_ARGS})
     QMAKE_POST_LINK += $${DEPLOY_CMD}
+
+    # Create renderers folder and copy renderers manually. windeployqt does not care of them.
+    TRGTDIR = $$shell_path($$shell_path($${MNE_BINARY_DIR}/renderers))
+    QMAKE_POST_LINK += $$sprintf($${QMAKE_MKDIR_CMD}, "$${TRGTDIR}") $$escape_expand(\n\t)
+    QMAKE_POST_LINK += $${QMAKE_COPY_DIR} "$$shell_path($$[QT_INSTALL_PLUGINS]/renderers)" "$$shell_path($${MNE_BINARY_DIR}/renderers)" $$escape_expand(\\n\\t)
 }
 
 # Activate FFTW backend in Eigen for non-static builds only


### PR DESCRIPTION
This PR bumps up the maximum allowed Qt version to Qt 5.15. Some changes to the pullrequest.yml Github Workflow were needed in order to deal with the fact that Qt 5.15 only comes pre built for MSVC 2019 on windows. Our static pre built binaries were updated to Qt 5.15 as well. The build guide was updated accordingly. Some how Qt3D's renderer plugins do not get copied via windployqt, so we have to copy them manually. 

WIP:

- [ ] Tests are failing for MSVC 2019 Qt 5.15. This does not happen locally on my machine. Any ideas @RDoerfel ?