### PR TITLE
[ENH] Add cmd line argument support to MNE Analyze

### DIFF
--- a/applications/mne_analyze/libs/anShared/Interfaces/IPlugin.h
+++ b/applications/mne_analyze/libs/anShared/Interfaces/IPlugin.h
@@ -153,6 +153,14 @@ public:
 
     //=========================================================================================================
     /**
+     * Initializes the plugin based on cmd line inputs given by the user.
+     *
+     * @param[in] sArguments  the cmd line arguments
+     */
+    virtual inline void cmdLineStartup(const QStringList& sArguments);
+
+    //=========================================================================================================
+    /**
      * Sets the global data, which provides the central database.
      *
      * @param[in] globalData  the global data
@@ -191,6 +199,13 @@ protected:
 
 //=============================================================================================================
 // INLINE DEFINITIONS
+//=============================================================================================================
+
+void IPlugin::cmdLineStartup(const QStringList& sArguments)
+{
+    Q_UNUSED(sArguments)
+}
+
 //=============================================================================================================
 
 void IPlugin::setGlobalData(QSharedPointer<AnalyzeData> globalData)

--- a/applications/mne_analyze/libs/anShared/Management/pluginmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/pluginmanager.cpp
@@ -114,7 +114,7 @@ void PluginManager::loadPluginsFromDirectory(const QString& dir)
 //=============================================================================================================
 
 void PluginManager::initPlugins(QSharedPointer<AnalyzeSettings> settings,
-                                      QSharedPointer<AnalyzeData> data)
+                                QSharedPointer<AnalyzeData> data)
 {
     for(IPlugin* plugin : m_qVecPlugins)
     {

--- a/applications/mne_analyze/mne_analyze/analyzecore.h
+++ b/applications/mne_analyze/mne_analyze/analyzecore.h
@@ -50,6 +50,7 @@
 #include <QObject>
 #include <QSharedPointer>
 #include <QPointer>
+#include <QCommandLineParser>
 
 //=============================================================================================================
 // FORWARD DECLARATIONS
@@ -126,17 +127,24 @@ public:
      */
     void initGlobalData();
 
-protected:
+private:
+    //=========================================================================================================
+    /**
+     * Init the command line parser
+     */
+    void initCmdLineParser();
 
-private slots:
+    //=========================================================================================================
+    /**
+     * Parse the cmd line arguments and pass them to the plugins
+     */
+    void parseCmdLineInputs();
 
     //=========================================================================================================
     /**
      * This is executed when the user presses "close" button (via QConnection from MainWindow)
      */
     void onMainWindowClosed();
-
-private:
 
     //=========================================================================================================
     /**
@@ -165,6 +173,8 @@ private:
     QSharedPointer<ANSHAREDLIB::PluginManager>      m_pPluginManager;       /**< Holds plugin manager. */
     QSharedPointer<ANSHAREDLIB::AnalyzeSettings>    m_analyzeSettings;      /**< The global settings. */
     QSharedPointer<ANSHAREDLIB::AnalyzeData>        m_analyzeData;          /**< The global data base. */
+
+    QCommandLineParser                              m_cmdLineParser;        /**< The command line parser. */
 };
 
 //=============================================================================================================

--- a/applications/mne_analyze/mne_analyze/main.cpp
+++ b/applications/mne_analyze/mne_analyze/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     fmt.setSamples(4);
     QSurfaceFormat::setDefaultFormat(fmt);
 
-    //New main window instance
+    //New AnalyzeCore instance
     QScopedPointer<AnalyzeCore> pAnalyzeCore (new AnalyzeCore);
     pAnalyzeCore->showMainWindow();
 

--- a/applications/mne_analyze/plugins/dataloader/dataloader.cpp
+++ b/applications/mne_analyze/plugins/dataloader/dataloader.cpp
@@ -38,9 +38,9 @@
 
 #include "dataloader.h"
 
-#include <anShared/Model/fiffrawviewmodel.h>
 #include <anShared/Management/communicator.h>
 #include <anShared/Management/analyzedata.h>
+#include <anShared/Model/fiffrawviewmodel.h>
 
 //=============================================================================================================
 // USED NAMESPACES
@@ -156,29 +156,45 @@ QVector<EVENT_TYPE> DataLoader::getEventSubscriptions(void) const
 
 //=============================================================================================================
 
+void DataLoader::cmdLineStartup(const QStringList& sArguments)
+{
+    if(sArguments.size() == 2 && (sArguments.first() == "file" || sArguments.first() == "f")) {
+        loadFilePath(sArguments.at(1));
+    }
+}
+
+//=============================================================================================================
+
+void DataLoader::loadFilePath(const QString& sFilePath)
+{
+    QFileInfo fileInfo(sFilePath);
+
+    if(fileInfo.exists() && (fileInfo.completeSuffix() == "fif")) {
+        m_pAnalyzeData->loadModel<ANSHAREDLIB::FiffRawViewModel>(sFilePath);
+    }
+}
+
+//=============================================================================================================
+
 void DataLoader::onLoadFilePressed()
 {
     #ifdef WASMBUILD
-    auto fileContentReady = [&](const QString &filePath, const QByteArray &fileContent) {
-        if(!filePath.isNull()) {
+    auto fileContentReady = [&](const QString &sFilePath, const QByteArray &fileContent) {
+        if(!sFilePath.isNull()) {
             // We need to prepend "wasm/" because QFileDialog::getOpenFileContent does not provide a full
             // path, which we need for organzing the different models in AnalyzeData
-            m_pAnalyzeData->loadModel<FiffRawViewModel>("wasm/"+filePath, fileContent);
+            m_pAnalyzeData->loadModel<FiffRawViewModel>("wasm/"+sFilePath, fileContent);
         }
     };
     QFileDialog::getOpenFileContent("Fiff File (*.fif *.fiff)",  fileContentReady);
     #else
     //Get the path
-    QString filePath = QFileDialog::getOpenFileName(Q_NULLPTR,
+    QString sFilePath = QFileDialog::getOpenFileName(Q_NULLPTR,
                                                     tr("Open File"),
                                                     QDir::currentPath()+"/MNE-sample-data",
                                                     tr("Fiff file(*.fif *.fiff)"));
 
-    QFileInfo fileInfo(filePath);
-
-    if(fileInfo.exists() && (fileInfo.completeSuffix() == "fif")) {
-        m_pAnalyzeData->loadModel<FiffRawViewModel>(filePath);
-    }
+    loadFilePath(sFilePath);
     #endif
 }
 
@@ -195,12 +211,12 @@ void DataLoader::onSaveFilePressed()
     m_pSelectedModel->saveToFile("");
     #else
     //Get the path
-    QString filePath = QFileDialog::getSaveFileName(Q_NULLPTR,
+    QString sFilePath = QFileDialog::getSaveFileName(Q_NULLPTR,
                                                     tr("Save File"),
                                                     QDir::currentPath()+"/MNE-sample-data",
                                                     tr("Fiff file(*.fif *.fiff)"));
 
-    QFileInfo fileInfo(filePath);
-    m_pSelectedModel->saveToFile(filePath);
+    QFileInfo fileInfo(sFilePath);
+    m_pSelectedModel->saveToFile(sFilePath);
     #endif
 }

--- a/applications/mne_analyze/plugins/dataloader/dataloader.h
+++ b/applications/mne_analyze/plugins/dataloader/dataloader.h
@@ -112,7 +112,23 @@ public:
     virtual void handleEvent(QSharedPointer<ANSHAREDLIB::Event> e) override;
     virtual QVector<ANSHAREDLIB::EVENT_TYPE> getEventSubscriptions() const override;
 
+    //=========================================================================================================
+    /**
+     * Initializes the plugin based on cmd line inputs given by the user.
+     *
+     * @param[in] sArguments  the cmd line arguments
+     */
+    virtual void cmdLineStartup(const QStringList& sArguments) override;
+
 private:
+    //=========================================================================================================
+    /**
+     * Load file from given file path.
+     *
+     * @param[in] sFilePath  the file path to load data from.
+     */
+    void loadFilePath(const QString& sFilePath);
+
     //=========================================================================================================
     /**
      * This functions is called when the load from file button is pressed.
@@ -129,6 +145,10 @@ private:
 
     QSharedPointer<ANSHAREDLIB::AbstractModel>  m_pSelectedModel;
 };
+
+//=============================================================================================================
+// INLINE DEFINITIONS
+//=============================================================================================================
 
 } // NAMESPACE
 

--- a/applications/mne_anonymize/main.cpp
+++ b/applications/mne_anonymize/main.cpp
@@ -88,10 +88,9 @@ int main(int argc, char* argv[])
 
     qtApp->setOrganizationName("MNE-CPP Project");
     qtApp->setApplicationName("MNE Anonymize");
-    qtApp->setApplicationVersion("0.1.4");
+    qtApp->setApplicationVersion("0.1.5");
 
-    QScopedPointer<MNEANONYMIZE::SettingsControllerCl>
-            controller(h->createController(qtApp->arguments()));
+    QScopedPointer<MNEANONYMIZE::SettingsControllerCl> controller(h->createController(qtApp->arguments()));
 
     return qtApp->exec();
 }


### PR DESCRIPTION
This PR includes:

- Add new feature to specify the file to be opened with MNE Analyze via the cmd line. Usage `mne_analyze --file sample_audvis_raw.fif` or `mne_analyze -f sample_audvis_raw.fif`. Closes #601 
- Added general functionality to initialize MNE Analyze plugins based on cmd line inputs.
- Bump up version to 0.1.5 in MNE Anonymize