### PR TITLE
[Fix] reset Hpi fitting properly

### DIFF
--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -511,6 +511,7 @@ void Hpi::run()
                 m_mutex.lock();
                 if(m_bDoSingleHpi) {
                     m_bDoSingleHpi = false;
+                    fitResult.devHeadTrans.clear();
                 }
                 fitResult.sFilePathDigitzers = m_sFilePathDigitzers;
                 m_mutex.unlock();

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -216,6 +216,9 @@ void HpiSettingsView::saveSettings()
     data.setValue(m_pUi->m_checkBox_useComp->isChecked());
     settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/useCOMP"), data);
 
+    data.setValue(m_pUi->m_checkBox_continousHPI->isChecked());
+    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/continousHPI"), data);
+
     data.setValue(m_pUi->m_doubleSpinBox_maxHPIContinousDist->value());
     settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/maxError"), data);
 }
@@ -237,6 +240,7 @@ void HpiSettingsView::loadSettings()
 
     m_pUi->m_checkBox_useSSP->setChecked(settings.value(m_sSettingsPath + QString("/HpiSettingsView/useSSP"), false).toBool());
     m_pUi->m_checkBox_useComp->setChecked(settings.value(m_sSettingsPath + QString("/HpiSettingsView/useCOMP"), false).toBool());
+    m_pUi->m_checkBox_continousHPI->setChecked(settings.value(m_sSettingsPath + QString("/HpiSettingsView/continousHPI"), false).toBool());
     m_pUi->m_doubleSpinBox_maxHPIContinousDist->setValue(settings.value(m_sSettingsPath + QString("/HpiSettingsView/maxError"), 10.0).toDouble());
 }
 

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -257,12 +257,12 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
         vecChIdcs(j) = iChIdx;
     }
 
-    //Generate seed point by projection the found channel position 3cm inwards
     vecError.resize(iNumCoils);
     double dError = std::accumulate(vecError.begin(), vecError.end(), .0) / vecError.size();
     MatrixXd matCoilPos = MatrixXd::Zero(iNumCoils,3);
 
-    if(transDevHead.trans == MatrixXd::Identity(4,4).cast<float>() /*|| dError > 0.003*/){
+    // Generate seed point by projection the found channel position 3cm inwards if previous transDevHead is identity or bad fit
+    if(transDevHead.trans == MatrixXd::Identity(4,4).cast<float>() || dError > 0.010) {
         for (int j = 0; j < vecChIdcs.rows(); ++j) {
             if(vecChIdcs(j) < pFiffInfo->chs.size()) {
                 Vector3f r0 = pFiffInfo->chs.at(vecChIdcs(j)).chpos.r0;
@@ -375,6 +375,9 @@ void HPIFit::findOrder(const MatrixXd& t_mat,
 {
     // create temporary copies that are necessary to reset values that are passed to fitHpi()
     fittedPointSet.clear();
+    transDevHead.clear();
+    vecError.fill(0);
+
     FiffDigPointSet fittedPointSetTemp = fittedPointSet;
     FiffCoordTrans transDevHeadTemp = transDevHead;
     FiffInfo::SPtr pFiffInfoTemp = pFiffInfo;
@@ -383,7 +386,6 @@ void HPIFit::findOrder(const MatrixXd& t_mat,
     QVector<double> vecErrorTemp = vecError;
     VectorXd vecGoFTemp = vecGoF;
     bool bIdentity = false;
-    fittedPointSetTemp.clear();
 
     MatrixXf matTrans = transDevHead.trans;
     if(transDevHead.trans == MatrixXf::Identity(4,4).cast<float>()) {


### PR DESCRIPTION
This PR introduces following fixes and therefore closes #639:

**HPI plugin**

- clear device - head transformation for single fit to always use seed points for better handling of single fits that are performed after a while

**HPI Library**

- use seedpoints if last fit was bad
- clear dev head trans in findOrder. This is necessary if accedantly a hpi fit is performed before ordering

**HPI Widget**

- store state of continious hpi checkbox. 
