### PR TITLE
[FIX] MNE Analyze: fixed indexing when updating event group list.

### DIFF
--- a/applications/mne_analyze/libs/anShared/Model/annotationmodel.cpp
+++ b/applications/mne_analyze/libs/anShared/Model/annotationmodel.cpp
@@ -864,15 +864,27 @@ void AnnotationModel::setGroupName(int iGroupIndex,
 
 //=============================================================================================================
 
-const QString& AnnotationModel::getGroupName(int iGroupIndex)
+QString AnnotationModel::getGroupName(int iGroupIndex)
 {
     if(!m_mAnnotationHub.contains(iGroupIndex)){
         qWarning() << "[AnnotationModel::getGroupName] Attempting to get name of group with invalid key.";
+        return "NAME NOT FOUND";
     }
 
     return m_mAnnotationHub[iGroupIndex]->groupName;
 }
 
+//=============================================================================================================
+
+QString AnnotationModel::getGroupNameFromList(int iGroupIndex)
+{
+    if(m_mAnnotationHub.keys().size() <= iGroupIndex){
+        qWarning() << "[AnnotationModel::getGroupNameFromList] Attempting to get name of group with invalid key.";
+        return "NAME NOT FOUND";
+    }
+
+    return m_mAnnotationHub[m_mAnnotationHub.keys()[iGroupIndex]]->groupName;
+}
 //=============================================================================================================
 
 int AnnotationModel::getIndexFromName(const QString &sGroupName)

--- a/applications/mne_analyze/libs/anShared/Model/annotationmodel.cpp
+++ b/applications/mne_analyze/libs/anShared/Model/annotationmodel.cpp
@@ -864,26 +864,26 @@ void AnnotationModel::setGroupName(int iGroupIndex,
 
 //=============================================================================================================
 
-QString AnnotationModel::getGroupName(int iGroupIndex)
+QString AnnotationModel::getGroupName(int iMapKey)
 {
-    if(!m_mAnnotationHub.contains(iGroupIndex)){
+    if(!m_mAnnotationHub.contains(iMapKey)){
         qWarning() << "[AnnotationModel::getGroupName] Attempting to get name of group with invalid key.";
         return "NAME NOT FOUND";
     }
 
-    return m_mAnnotationHub[iGroupIndex]->groupName;
+    return m_mAnnotationHub[iMapKey]->groupName;
 }
 
 //=============================================================================================================
 
-QString AnnotationModel::getGroupNameFromList(int iGroupIndex)
+QString AnnotationModel::getGroupNameFromList(int iListIndex)
 {
-    if(m_mAnnotationHub.keys().size() <= iGroupIndex){
+    if(m_mAnnotationHub.keys().size() <= iListIndex){
         qWarning() << "[AnnotationModel::getGroupNameFromList] Attempting to get name of group with invalid key.";
         return "NAME NOT FOUND";
     }
 
-    return m_mAnnotationHub[m_mAnnotationHub.keys()[iGroupIndex]]->groupName;
+    return m_mAnnotationHub[m_mAnnotationHub.keys()[iListIndex]]->groupName;
 }
 //=============================================================================================================
 

--- a/applications/mne_analyze/libs/anShared/Model/annotationmodel.h
+++ b/applications/mne_analyze/libs/anShared/Model/annotationmodel.h
@@ -466,7 +466,17 @@ public:
      *
      * @return name of group at index iGroupIndex
      */
-    const QString& getGroupName(int iGroupIndex);
+    QString getGroupName(int iGroupIndex);
+
+    //=========================================================================================================
+    /**
+     * Returns the name of the event at index iGroup as if the map of groups were an array. Does not use Group Index.
+     *
+     * @param[in] iGroup    index of the group from which we are getting the name
+     *
+     * @return name of the iGroup-th event group
+     */
+    QString getGroupNameFromList(int iGroup);
 
     //=========================================================================================================
     /**

--- a/applications/mne_analyze/libs/anShared/Model/annotationmodel.h
+++ b/applications/mne_analyze/libs/anShared/Model/annotationmodel.h
@@ -460,23 +460,23 @@ public:
 
     //=========================================================================================================
     /**
-     * Returns group name of the group with input parameter iGroupIndex
+     * Returns group name of the group with map key iMapKey
      *
-     * @param[in] iGroupIndex   index of the group from which we are getting the name
+     * @param[in] iMapKey       map key(group index) of the group from which we are getting the name
      *
-     * @return name of group at index iGroupIndex
+     * @return name of group at from m_mAnnotationHub at iMapKey
      */
-    QString getGroupName(int iGroupIndex);
+    QString getGroupName(int iMapKey);
 
     //=========================================================================================================
     /**
-     * Returns the name of the event at index iGroup as if the map of groups were an array. Does not use Group Index.
+     * Returns the name of the event at index iListIndex as if the map of groups were an array. Does not use Group Index.
      *
-     * @param[in] iGroup    index of the group from which we are getting the name
+     * @param[in] iListIndex    index of the group from which we are getting the name
      *
-     * @return name of the iGroup-th event group
+     * @return name of the iListIndex-th event group for m_mAnnotationHub
      */
-    QString getGroupNameFromList(int iGroup);
+    QString getGroupNameFromList(int iListIndex);
 
     //=========================================================================================================
     /**

--- a/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.cpp
+++ b/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.cpp
@@ -44,7 +44,6 @@
 #include <rtprocessing/detecttrigger.h>
 #include <anShared/Model/fiffrawviewmodel.h>
 #include <disp/viewers/triggerdetectionview.h>
-#include <iostream>
 
 //=============================================================================================================
 // QT INCLUDES
@@ -524,16 +523,11 @@ void AnnotationSettingsView::deleteGroup()
 {
     int iSelected = m_pUi->m_listWidget_groupListWidget->selectionModel()->selectedRows().first().row();
     QListWidgetItem* itemToDelete = m_pUi->m_listWidget_groupListWidget->takeItem(iSelected);
-    std::cout << "1";
     m_pAnnModel->removeGroup(itemToDelete->data(Qt::UserRole).toInt());
-    std::cout << "2";
     m_pUi->m_listWidget_groupListWidget->selectionModel()->clearSelection();
     delete itemToDelete;
-    std::cout << "3";
     onDataChanged();
-    std::cout << "4";
     emit groupsUpdated();
-    std::cout << "5";
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.cpp
+++ b/applications/mne_analyze/plugins/annotationmanager/annotationsettingsview.cpp
@@ -44,6 +44,7 @@
 #include <rtprocessing/detecttrigger.h>
 #include <anShared/Model/fiffrawviewmodel.h>
 #include <disp/viewers/triggerdetectionview.h>
+#include <iostream>
 
 //=============================================================================================================
 // QT INCLUDES
@@ -523,11 +524,16 @@ void AnnotationSettingsView::deleteGroup()
 {
     int iSelected = m_pUi->m_listWidget_groupListWidget->selectionModel()->selectedRows().first().row();
     QListWidgetItem* itemToDelete = m_pUi->m_listWidget_groupListWidget->takeItem(iSelected);
+    std::cout << "1";
     m_pAnnModel->removeGroup(itemToDelete->data(Qt::UserRole).toInt());
+    std::cout << "2";
     m_pUi->m_listWidget_groupListWidget->selectionModel()->clearSelection();
     delete itemToDelete;
+    std::cout << "3";
     onDataChanged();
+    std::cout << "4";
     emit groupsUpdated();
+    std::cout << "5";
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/plugins/averaging/averaging.cpp
+++ b/applications/mne_analyze/plugins/averaging/averaging.cpp
@@ -613,7 +613,7 @@ void Averaging::updateGroups()
 {
     m_pAveragingSettingsView->clearSelectionGroup();
     for(int i = 0; i < m_pFiffRawModel->getAnnotationModel()->getHubSize(); i++){
-        m_pAveragingSettingsView->addSelectionGroup(m_pFiffRawModel->getAnnotationModel()->getGroupName(i));
+        m_pAveragingSettingsView->addSelectionGroup(m_pFiffRawModel->getAnnotationModel()->getGroupNameFromList(i));
     }
 }
 


### PR DESCRIPTION
Fixed issue where function was trying to get the name from an invalid index from iterating over map while not looking up the list of keys before reading from the map. Also changed return of function from QString& to QString for best practices.