### PR TITLE
[ENH] Revert setting default filter length 

### DIFF
--- a/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.cpp
+++ b/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.cpp
@@ -270,8 +270,24 @@ bool FiffRawViewModel::saveToFile(const QString& sPath)
 
     if(m_pFiffIO->m_qlistRaw.size() > 0) {
         if(m_bPerformFiltering) {
+            // Write to file with a better filter kernel with 4096 filter taps
+            int iOrder = 4096;
+            QList<FilterKernel> lFilterKernelNew = m_filterKernel;
+            for(int i = 0; i < lFilterKernelNew.size(); ++i) {
+                if(lFilterKernelNew[i].getFilterOrder() < iOrder) {
+                    lFilterKernelNew[i] = FilterKernel(lFilterKernelNew[i].getName(),
+                                                       lFilterKernelNew[i].m_Type,
+                                                       iOrder,
+                                                       lFilterKernelNew[i].getCenterFrequency(),
+                                                       lFilterKernelNew[i].getBandwidth(),
+                                                       lFilterKernelNew[i].getParksWidth(),
+                                                       lFilterKernelNew[i].getSamplingFrequency(),
+                                                       lFilterKernelNew[i].m_designMethod);
+                }
+            }
+
             Filter filter;
-            return filter.filterData(*bufferOut, m_pFiffIO->m_qlistRaw[0], m_filterKernel);
+            return filter.filterData(*bufferOut, m_pFiffIO->m_qlistRaw[0], lFilterKernelNew);
         } else {
             return m_pFiffIO->write_raw(*bufferOut, 0);
         }
@@ -290,8 +306,24 @@ bool FiffRawViewModel::saveToFile(const QString& sPath)
 
     if(m_pFiffIO->m_qlistRaw.size() > 0) {
         if(m_bPerformFiltering) {
+            // Write to file with a better filter kernel with 4096 filter taps
+            int iOrder = 4096;
+            QList<FilterKernel> lFilterKernelNew = m_filterKernel;
+            for(int i = 0; i < lFilterKernelNew.size(); ++i) {
+                if(lFilterKernelNew[i].getFilterOrder() < iOrder) {
+                    lFilterKernelNew[i] = FilterKernel(lFilterKernelNew[i].getName(),
+                                                       lFilterKernelNew[i].m_Type,
+                                                       iOrder,
+                                                       lFilterKernelNew[i].getCenterFrequency(),
+                                                       lFilterKernelNew[i].getBandwidth(),
+                                                       lFilterKernelNew[i].getParksWidth(),
+                                                       lFilterKernelNew[i].getSamplingFrequency(),
+                                                       lFilterKernelNew[i].m_designMethod);
+                }
+            }
+
             Filter filter;
-            return filter.filterFile(fFileOut, m_pFiffIO->m_qlistRaw[0], m_filterKernel);
+            return filter.filterFile(fFileOut, m_pFiffIO->m_qlistRaw[0], lFilterKernelNew);
         } else {
             return m_pFiffIO->write_raw(fFileOut, 0);
         }

--- a/libraries/rtprocessing/filter.cpp
+++ b/libraries/rtprocessing/filter.cpp
@@ -127,19 +127,10 @@ bool Filter::filterFile(QIODevice &pIODevice,
         return false;
     }
 
-    // Try to filter with at least order of 4096
-    int iOrder = 4096;
-    QList<FilterKernel> lFilterKernelNew = lFilterKernel;
-    for(int i = 0; i < lFilterKernelNew.size(); ++i) {
-        if(lFilterKernelNew[i].getFilterOrder() < iOrder) {
-            lFilterKernelNew[i] = FilterKernel(lFilterKernelNew[i].getName(),
-                                               lFilterKernelNew[i].m_Type,
-                                               iOrder,
-                                               lFilterKernelNew[i].getCenterFrequency(),
-                                               lFilterKernelNew[i].getBandwidth(),
-                                               lFilterKernelNew[i].getParksWidth(),
-                                               lFilterKernelNew[i].getSamplingFrequency(),
-                                               lFilterKernelNew[i].m_designMethod);
+    int iOrder = lFilterKernel.first().getFilterOrder();
+    for(int i = 0; i < lFilterKernel.size(); ++i) {
+        if(lFilterKernel[i].getFilterOrder() > iOrder) {
+            iOrder = lFilterKernel[i].getFilterOrder();
         }
     }
 
@@ -200,7 +191,7 @@ bool Filter::filterFile(QIODevice &pIODevice,
 
         data = filter.filterDataBlock(data,
                                       vecPicks,
-                                      lFilterKernelNew,
+                                      lFilterKernel,
                                       true,
                                       bUseThreads);
 

--- a/libraries/rtprocessing/filter.h
+++ b/libraries/rtprocessing/filter.h
@@ -118,7 +118,7 @@ public:
      * @param [in] dBandwidth           The filter bandwidth. Ignored if FilterType is set to LPF,HPF. If NOTCH/BPF: bandwidth of stop-/passband
      * @param [in] dTransition          The transistion band determines the width of the filter slopes (steepness)
      * @param [in] dSFreq               The input data sampling frequency.
-     * @param [in] iOrder               Represents the order of the filter, the higher the higher is the stopband attenuation. Default is 1024 taps.
+     * @param [in] iOrder               Represents the order of the filter, the higher the higher is the stopband attenuation. Default is 4096 taps.
      * @param [in] designMethod         The design method to use. Choose between Cosine and Tschebyscheff. Defaul is set to Cosine.
      * @param [in] vecPicks             Channel indexes to filter. Default is filter all channels.
      * @param [in] bUseThreads          hether to use multiple threads. Default is set to true.
@@ -132,7 +132,7 @@ public:
                     double dBandwidth,
                     double dTransition,
                     double dSFreq,
-                    int iOrder = 1024,
+                    int iOrder = 4096,
                     RTPROCESSINGLIB::FilterKernel::DesignMethod designMethod = RTPROCESSINGLIB::FilterKernel::Cosine,
                     const Eigen::RowVectorXi &vecPicks = Eigen::RowVectorXi(),
                     bool bUseThreads = true) const;


### PR DESCRIPTION
Revert always changing the filter order to 4096 when using the `filterFile()` function. This is too intransparent for the user/developer. Let the user decide/make sure that the filter kernel has a sufficient filter length. In MNE Analyze we now redesign the filter to 4096 before saving to file.