### PR TITLE
solve fiff lib typo in example spectral and debug mode

### DIFF
--- a/examples/ex_spectral/ex_spectral.pro
+++ b/examples/ex_spectral/ex_spectral.pro
@@ -61,7 +61,7 @@ CONFIG(debug, debug|release) {
             -lmnecppInversed \
             -lmnecppFwdd \
             -lmnecppMned \
-            -lmnecppFiff \
+            -lmnecppFiffd \
             -lmnecppFsd \
             -lmnecppUtilsd \
 } else {


### PR DESCRIPTION
Hi,

In the example ex_spectral, a small typo in the name of the fiff library in debug mode would not allow the project to compile directly in debug mode. 

