### PR TITLE
[FIX] Fix mesa-dev package download in linux static ci builds

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -116,6 +116,7 @@ jobs:
     - name: Install OpenGL (Linux)
       if: matrix.os == 'ubuntu-16.04'
       run: |
+        sudo apt-get update -q
         sudo apt-get install build-essential libgl1-mesa-dev
     - name: Install Qt (Linux)
       if: matrix.os == 'ubuntu-16.04'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install OpenGL
       run: |
+        sudo apt-get update -q
         sudo apt-get install build-essential libgl1-mesa-dev
     - name: Install Qt
       run: |


### PR DESCRIPTION
This PR includes:

- Add apt-update to fix mesa-dev package download in linux static ci build