### PR TITLE
[FIX] Fix data plotting when scrolling to the left in MNE Analyze

### DIFF
--- a/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
+++ b/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
@@ -418,14 +418,6 @@ public:
 
     //=========================================================================================================
     /**
-     * This tells the model where the view currently is horizontally.
-     *
-     * @param newScrollPosition Absolute sample number.
-     */
-    void updateHorizontalScrollPosition(qint32 newScrollPosition);
-
-    //=========================================================================================================
-    /**
      * Toggle whether to dipslay annotations
      *
      * @param[in] iToggleDisp   0 for no, 1+ for yes
@@ -495,6 +487,14 @@ public:
      * @return m_pFiffIO, member varaible saving the FiffRawData and FiffEvoked parameters
      */
     QSharedPointer<FIFFLIB::FiffIO> getFiffIO() const;
+
+    //=========================================================================================================
+    /**
+     * This tells the model where the view currently is horizontally.
+     *
+     * @param newScrollPosition Absolute sample number.
+     */
+    void updateHorizontalScrollPosition(qint32 newScrollPosition);
 
 private:
     //=========================================================================================================

--- a/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
+++ b/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
@@ -414,7 +414,7 @@ public:
      *
      * @return number of blocks
      */
-    int getWindowSizeBlocks() const;
+    int getTotalBlockCount() const;
 
     //=========================================================================================================
     /**

--- a/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
+++ b/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
@@ -499,19 +499,17 @@ public:
 private:
     //=========================================================================================================
     /**
-     * Calculates the filtered version of all loaded data blocks
-     */
-    void filterAllDataBlocks();
-
-    //=========================================================================================================
-    /**
      * Calculates the filtered version of one single datablock
      *
-     * @param[in]   matData         The data block to be filtered.
-     * @param [in]  bFilterEnd      Whether to perform the overlap add in the beginning or end of the data.
+     * @param [in]   matData         The data block to be filtered.
+     * @param [in]   bFilterEnd      Whether to perform the overlap add in the beginning or end of the data.
+     * @param [in]   bKeepOverhead   Whether to keep the overhead.
+     *
+     * @return Returns true if filtering was performed, otherwise returns false
      */
-    void filterDataBlock(MatrixXd& matData,
-                         bool bFilterEnd);
+    bool filterDataBlock(MatrixXd& matData,
+                         bool bFilterEnd,
+                         bool bKeepOverhead = false);
 
     //=========================================================================================================
     /**

--- a/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
+++ b/applications/mne_analyze/libs/anShared/Model/fiffrawviewmodel.h
@@ -556,7 +556,7 @@ private:
     /**
      * Replicates the behavior of initFiffData to accomodate changes in number of samples shown
      */
-    void updateDisplayData();
+    void reloadAllData();
 
     std::list<QSharedPointer<QPair<MatrixXd, MatrixXd> > > m_lData;             /**< Data */
     std::list<QSharedPointer<QPair<MatrixXd, MatrixXd> > > m_lNewData;          /**< Data that is to be appended or prepended */

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
@@ -132,6 +132,9 @@ void FiffRawViewDelegate::paint(QPainter *painter,
                 const FiffRawViewModel* pFiffRawModel = static_cast<const FiffRawViewModel*>(index.model());
 
                 int pos = pFiffRawModel->pixelDifference() * (pFiffRawModel->currentFirstSample() - pFiffRawModel->absoluteFirstSample());
+                qDebug() << "pos" << pos;
+                qDebug() << "pFiffRawModel->currentFirstSample()" << pFiffRawModel->currentFirstSample();
+                qDebug() << "pFiffRawModel->absoluteFirstSample()" << pFiffRawModel->absoluteFirstSample();
 
                 QPainterPath path = QPainterPath(QPointF(option.rect.x()+pos, option.rect.y()));
 //                QPainterPath path  = QPainterPath(QPointF(option.rect.x(),option.rect.y()));
@@ -242,6 +245,7 @@ void FiffRawViewDelegate::createPlotPath(const QStyleOptionViewItem &option,
     if (iPaintStep < 2){
         iPaintStep = 1;
     }
+    iPaintStep = 1;
 
     for(unsigned int j = 0; j < data.size(); j = j + iPaintStep) {
         dValue = data[j] * dScaleY;
@@ -250,7 +254,13 @@ void FiffRawViewDelegate::createPlotPath(const QStyleOptionViewItem &option,
         newY = y_base - dValue;
         //qDebug() << "data:" << dValue;
         qSamplePosition.setY(newY);
+
+        // Multiply by dDx because we need to take into account different visible window sizes specified by the user.
+        // The spacing we use to paint the samples is therefore dependent on how much data we plot (in samples) in
+        // the GUI view with user selected width (in pixels). This relationship is calculated in the FiffRawView
+        // and is reflected by dDx
         qSamplePosition.setX(path.currentPosition().x() + (dDx * (float)iPaintStep));
+
         path.lineTo(qSamplePosition);
     }
 //    for(int j = iPaintStep; j < data.size(); j = j + iPaintStep) {
@@ -291,7 +301,7 @@ void FiffRawViewDelegate::createTimeSpacersPath(const QModelIndex &index,
     float fTop = option.rect.topLeft().y();
     float fBottom = option.rect.bottomRight().y();
 
-    for(int j = 0; j < (1.5 * iSpacersPerSecond * t_pModel->getWindowSizeBlocks()); j++) {
+    for(int j = 0; j < (1.5 * iSpacersPerSecond * t_pModel->getTotalBlockCount()); j++) {
         //draw vertical line
         path.moveTo(path.currentPosition().x(), fTop);
         path.lineTo(path.currentPosition().x(), fBottom);

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
@@ -132,9 +132,6 @@ void FiffRawViewDelegate::paint(QPainter *painter,
                 const FiffRawViewModel* pFiffRawModel = static_cast<const FiffRawViewModel*>(index.model());
 
                 int pos = pFiffRawModel->pixelDifference() * (pFiffRawModel->currentFirstSample() - pFiffRawModel->absoluteFirstSample());
-                qDebug() << "pos" << pos;
-                qDebug() << "pFiffRawModel->currentFirstSample()" << pFiffRawModel->currentFirstSample();
-                qDebug() << "pFiffRawModel->absoluteFirstSample()" << pFiffRawModel->absoluteFirstSample();
 
                 QPainterPath path = QPainterPath(QPointF(option.rect.x()+pos, option.rect.y()));
 

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
@@ -137,7 +137,6 @@ void FiffRawViewDelegate::paint(QPainter *painter,
                 qDebug() << "pFiffRawModel->absoluteFirstSample()" << pFiffRawModel->absoluteFirstSample();
 
                 QPainterPath path = QPainterPath(QPointF(option.rect.x()+pos, option.rect.y()));
-//                QPainterPath path  = QPainterPath(QPointF(option.rect.x(),option.rect.y()));
 
                 //Plot data
                 createPlotPath(option,
@@ -241,11 +240,12 @@ void FiffRawViewDelegate::createPlotPath(const QStyleOptionViewItem &option,
 
     QPointF qSamplePosition;
 
-    int iPaintStep = (int)(1.0/dDx) - 1;
-    if (iPaintStep < 2){
-        iPaintStep = 1;
-    }
-    iPaintStep = 1;
+    //Deactivate downsampling for now due to aliasing effects
+//    int iPaintStep = (int)(1.0/dDx) - 1;
+//    if (iPaintStep < 2){
+//        iPaintStep = 1;
+//    }
+    int iPaintStep = 1;
 
     for(unsigned int j = 0; j < data.size(); j = j + iPaintStep) {
         dValue = data[j] * dScaleY;

--- a/examples/ex_disp_3D/main.cpp
+++ b/examples/ex_disp_3D/main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
     QCommandLineOption evokedFileOption("ave", "Path to the evoked/average <file>.", "file", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis-ave.fif");
     QCommandLineOption methodOption("method", "Inverse estimation <method>, i.e., 'MNE', 'dSPM' or 'sLORETA'.", "method", "dSPM");//"MNE" | "dSPM" | "sLORETA"
     QCommandLineOption snrOption("snr", "The SNR value used for computation <snr>.", "snr", "3.0");//3.0;//0.1;//3.0;
-    QCommandLineOption evokedIndexOption("aveIdx", "The average <index> to choose from the average file.", "index", "3");
+    QCommandLineOption evokedIndexOption("aveIdx", "The average <index> to choose from the average file.", "index", "1");
 
     parser.addOption(surfOption);
     parser.addOption(annotOption);

--- a/libraries/disp/viewers/averagelayoutview.cpp
+++ b/libraries/disp/viewers/averagelayoutview.cpp
@@ -92,7 +92,7 @@ AverageLayoutView::AverageLayoutView(const QString& sSettingsPath,
     m_pAverageLayoutView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     m_pAverageScene = AverageScene::SPtr(new AverageScene(m_pAverageLayoutView.data(), this));
-    m_pAverageScene->setBackgroundBrush(QBrush(Qt::black));
+    m_pAverageScene->setBackgroundBrush(QBrush(Qt::white));
 
     m_pAverageLayoutView->setScene(m_pAverageScene.data());
 

--- a/libraries/disp/viewers/butterflyview.cpp
+++ b/libraries/disp/viewers/butterflyview.cpp
@@ -302,7 +302,7 @@ void ButterflyView::loadSettings()
 
     painter.save();
     painter.setBrush(QBrush(m_colCurrentBackgroundColor));
-    painter.drawRect(QRect(0,0,this->width()-1,this->height()-1));
+    painter.drawRect(QRect(-1,-1,this->width()+2,this->height()+2));
     painter.restore();
 
     painter.setRenderHint(QPainter::Antialiasing, true);

--- a/libraries/disp3D/engine/model/data3Dtreemodel.h
+++ b/libraries/disp3D/engine/model/data3Dtreemodel.h
@@ -207,8 +207,8 @@ public:
      * @return                           Returns a pointer to the added tree item. Default is a NULL pointer if no item was added.
      */
     QList<SourceSpaceTreeItem*> addForwardSolution(const QString& sSubject,
-                                            const QString& sMeasurementSetName,
-                                            const MNELIB::MNEForwardSolution& forwardSolution);
+                                                   const QString& sMeasurementSetName,
+                                                   const MNELIB::MNEForwardSolution& forwardSolution);
 
     //=========================================================================================================
     /**
@@ -413,13 +413,13 @@ protected:
      * @return                           Returns a pointer to the added tree item. Default is a NULL pointer if no item was added.
      */
     SensorDataTreeItem *addGpuSensorData(const QString& sSubject,
-                                            const QString& sMeasurementSetName,
-                                            const Eigen::MatrixXd& matSensorData,
-                                            const MNELIB::MNEBemSurface& tBemSurface,
-                                            const FIFFLIB::FiffInfo &fiffInfo,
-                                            const QString &sDataType,
-                                            const double dCancelDist,
-                                            const QString &sInterpolationFunction);
+                                         const QString& sMeasurementSetName,
+                                         const Eigen::MatrixXd& matSensorData,
+                                         const MNELIB::MNEBemSurface& tBemSurface,
+                                         const FIFFLIB::FiffInfo &fiffInfo,
+                                         const QString &sDataType,
+                                         const double dCancelDist,
+                                         const QString &sInterpolationFunction);
 
     //=========================================================================================================
     /**


### PR DESCRIPTION
This PR includes:

- Fix data plotting when scrolling to the left (raw and filtering). Fixed a problem where the current fiff curser of the beginning data block was substracted by the filter delay even if filtering was disabled. Fixes #659
- Remove `filterAllData` function and replace usage by `reloadAllData`, which leads to an performance improvement
- Rename `updateDisplayData` to `reloadAllData`
- Comment out some qInfo outputs
- Rename `getWindowSizeBlocks` to `getTotalBlockCount`
- Disable downsampling when plotting since it introduced aliasing effects