### PR TITLE
[MAINT, DOC] Use "command line" without hyphen and add link to mne_anonymize wasm 

### DIFF
--- a/applications/mne_anonymize/apphandler.h
+++ b/applications/mne_anonymize/apphandler.h
@@ -111,7 +111,7 @@ public:
      * @brief Creates a controller object according tu user's preference for a command line or a
      *  GUI application.
      *
-     * @details Depending on the state of the bool member variable m_bGuiMode, the method creates a command-line or a
+     * @details Depending on the state of the bool member variable m_bGuiMode, the method creates a command line or a
      * GUI oriented controller object of the SettingsControllerCL or the SettingsControllerGui class.
      *
      * @see MNE-CPP Documentation
@@ -128,7 +128,7 @@ protected:
 
 private:
 
-bool m_bGuiMode;  /**< GUI based app, or a command-line one.*/
+bool m_bGuiMode;  /**< GUI based app, or a command line one.*/
 
 };
 

--- a/applications/mne_anonymize/mainwindow.h
+++ b/applications/mne_anonymize/mainwindow.h
@@ -125,7 +125,7 @@ public:
     /**
      * @brief Sets the state of the checkbox for selecting Brute Mode on.
      *
-     * @details Allows the controller to set state of the Brute Mode, according to the command-line arguments of the
+     * @details Allows the controller to set state of the Brute Mode, according to the command line arguments of the
      * call to MNE_Anonymize application.
      *
      * @param [in] b bool variable containing the desired state to set the checkbox to.
@@ -137,7 +137,7 @@ public:
     /**
      * @brief Sets the state of the Measuremenet date control in the user interface..
      *
-     * @details Allows the controller to set state of the measurement date control, according to the command-line arguments of the
+     * @details Allows the controller to set state of the measurement date control, according to the command line arguments of the
      * call to MNE_Anonymize application.
      *
      * @param [in] QDateTime dt reference variable containing the desired measurement date to be used when anonymizing the input fif file..
@@ -149,7 +149,7 @@ public:
     /**
      * @brief Sets the state of the checkbox for selecting measurement date offset on.
      *
-     * @details Allows the controller to set state of the use of the measurement date offset related checkbox, according to the command-line arguments of the
+     * @details Allows the controller to set state of the use of the measurement date offset related checkbox, according to the command line arguments of the
      * call to MNE_Anonymize application.
      *
      * @param [in] o bool variable representing the use or not of measurement offset when updating the mesasurement date of a file.
@@ -162,7 +162,7 @@ public:
      * @brief Sets the number of days to offset the measurement date with.
      *
      * @details Measurement date offset. Minimal, Maximum values [-10000, 10000]. This method will update the user interface, according according
-     * to the command-line arguments of the call to MNE_Anonymize application.
+     * to the command line arguments of the call to MNE_Anonymize application.
      *
      * @param [in] d Int. Number of days to offset the measurement date with.
      *

--- a/applications/mne_anonymize/settingscontrollercl.cpp
+++ b/applications/mne_anonymize/settingscontrollercl.cpp
@@ -168,7 +168,7 @@ void SettingsControllerCl::initParser()
     m_parser.addHelpOption();
 
     //this breaks encapsulation. damn it. it has to be here in order to show in the help text.
-    QCommandLineOption commandLineOpt("no-gui",QCoreApplication::translate("main","Command-line version of this application."));
+    QCommandLineOption commandLineOpt("no-gui",QCoreApplication::translate("main","command line version of this application."));
     m_parser.addOption(commandLineOpt);
 
     QCommandLineOption versionOpt("version",QCoreApplication::translate("main","Show the version of this application."));
@@ -232,7 +232,7 @@ void SettingsControllerCl::initParser()
 
     QCommandLineOption mneEnvironmentOpt("mne_environment",
                                          QCoreApplication::translate("main","Anonymize information related to the MNE environment. "
-                                                                                       "If found in the file, Working Directory or Command-line tags will be anonymized."));
+                                                                                       "If found in the file, Working Directory or command line tags will be anonymized."));
     m_parser.addOption(mneEnvironmentOpt);
 }
 

--- a/applications/mne_anonymize/settingscontrollercl.cpp
+++ b/applications/mne_anonymize/settingscontrollercl.cpp
@@ -168,7 +168,7 @@ void SettingsControllerCl::initParser()
     m_parser.addHelpOption();
 
     //this breaks encapsulation. damn it. it has to be here in order to show in the help text.
-    QCommandLineOption commandLineOpt("no-gui",QCoreApplication::translate("main","command line version of this application."));
+    QCommandLineOption commandLineOpt("no-gui",QCoreApplication::translate("main","Command line version of this application."));
     m_parser.addOption(commandLineOpt);
 
     QCommandLineOption versionOpt("version",QCoreApplication::translate("main","Show the version of this application."));

--- a/doc/gh-pages/pages/install/binaries.md
+++ b/doc/gh-pages/pages/install/binaries.md
@@ -27,4 +27,4 @@ Web Assembly Release
 
 | Version | Release | Link |
 |---------|------|------|
-| dev_build | [Latest commit](https://github.com/mne-tools/mne-cpp/commits/master){:target="_blank" rel="noopener"} | <span class="fs-2"> [MNE Analyze - WASM](https://mne-cpp.github.io/wasm/mne_analyze.html){: .btn .btn-purple } </span> |
+| dev_build | [Latest commit](https://github.com/mne-tools/mne-cpp/commits/master){:target="_blank" rel="noopener"} | <span class="fs-2"> [MNE Analyze - WASM](https://mne-cpp.github.io/wasm/mne_analyze.html){: .btn .btn-purple } </span> <span class="fs-2"> [MNE Anonymize - WASM](https://mne-cpp.github.io/wasm/mne_anonymize.html){: .btn .btn-purple } </span>|

--- a/doc/gh-pages/pages/learn/dipolefit.md
+++ b/doc/gh-pages/pages/learn/dipolefit.md
@@ -6,9 +6,9 @@ nav_order: 4
 ---
 # MNE Dipole Fit CLI
 
-## Command-line options 
+## command line options 
 
-`mne_dipole_fit` recognizes the following command-line options:
+`mne_dipole_fit` recognizes the following command line options:
 
 Input data:
 ```

--- a/doc/gh-pages/pages/learn/dipolefit.md
+++ b/doc/gh-pages/pages/learn/dipolefit.md
@@ -6,7 +6,7 @@ nav_order: 4
 ---
 # MNE Dipole Fit CLI
 
-## command line options 
+## Command line options 
 
 `mne_dipole_fit` recognizes the following command line options:
 

--- a/doc/gh-pages/pages/learn/fwdsolution.md
+++ b/doc/gh-pages/pages/learn/fwdsolution.md
@@ -6,9 +6,9 @@ nav_order: 5
 ---
 # MNE Forward Solution CLI
 
-## Command-line options 
+## command line options 
 
-`mne_forward_solution` recognizes the following command-line options:
+`mne_forward_solution` recognizes the following command line options:
 
 Input data:
 ```

--- a/doc/gh-pages/pages/learn/fwdsolution.md
+++ b/doc/gh-pages/pages/learn/fwdsolution.md
@@ -6,7 +6,7 @@ nav_order: 5
 ---
 # MNE Forward Solution CLI
 
-## command line options 
+## Command line options 
 
 `mne_forward_solution` recognizes the following command line options:
 

--- a/doc/gh-pages/pages/learn/mneanonymize.md
+++ b/doc/gh-pages/pages/learn/mneanonymize.md
@@ -1,5 +1,5 @@
 ---
-title: MNE Anonymize CLI
+title: MNE Anonymize GUI/CLI
 has_children: false
 parent: Learn
 nav_order: 3

--- a/doc/gh-pages/pages/learn/mneanonymize.md
+++ b/doc/gh-pages/pages/learn/mneanonymize.md
@@ -55,18 +55,18 @@ MNE Anonymize does not modify the input file. Moreover, this application can eve
 
 ## GUI Mode
 
-MNE Anonymize binary file is named `mne_anonymize`. By default, the application is executed in GUI mode. However, if you want to run `mne_anonymize` in GUI mode but you still want to initialize some of the options through a command-line call, you can allways do so through the actual command prompt. For example, if you execute `mne_anonymize --in example.fif -bdf` the GUI will start and the options in it will be already set accordingly. The application recognizes several command-line options, see bellow.
+MNE Anonymize binary file is named `mne_anonymize`. By default, the application is executed in GUI mode. However, if you want to run `mne_anonymize` in GUI mode but you still want to initialize some of the options through a command line call, you can allways do so through the actual command prompt. For example, if you execute `mne_anonymize --in example.fif -bdf` the GUI will start and the options in it will be already set accordingly. The application recognizes several command line options, see bellow.
 
-## Command-line Mode 
+## command line Mode 
 
-MNE Anonymize can also be executed in command-line mode. This is intended for users that might want to anonymize a considerable number of files. The following table shows all valid command-line options. 
+MNE Anonymize can also be executed in command line mode. This is intended for users that might want to anonymize a considerable number of files. The following table shows all valid command line options. 
 
-### Command-line Options
+### command line Options
 
 | Option | Description | 
 |--------|-------------|
-|`-h --help`| Displays help on the command-line.|
-|`--no-gui`| Command-line version of the application.|
+|`-h --help`| Displays help on the command line.|
+|`--no-gui`| command line version of the application.|
 |`--version`| Show the version of this appliation.|
 |`-i --in <infile>`| File to anonymize.|
 |`-o --out <outfile>` *optional*| Output file `<outfile>`. As default '_anonymized.fif' is attached to the file name.|
@@ -122,7 +122,7 @@ It is important to remark that tags will not be deleted. The information in the 
 
 For all examples we will use MNE-CPP's sample data which can be found inside the project folder in `bin/MNE-sample-data/MEG/sample` folder. If you find that folder empty, please read `README.md` file inside `MNE-sample-data` folder.
 
-The easiest way to run `mne_anonymize` is by just running the application and using the GUI. Remember you can pre-initialize the options of the GUI through the command-line call. If you want, you can allways use the command-line mode, without GUI. For instance:
+The easiest way to run `mne_anonymize` is by just running the application and using the GUI. Remember you can pre-initialize the options of the GUI through the command line call. If you want, you can allways use the command line mode, without GUI. For instance:
 
 For specifying an input file to anonymize:
 

--- a/doc/gh-pages/pages/learn/mneanonymize.md
+++ b/doc/gh-pages/pages/learn/mneanonymize.md
@@ -57,16 +57,16 @@ MNE Anonymize does not modify the input file. Moreover, this application can eve
 
 MNE Anonymize binary file is named `mne_anonymize`. By default, the application is executed in GUI mode. However, if you want to run `mne_anonymize` in GUI mode but you still want to initialize some of the options through a command line call, you can allways do so through the actual command prompt. For example, if you execute `mne_anonymize --in example.fif -bdf` the GUI will start and the options in it will be already set accordingly. The application recognizes several command line options, see bellow.
 
-## command line Mode 
+## Command line Mode 
 
 MNE Anonymize can also be executed in command line mode. This is intended for users that might want to anonymize a considerable number of files. The following table shows all valid command line options. 
 
-### command line Options
+### Command line Options
 
 | Option | Description | 
 |--------|-------------|
 |`-h --help`| Displays help on the command line.|
-|`--no-gui`| command line version of the application.|
+|`--no-gui`| Command line version of the application.|
 |`--version`| Show the version of this appliation.|
 |`-i --in <infile>`| File to anonymize.|
 |`-o --out <outfile>` *optional*| Output file `<outfile>`. As default '_anonymized.fif' is attached to the file name.|


### PR DESCRIPTION
Hi, there were 24 uses of "command-line" **with** hyphen in the code base and about 150 **without**. Most of the uses came from the damn anonymize app... 🤫.
We now use no hyphen in the term. Little bit of coherence can't hurt. 
Besides I've come through [this](https://dzone.com/articles/blogging-programmers#:~:text=%22Open%2DSource%22%20and%20%22,noun%20or%20a%20compound%20adjective) interesting post, which besides it being quite old, I think it is still valuable.

Also added the link to anonymize wasm and change the title in the docs.