### PR TITLE
[MAINT] Bump up CI Qt version to 5.15.1 

### DIFF
--- a/.github/workflows/buildqtbinaries.yml
+++ b/.github/workflows/buildqtbinaries.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         # Clone Qt5 repo
         cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
         # Create shadow build folder
@@ -34,11 +34,11 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        tar cfvz qt5_5142_static_binaries_linux.tar.gz ../Qt5_binaries/.
+        tar cfvz qt5_5151_static_binaries_linux.tar.gz ../Qt5_binaries/.
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5142_static_binaries_linux.tar.gz
-        path: qt5_5142_static_binaries_linux.tar.gz
+        name: qt5_5151_static_binaries_linux.tar.gz
+        path: qt5_5151_static_binaries_linux.tar.gz
 
   GenerateMacOSStaticBinaries:
     runs-on: macos-latest
@@ -50,7 +50,7 @@ jobs:
       run: |
         # Clone Qt5 repo
         cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
         # Create shadow build folder
@@ -64,11 +64,11 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        tar cfvz qt5_5142_static_binaries_macos.tar.gz ../Qt5_binaries/.
+        tar cfvz qt5_5151_static_binaries_macos.tar.gz ../Qt5_binaries/.
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5142_static_binaries_macos.tar.gz
-        path: qt5_5142_static_binaries_macos.tar.gz
+        name: qt5_5151_static_binaries_macos.tar.gz
+        path: qt5_5151_static_binaries_macos.tar.gz
 
   GenerateWinStaticBinaries:
     runs-on: windows-2016
@@ -90,7 +90,7 @@ jobs:
       run: |
         # Clone Qt5 repo
         cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
         cd qt5
         perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
         # Create shadow build folder
@@ -98,7 +98,7 @@ jobs:
         mkdir qt5_shadow
         cd qt5_shadow
         # Setup the compiler 
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         # Configure Qt5
         ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
@@ -107,11 +107,11 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        7z a qt5_5142_static_binaries_win.zip ..\Qt5_binaries
+        7z a qt5_5151_static_binaries_win.zip ..\Qt5_binaries
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5142_static_binaries_win.zip
-        path: qt5_5142_static_binaries_win.zip
+        name: qt5_5151_static_binaries_win.zip
+        path: qt5_5151_static_binaries_win.zip
 
   GenerateWasmBinaries:
     runs-on: ubuntu-latest
@@ -128,16 +128,16 @@ jobs:
         cd emsdk
         git pull
         # Download and install the latest SDK tools.
-        ./emsdk install 1.39.3        
+        ./emsdk install 1.39.8        
     - name: Compile wasm Qt version
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.3
+        ./emsdk/emsdk activate 1.39.8
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
         # Configure Qt5
@@ -147,8 +147,8 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        tar cfvz qt5_5142_static_binaries_wasm.tar.gz ../Qt5_binaries/.
+        tar cfvz qt5_5151_static_binaries_wasm.tar.gz ../Qt5_binaries/.
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5142_static_binaries_wasm.tar.gz
-        path: qt5_5142_static_binaries_wasm.tar.gz
+        name: qt5_5151_static_binaries_wasm.tar.gz
+        path: qt5_5151_static_binaries_wasm.tar.gz

--- a/.github/workflows/buildqtbinaries.yml
+++ b/.github/workflows/buildqtbinaries.yml
@@ -71,7 +71,7 @@ jobs:
         path: qt5_5151_static_binaries_macos.tar.gz
 
   GenerateWinStaticBinaries:
-    runs-on: windows-2016
+    runs-on: windows-2019
 
     steps:
     - name: Clone repository

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -142,7 +142,7 @@ jobs:
         cd applications\mne_scan\plugins\brainflowboard\brainflow
         mkdir build
         cd build
-        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile BrainFlow submodule (Linux|MacOS)
       if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -253,7 +253,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-16.04, macos-latest, windows-2019]
+        os: [ubuntu-16.04, macos-latest, windows-2016]
 
     steps:
     - name: Clone repository
@@ -273,17 +273,17 @@ jobs:
       if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.15.1
+        version: 5.15.0
         modules: qtcharts
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.15.1
-        arch: win64_msvc2019_64
+        version: 5.15.0
+        arch: win64_msvc2017_64
         modules: qtcharts
     - name: Install jom (Windows)
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2016'
       run: |
         Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
@@ -302,7 +302,7 @@ jobs:
       if: matrix.os == 'windows-2019'
       run: |
         # Setup VS compiler
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
         jom -j4

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 3
       matrix:
         qt: [5.10.1]
         os: [ubuntu-16.04, macos-latest, windows-2016]
@@ -100,7 +100,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 3
       matrix:
         qt: [5.15.1]
         os: [ubuntu-16.04, macos-latest, windows-2019]
@@ -159,7 +159,7 @@ jobs:
         cd applications\mne_scan\plugins\lsladapter\liblsl
         mkdir build
         cd build
-        cmake .. -G "Visual Studio 15 2017" -A x64
+        cmake .. -G "Visual Studio 16 2019" -A x64
         cmake --build . --config Release --target install
     - name: Compile LSL submodule (Linux|MacOS)
       if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -211,21 +211,21 @@ jobs:
       if: matrix.os == 'ubuntu-16.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5142_static_binaries_linux.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5142_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5151_static_binaries_linux.tar.gz?dl=1
         mkdir ../Qt5_binaries
-        tar xvzf qt5_5142_static_binaries_linux.tar.gz -C ../ -P
+        tar xvzf qt5_5151_static_binaries_linux.tar.gz -C ../ -P
     - name: Install Qt (MacOS)
       if: matrix.os == 'macos-latest'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5142_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5142_static_binaries_macos.tar.gz?dl=1
-        tar xvzf qt5_5142_static_binaries_macos.tar.gz -P
+        wget -O qt5_5151_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5151_static_binaries_macos.tar.gz?dl=1
+        tar xvzf qt5_5151_static_binaries_macos.tar.gz -P
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5142_static_binaries_win.zip?dl=1 -OutFile .\qt5_5142_static_binaries_win.zip
-        expand-archive -path "qt5_5142_static_binaries_win.zip" -destinationpath "..\"
+        Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5151_static_binaries_win.zip?dl=1 -OutFile .\qt5_5151_static_binaries_win.zip
+        expand-archive -path "qt5_5151_static_binaries_win.zip" -destinationpath "..\"
     - name: Install jom (Windows)
       if: matrix.os == 'windows-2019'
       run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -142,7 +142,7 @@ jobs:
         cd applications\mne_scan\plugins\brainflowboard\brainflow
         mkdir build
         cd build
-        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile BrainFlow submodule (Linux|MacOS)
       if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        qt: [5.14.2, 5.10.1]
-        os: [ubuntu-16.04, macos-latest, windows-2016]
+        qt: [5.15.1, 5.10.1]
+        os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -35,25 +35,25 @@ jobs:
         version: ${{ matrix.qt }}
         modules: qtcharts
     - name: Install Qt (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       uses: jurplel/install-qt-action@v2
       with:
         version: ${{ matrix.qt }}
-        arch: win64_msvc2017_64
+        arch: win64_msvc2019_64
         modules: qtcharts
     - name: Install jom (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
         echo "::add-path::$HOME\jom"
     - name: Compile BrainFlow submodule (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         cd applications\mne_scan\plugins\brainflowboard\brainflow
         mkdir build
         cd build
-        cmake -G "Visual Studio 15 2017" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile BrainFlow submodule (Linux|MacOS)
       if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
@@ -65,7 +65,7 @@ jobs:
         make
         make install
     - name: Compile LSL submodule (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         cd applications\mne_scan\plugins\lsladapter\liblsl
         mkdir build
@@ -87,10 +87,10 @@ jobs:
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
         make -j4
     - name: Configure and compile MNE-CPP (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         # Setup VS compiler
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
         jom -j4
@@ -102,8 +102,8 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        qt: [5.14.2]
-        os: [ubuntu-16.04, macos-latest, windows-2016]
+        qt: [5.15.1]
+        os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -132,13 +132,13 @@ jobs:
         wget -O qt5_5142_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5142_static_binaries_macos.tar.gz?dl=1
         tar xvzf qt5_5142_static_binaries_macos.tar.gz -P
     - name: Install Qt (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
         Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5142_static_binaries_win.zip?dl=1 -OutFile .\qt5_5142_static_binaries_win.zip
         expand-archive -path "qt5_5142_static_binaries_win.zip" -destinationpath "..\"
     - name: Install jom (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
@@ -149,10 +149,10 @@ jobs:
         ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=static
         make -j4
     - name: Configure and compile MNE-CPP (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         # Setup VS compiler
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=static
         jom -j4
@@ -164,7 +164,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-16.04, macos-latest, windows-2016]
+        os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -184,17 +184,17 @@ jobs:
       if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.1
         modules: qtcharts
     - name: Install Qt (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
-        arch: win64_msvc2017_64
+        version: 5.15.1
+        arch: win64_msvc2019_64
         modules: qtcharts
     - name: Install jom (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
@@ -210,10 +210,10 @@ jobs:
         qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
         make -j4
     - name: Configure and compile MNE-CPP (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       run: |
         # Setup VS compiler
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
         jom -j4
@@ -246,7 +246,7 @@ jobs:
           $test
         done
     - name: Run tests (Windows)
-      if: matrix.os == 'windows-2016'
+      if: matrix.os == 'windows-2019'
       env:
         QTEST_FUNCTION_TIMEOUT: 900000
       run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,14 +6,103 @@ on:
     - master
 
 jobs:
-  QtDynamic:
+  MinQtDynamic:
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       max-parallel: 6
       matrix:
-        qt: [5.15.1, 5.10.1]
+        qt: [5.10.1]
+        os: [ubuntu-16.04, macos-latest, windows-2016]
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install BrainFlow and LSL submodules
+      run: |
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+    - name: Install Qt (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: ${{ matrix.qt }}
+        modules: qtcharts
+    - name: Install Qt (Windows)
+      if: matrix.os == 'windows-2016'
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: ${{ matrix.qt }}
+        arch: win64_msvc2017_64
+        modules: qtcharts
+    - name: Install jom (Windows)
+      if: matrix.os == 'windows-2016'
+      run: |
+        Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
+        expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
+        echo "::add-path::$HOME\jom"
+    - name: Compile BrainFlow submodule (Windows)
+      if: matrix.os == 'windows-2016'
+      run: |
+        cd applications\mne_scan\plugins\brainflowboard\brainflow
+        mkdir build
+        cd build
+        cmake -G "Visual Studio 15 2017" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake --build . --target install --config Release
+    - name: Compile BrainFlow submodule (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
+      run: |
+        cd applications/mne_scan/plugins/brainflowboard/brainflow
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=../installed ..
+        make
+        make install
+    - name: Compile LSL submodule (Windows)
+      if: matrix.os == 'windows-2016'
+      run: |
+        cd applications\mne_scan\plugins\lsladapter\liblsl
+        mkdir build
+        cd build
+        cmake .. -G "Visual Studio 15 2017" -A x64
+        cmake --build . --config Release --target install
+    - name: Compile LSL submodule (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
+      run: |
+        cd applications/mne_scan/plugins/lsladapter/liblsl
+        mkdir build
+        cd build
+        cmake ..
+        make
+        make install
+    - name: Configure and compile MNE-CPP (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
+      run: |
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        make -j4
+    - name: Configure and compile MNE-CPP (Windows)
+      if: matrix.os == 'windows-2016'
+      run: |
+        # Setup VS compiler
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        jom -j4
+
+  MaxQtDynamic:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        qt: [5.15.1]
         os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,15 +71,15 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        wget -O qt5_5142_static_binaries_linux.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5142_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5151_static_binaries_linux.tar.gz?dl=1
         mkdir ../Qt5_binaries
-        tar xvzf qt5_5142_static_binaries_linux.tar.gz -C ../ -P
+        tar xvzf qt5_5151_static_binaries_linux.tar.gz -C ../ -P
     # Uncomment this if you want to build Qt statically in this workflow
     # - name: Compile static Qt version
     #   run: |
     #     # Clone Qt5 repo
     #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
     #     cd qt5
     #     ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
     #     # Create shadow build folder
@@ -133,14 +133,14 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        wget -O qt5_5142_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5142_static_binaries_macos.tar.gz?dl=1
-        tar xzf qt5_5142_static_binaries_macos.tar.gz -P
+        wget -O qt5_5151_static_binaries_macos.tar.gz https://www.dropbox.com/s/bnlec4qpl7c22rp/qt5_5151_static_binaries_macos.tar.gz?dl=1
+        tar xzf qt5_5151_static_binaries_macos.tar.gz -P
     # Uncomment this if you want to build Qt statically in this workflow
     # - name: Compile static Qt version
     #   run: |
     #     # Clone Qt5 repo
     #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
     #     cd qt5
     #     ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
     #     # Create shadow build folder
@@ -185,7 +185,7 @@ jobs:
         overwrite: true
         
   WinStatic:
-    runs-on: windows-2016
+    runs-on: windows-2019
     needs: CreateRelease
 
     steps:
@@ -204,14 +204,14 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5142_static_binaries_win.zip?dl=1 -OutFile .\qt5_5142_static_binaries_win.zip
-        expand-archive -path "qt5_5142_static_binaries_win.zip" -destinationpath "..\"
+        Invoke-WebRequest https://www.dropbox.com/s/r1z7jjit23si9rp/qt5_5151_static_binaries_win.zip?dl=1 -OutFile .\qt5_5151_static_binaries_win.zip
+        expand-archive -path "qt5_5151_static_binaries_win.zip" -destinationpath "..\"
     # Uncomment this if you want to build Qt statically in this workflow
     # - name: Compile static Qt version
     #   run: |
     #     # Clone Qt5 repo
     #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
     #     cd qt5
     #     perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
     #     # Create shadow build folder
@@ -219,7 +219,7 @@ jobs:
     #     mkdir qt5_shadow
     #     cd qt5_shadow
     #     # Setup the compiler 
-    #     cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+    #     cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
     #     Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
     #     # Configure Qt5
     #     ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
@@ -227,7 +227,7 @@ jobs:
     #     nmake install
     - name: Configure and compile MNE-CPP
       run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
         jom -j4
@@ -277,7 +277,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.1
         modules: qtcharts
     - name: Compile BrainFlow submodule
       run: |
@@ -319,7 +319,7 @@ jobs:
         cp -r ./bin ./lib mne-cpp/
         # linuxdeployqt uses mne_scan binary to resolve dependencies in current directory. 
         cd mne-cpp
-        ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2
+        ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2 -extra-plugins=renderers
         # Creating archive of everything in current directory
         tar cfvz ../mne-cpp-linux-dynamic-x86_64.tar.gz ./*
     - name: Deploy binaries with stable release on Github
@@ -360,7 +360,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.1
         modules: qtcharts
     - name: Compile BrainFlow submodule 
       run: |
@@ -414,7 +414,7 @@ jobs:
         overwrite: true
 
   WinDynamic:
-    runs-on: windows-2016
+    runs-on: windows-2019
     needs: CreateRelease
 
     steps:
@@ -432,7 +432,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.1
         arch: win64_msvc2017_64
         modules: qtcharts
     - name: Install jom
@@ -445,7 +445,7 @@ jobs:
         cd applications\mne_scan\plugins\brainflowboard\brainflow
         mkdir build
         cd build
-        cmake -G "Visual Studio 15 2017" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile LSL submodule
       run: |
@@ -456,7 +456,7 @@ jobs:
         cmake --build . --config Release --target install
     - name: Configure and compile MNE-CPP
       run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
         jom -j4
@@ -508,7 +508,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.14.2
+        version: 5.15.1
         modules: qtcharts
     - name: Configure and compile MNE-CPP
       run: |
@@ -645,7 +645,7 @@ jobs:
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
         # Configure Qt5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,7 +445,7 @@ jobs:
         cd applications\mne_scan\plugins\brainflowboard\brainflow
         mkdir build
         cd build
-        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile LSL submodule
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,7 +452,7 @@ jobs:
         cd applications\mne_scan\plugins\lsladapter\liblsl
         mkdir build
         cd build
-        cmake .. -G "Visual Studio 15 2017" -A x64
+        cmake .. -G "Visual Studio 16 2019" -A x64
         cmake --build . --config Release --target install
     - name: Configure and compile MNE-CPP
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,7 +445,7 @@ jobs:
         cd applications\mne_scan\plugins\brainflowboard\brainflow
         mkdir build
         cd build
-        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile LSL submodule
       run: |

--- a/.github/workflows/wasmtest.yml
+++ b/.github/workflows/wasmtest.yml
@@ -22,23 +22,23 @@ jobs:
         cd emsdk
         git pull
         # Download and install the latest SDK tools.
-        ./emsdk install 1.39.3     
+        ./emsdk install 1.39.8     
     # - name: Install Qt
     #   run: |
     #     # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-    #     wget -O qt5_5142_static_binaries_wasm.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5142_static_binaries_wasm.tar.tar.gz?dl=1
+    #     wget -O qt5_5151_static_binaries_wasm.tar.gz https://www.dropbox.com/s/k245dalpw02ok1q/qt5_5151_static_binaries_wasm.tar.tar.gz?dl=1
     #     mkdir ../Qt5_binaries
-    #     tar xvzf qt5_5142_static_binaries_wasm.tar.gz -C ../ -P  
+    #     tar xvzf qt5_5151_static_binaries_wasm.tar.gz -C ../ -P  
     # Uncomment this if you want to build Qt statically in this workflow         
     - name: Compile wasm Qt version
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.3
+        ./emsdk/emsdk activate 1.39.8
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.14.2
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
         # Configure Qt5
@@ -49,7 +49,7 @@ jobs:
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.3
+        ./emsdk/emsdk activate 1.39.8
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Compile MNE-CPP        

--- a/applications/mne_analyze/mne_analyze/mne_analyze.pro
+++ b/applications/mne_analyze/mne_analyze/mne_analyze.pro
@@ -197,6 +197,14 @@ macx {
     loutrc.files = $${ROOT_DIR}/resources/general/2DLayouts
     QMAKE_BUNDLE_DATA += loutrc
 
+    # If Qt3D plugins/renderers folder exisits, create and copy renderers folder to mne-cpp/bin manually.
+    # macdeployqt does not deploy them. This will be fixed in Qt 5.15.2.
+    exists($$shell_path($$[QT_INSTALL_PLUGINS]/renderers)) {
+        qt3drenderers.path = Contents/PlugIns/
+        qt3drenderers.files = $$[QT_INSTALL_PLUGINS]/renderers
+        QMAKE_BUNDLE_DATA += qt3drenderers
+    }
+
     !contains(MNECPP_CONFIG, static) {
         # 3 entries returned in DEPLOY_CMD
         EXTRA_ARGS =

--- a/applications/mne_analyze/mne_analyze/mne_analyze.pro
+++ b/applications/mne_analyze/mne_analyze/mne_analyze.pro
@@ -42,9 +42,8 @@ TEMPLATE = app
 QT += gui widgets network opengl svg concurrent
 qtHaveModule(printsupport): QT += printsupport
 
-contains(MNECPP_CONFIG, noOpenGL) {
-    DEFINES += NO_OPENGL
-    QT -= opengl
+contains(MNECPP_CONFIG, noQOpenGLWidget) {
+    DEFINES += NO_QOPENGLWIDGET
 }
 
 TARGET = mne_analyze

--- a/applications/mne_analyze/plugins/averaging/averaging.pro
+++ b/applications/mne_analyze/plugins/averaging/averaging.pro
@@ -54,9 +54,8 @@ CONFIG(debug, debug|release) {
     TARGET = $$join(TARGET,,,d)
 }
 
-contains(MNECPP_CONFIG, noOpenGL) {
-    DEFINES += NO_OPENGL
-    QT -= opengl
+contains(MNECPP_CONFIG, noQOpenGLWidget) {
+    DEFINES += NO_QOPENGLWIDGET
 }
 
 DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_plugins

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
@@ -64,7 +64,7 @@
 #include <QKeyEvent>
 #include <QLabel>
 
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     #include <QOpenGLWidget>
 #endif
 
@@ -161,7 +161,7 @@ void FiffRawView::setModel(const QSharedPointer<FiffRawViewModel>& pModel)
 
     m_pTableView->setModel(m_pModel.data());
 
-    #if !defined(NO_OPENGL)
+    #if !defined(NO_QOPENGLWIDGET)
     m_pTableView->setViewport(new QOpenGLWidget);
     #endif
 

--- a/applications/mne_analyze/plugins/rawdataviewer/rawdataviewer.pro
+++ b/applications/mne_analyze/plugins/rawdataviewer/rawdataviewer.pro
@@ -46,9 +46,8 @@ DEFINES += RAWDATAVIEWER_PLUGIN
 
 QT += gui widgets charts svg opengl
 
-contains(MNECPP_CONFIG, noOpenGL) {
-    DEFINES += NO_OPENGL
-    QT -= opengl
+contains(MNECPP_CONFIG, noQOpenGLWidget) {
+    DEFINES += NO_QOPENGLWIDGET
 }
 
 TARGET = rawdataviewer

--- a/applications/mne_anonymize/mne_anonymize.pro
+++ b/applications/mne_anonymize/mne_anonymize.pro
@@ -50,11 +50,6 @@ CONFIG(debug,debug|release) {
     }
 }
 
-contains(MNECPP_CONFIG, noOpenGL) {
-    DEFINES += NO_OPENGL
-    QT -= opengl
-}
-
 contains(MNECPP_CONFIG, static) {
     CONFIG += static
     DEFINES += STATICBUILD

--- a/applications/mne_scan/libs/scDisp/scDisp.pro
+++ b/applications/mne_scan/libs/scDisp/scDisp.pro
@@ -43,9 +43,8 @@ QT += widgets concurrent xml svg 3dextras opengl
 
 DEFINES += SCDISP_LIBRARY
 
-contains(MNECPP_CONFIG, noOpenGL) {
-    DEFINES += NO_OPENGL
-    QT -= opengl
+contains(MNECPP_CONFIG, noQOpenGLWidget) {
+    DEFINES += NO_QOPENGLWIDGET
 }
 
 TARGET = scDisp

--- a/applications/mne_scan/mne_scan/mne_scan.pro
+++ b/applications/mne_scan/mne_scan/mne_scan.pro
@@ -50,9 +50,8 @@ CONFIG(debug, debug|release) {
 
 DESTDIR = $${MNE_BINARY_DIR}
 
-contains(MNECPP_CONFIG, noOpenGL) {
-    DEFINES += NO_OPENGL
-    QT -= opengl
+contains(MNECPP_CONFIG, noQOpenGLWidget) {
+    DEFINES += NO_QOPENGLWIDGET
 }
 
 contains(MNECPP_CONFIG, static) {

--- a/applications/mne_scan/mne_scan/mne_scan.pro
+++ b/applications/mne_scan/mne_scan/mne_scan.pro
@@ -39,11 +39,7 @@ include(../../../mne-cpp.pri)
 
 TEMPLATE = app
 
-QT += network core widgets xml svg charts concurrent opengl
-
-qtHaveModule(3dextras) {
-    QT += 3dextras
-}
+QT += network core widgets xml svg charts concurrent opengl 3dextras
 
 CONFIG += console
 
@@ -221,6 +217,14 @@ macx {
     plugins.path = Contents/MacOS/
     plugins.files = $${ROOT_DIR}/bin/mne_scan_plugins
     QMAKE_BUNDLE_DATA += plugins
+
+    # If Qt3D plugins/renderers folder exisits, create and copy renderers folder to mne-cpp/bin manually.
+    # macdeployqt does not deploy them. This will be fixed in Qt 5.15.2.
+    exists($$shell_path($$[QT_INSTALL_PLUGINS]/renderers)) {
+        qt3drenderers.path = Contents/PlugIns/
+        qt3drenderers.files = $$[QT_INSTALL_PLUGINS]/renderers
+        QMAKE_BUNDLE_DATA += qt3drenderers
+    }
 
     !contains(MNECPP_CONFIG, static) {
         # 3 entries returned in DEPLOY_CMD

--- a/doc/gh-pages/pages/install/buildguide_dynamic.md
+++ b/doc/gh-pages/pages/install/buildguide_dynamic.md
@@ -12,7 +12,7 @@ Make sure you have one of the following compilers installed:
 
 | Windows | Linux | MacOS |
 |---------|-------|-------|
-| min. MSVC 2015 (We recommend the [MSVC 2017 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"} compiler. During install exclude everything except for VC++, Win 10 SDK and ATL support) | min. [GCC 5.3.1](https://gcc.gnu.org/releases.html){:target="_blank" rel="noopener"} | min. [Clang 3.5](https://developer.apple.com/xcode/){:target="_blank" rel="noopener"}|
+| min. MSVC 2015 (We recommend the [MSVC 2019 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"} compiler. During install exclude everything except for VC++, Win 10 SDK and ATL support) | min. [GCC 5.3.1](https://gcc.gnu.org/releases.html){:target="_blank" rel="noopener"} | min. [Clang 3.5](https://developer.apple.com/xcode/){:target="_blank" rel="noopener"}|
 
 ## Get Qt
 
@@ -24,10 +24,10 @@ Qt is the only dependency you will need to install. Go to the Qt download sectio
 
 Please note that Qt 5.10.0 or higher is needed in order to have full Qt3D support. Install the Qt version with the minimum of the following features (uncheck all other boxes) to a path without white spaces:
 
-- Qt/5.14.2/MSVC 2017 64-bit (Make sure to select the correct version based on your compiler)
-- Qt/5.14.2/QtCharts
+- Qt/5.15.1/MSVC 2019 64-bit (Make sure to select the correct version based on your compiler)
+- Qt/5.15.1/QtCharts
 
-After the installation is finished make sure to add the Qt bin folder (e.g. `<QtFolder>\5.14.2\msvc2017_64\bin`) to your `PATH` variable. On Linux and MacOS you might also need to add the Qt lib folder (e.g. `<QtFolder>\5.14.2\msvc2017_64\lib`) to the `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH`, respectivley.
+After the installation is finished make sure to add the Qt bin folder (e.g. `<QtFolder>\5.15.1\msvc2019_64\bin`) to your `PATH` variable. On Linux and MacOS you might also need to add the Qt lib folder (e.g. `<QtFolder>\5.15.1\msvc2019_64\lib`) to the `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH`, respectivley.
 
 ## Get the Source Code
 
@@ -59,7 +59,7 @@ git rebase upstream/master
 | **Please note:** If you are working on an operating system on a "non-western" system, i.e. Japan, you might encounter problems with unicode interpretation. Please do the  following: Go to Control Panel > Language and Region > Management tab > Language Settings for non-Unicode Programs > Set to English (U.S.) > Reboot your system. |
 
 1. Go to your cloned repository folder and run the `mne-cpp.pro` file with QtCreator.
-2. The first time you open the mne-cpp.pro file you will be prompted to configure the project with a pre-defined kit. Select the appropriate kit, e.g., `Desktop Qt 5.14.2 MSVC2017 64bit` and configure the project.
+2. The first time you open the mne-cpp.pro file you will be prompted to configure the project with a pre-defined kit. Select the appropriate kit, e.g., `Desktop Qt 5.15.1 MSVC2019 64bit` and configure the project.
 3. In QtCreator select the Release mode in the lower left corner.
 4. In the Qt Creator's Projects window, right mouse click on the top level MNE-CPP tree item and select Run qmake. Wait until progress bar in lower right corner turns green (this step may take some time).
 5. Right mouse click again and then hit Build (this step may take some time). Wait until progress bar in lower right corner turns green.
@@ -72,8 +72,8 @@ Create a shadow build folder, run `qmake` on `mne-cpp.pro` and build:
 ```
 mkdir mne-cpp_shadow
 cd mne-cpp_shadow
-<QtFolder>/5.14.2/msvc2017_64/bin/qmake ../mne-cpp/mne-cpp.pro
-<QtFolder>/5.14.2/msvc2017_64/bin/jom -j8 # On Windows
+<QtFolder>/5.15.1/msvc2019_64/bin/qmake ../mne-cpp/mne-cpp.pro
+<QtFolder>/5.15.1/msvc2019_64/bin/jom -j8 # On Windows
 make -j8 # On Linux and MacOS
 ```
 

--- a/doc/gh-pages/pages/install/buildguide_static.md
+++ b/doc/gh-pages/pages/install/buildguide_static.md
@@ -83,7 +83,7 @@ Setup the following dependencies:
 
 * Install [Perl](https://www.activestate.com/products/perl/downloads/){:target="_blank" rel="noopener"} and add it to `PATH`
 * Install [Python](https://www.python.org/downloads/){:target="_blank" rel="noopener"} and add it to `PATH`
-* Install MSVC 2015 or higher (We recommend the [MSVC 2017 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"})
+* Install MSVC 2015 or higher (We recommend the [MSVC 2019 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"})
 * Install the [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk/){:target="_blank" rel="noopener"} (can also be installed via the MSVC community edition installer)
 * If you want to use multiple cores (MSVC's `nmake` does not support multicore usage), install the [jom compiler](http://download.qt.io/official_releases/jom/jom.zip){:target="_blank" rel="noopener"} and add it to `PATH`
 

--- a/doc/gh-pages/pages/install/buildguide_static.md
+++ b/doc/gh-pages/pages/install/buildguide_static.md
@@ -27,16 +27,16 @@ Make sure you have one of the following compilers installed:
 
 | Windows | Linux | MacOS |
 |---------|-------|-------|
-| min. MSVC 2015 (We recommend the [MSVC 2017 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"} compiler. During install exclude everything except for VC++, Win 10 SDK and ATL support) | min. [GCC 5.3.1](https://gcc.gnu.org/releases.html){:target="_blank" rel="noopener"} | min. [Clang 3.5](https://developer.apple.com/xcode/){:target="_blank" rel="noopener"}|
+| min. MSVC 2015 (We recommend the [MSVC 2019 Community Version](https://visualstudio.microsoft.com/vs/older-downloads/){:target="_blank" rel="noopener"} compiler. During install exclude everything except for VC++, Win 10 SDK and ATL support) | min. [GCC 5.3.1](https://gcc.gnu.org/releases.html){:target="_blank" rel="noopener"} | min. [Clang 3.5](https://developer.apple.com/xcode/){:target="_blank" rel="noopener"}|
 
 ## Build a Static Version of Qt
 
 ### Get the Qt Aource Code
 
-Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase subdivides in other modules reflecting most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.14.2 type:
+Clone the current Qt version. Currently, MNE-CPP uses four Qt modules: QtBase, QtCharts, QtSvg and Qt3D. QtBase subdivides in other modules reflecting most of the Qt functionality (core, gui, widgets, etc). In order to setup the sources for Qt 5.15.1 type:
 
 ```
-git clone https://code.qt.io/qt/qt5.git -b 5.14.2  
+git clone https://code.qt.io/qt/qt5.git -b 5.15.1  
 cd qt5
 ```
 
@@ -101,10 +101,10 @@ mkdir qt5_shadow
 cd qt5_shadow
 ```
 
-Setup the visual studio compiler by starting the `VS2017 x64 Native Tools Command Prompt` or by typing (assuming you are using MSVC 2017):
+Setup the visual studio compiler by starting the `VS2019 x64 Native Tools Command Prompt` or by typing (assuming you are using MSVC 2017):
     
 ```
-cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio 15.0\VC\bin\amd64\vcvars64.bat`" && set > %temp%\vcvars.txt"
+cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
 Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
 ```
 

--- a/libraries/disp/disp.pro
+++ b/libraries/disp/disp.pro
@@ -56,9 +56,8 @@ contains(MNECPP_CONFIG, wasm) {
     DEFINES += WASMBUILD
 }
 
-contains(MNECPP_CONFIG, noOpenGL) {
-    DEFINES += NO_OPENGL
-    QT -= opengl
+contains(MNECPP_CONFIG, noQOpenGLWidget) {
+    DEFINES += NO_QOPENGLWIDGET
 }
 
 DESTDIR = $${MNE_LIBRARY_DIR}

--- a/libraries/disp/viewers/averagelayoutview.cpp
+++ b/libraries/disp/viewers/averagelayoutview.cpp
@@ -58,7 +58,7 @@
 #include <QDebug>
 #include <QGraphicsItem>
 #include <QSettings>
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     #include <QOpenGLWidget>
 #endif
 
@@ -85,7 +85,7 @@ AverageLayoutView::AverageLayoutView(const QString& sSettingsPath,
 
     m_pAverageLayoutView = new QGraphicsView();
 
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     m_pAverageLayoutView->setViewport(new QOpenGLWidget);
 #endif
 
@@ -116,7 +116,7 @@ AverageLayoutView::~AverageLayoutView()
 
 void AverageLayoutView::updateOpenGLViewport()
 {
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     if(m_pAverageLayoutView) {
         m_pAverageLayoutView->setViewport(new QOpenGLWidget);
     }

--- a/libraries/disp/viewers/butterflyview.cpp
+++ b/libraries/disp/viewers/butterflyview.cpp
@@ -70,7 +70,7 @@ ButterflyView::ButterflyView(const QString& sSettingsPath,
                              QWidget *parent,
                              Qt::WindowFlags f)
 :
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
   QOpenGLWidget(parent, f)
 #else
   QWidget(parent, f)
@@ -106,7 +106,7 @@ ButterflyView::~ButterflyView()
 
 void ButterflyView::updateOpenGLViewport()
 {
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     // Activate anti aliasing
     initializeGL();
 #endif
@@ -320,7 +320,7 @@ void ButterflyView::loadSettings()
 
 //=============================================================================================================
 
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     void ButterflyView::paintGL()
 #else
     void ButterflyView::paintEvent(QPaintEvent *event)
@@ -492,7 +492,7 @@ void ButterflyView::loadSettings()
         }
     }
 
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     return QOpenGLWidget::paintGL();
 #else
     return QWidget::paintEvent(event);

--- a/libraries/disp/viewers/butterflyview.h
+++ b/libraries/disp/viewers/butterflyview.h
@@ -48,7 +48,7 @@
 
 #include <QMap>
 #include <QWidget>
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
 #include <QOpenGLWidget>
 #endif
 
@@ -79,7 +79,7 @@ class ChannelInfoModel;
  *
  * @brief The ButterflyView class provides a butterfly view.
  */
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
 class DISPSHARED_EXPORT ButterflyView : public QOpenGLWidget
 #else
 class DISPSHARED_EXPORT ButterflyView : public QWidget
@@ -278,7 +278,7 @@ protected:
      *
      * @param [in] event pointer to PaintEvent -> not used.
      */
-    #if !defined(NO_OPENGL)
+    #if !defined(NO_QOPENGLWIDGET)
     virtual void paintGL();
     #else
     virtual void paintEvent(QPaintEvent *event);

--- a/libraries/disp/viewers/rtfiffrawview.cpp
+++ b/libraries/disp/viewers/rtfiffrawview.cpp
@@ -58,7 +58,7 @@
 #include <QScrollBar>
 #include <QMouseEvent>
 
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     #include <QOpenGLWidget>
 #endif
 
@@ -88,7 +88,7 @@ RtFiffRawView::RtFiffRawView(const QString& sSettingsPath,
     m_sSettingsPath = sSettingsPath;
     m_pTableView = new QTableView;
 
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     m_pTableView->setViewport(new QOpenGLWidget);
 #endif
 
@@ -116,7 +116,7 @@ RtFiffRawView::~RtFiffRawView()
 
 void RtFiffRawView::updateOpenGLViewport()
 {
-#if !defined(NO_OPENGL)
+#if !defined(NO_QOPENGLWIDGET)
     if(m_pTableView) {
         m_pTableView->setViewport(new QOpenGLWidget);
     }

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -114,7 +114,7 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2020 Authors of MNE-CPP. All rights reser
 ## To disable applications run: qmake MNECPP_CONFIG+=noApplications
 ## To build MNE-CPP libraries and executables statically run: qmake MNECPP_CONFIG+=static
 ## To build MNE-CPP with FFTW support in Eigen (make sure to specify FFTW_DIRs below): qmake MNECPP_CONFIG+=useFFTW
-## To build MNE-CPP Disp library without OpenGL support (default is with OpenGL support): qmake MNECPP_CONFIG+=noOpenGL
+## To build MNE-CPP without QOpenGLWidget support: qmake MNECPP_CONFIG+=noQOpenGLWidget
 ## To build MNE-CPP against WebAssembly (Wasm): qmake MNECPP_CONFIG+=wasm
 ## To build MNE Scan with BrainFlow support: qmake MNECPP_CONFIG+=withBrainFlow
 ## To build MNE Scan with LSL support: qmake MNECPP_CONFIG+=withLsl
@@ -126,27 +126,8 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2020 Authors of MNE-CPP. All rights reser
 # Default flags
 MNECPP_CONFIG +=
 
-# Check versions
-!minQtVersion(5, 10, 0) {
-    error("You are trying to build with Qt version $${QT_VERSION}. However, the minimal Qt version to build MNE-CPP is 5.10.0.")
-}
-
-# Build static version if wasm flag was defined
-contains(MNECPP_CONFIG, wasm) {
-    message("The wasm flag was detected. Building static version of MNE-CPP. Disable OpenGL support for Disp library.")
-    MNECPP_CONFIG += static noOpenGL
-}
-
-contains(MNECPP_CONFIG, static) {
-    message("The static flag was detected. Building static version of MNE-CPP.")
-}
-
-# Some MacOS specific setups
+# Suppress untested SDK version checks on MacOS
 macx {
-    # Do not support OpenGL support on macx because signal backgrounds are not plotted correctly (tested on Qt 5.15.0 and Qt 5.15.1)
-    MNECPP_CONFIG += noOpenGL
-
-    # Suppress untested SDK version checks
     CONFIG += sdk_no_version_check
 }
 

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -141,6 +141,15 @@ contains(MNECPP_CONFIG, static) {
     message("The static flag was detected. Building static version of MNE-CPP.")
 }
 
+# Some MacOS specific setups
+macx {
+    # Do not support OpenGL support on macx because signal backgrounds are not plotted correctly (tested on Qt 5.15.0 and Qt 5.15.1)
+    MNECPP_CONFIG += noOpenGL
+
+    # Suppress untested SDK version checks
+    CONFIG += sdk_no_version_check
+}
+
 ########################################### DIRECTORY DEFINITIONS #############################################
 
 # Eigen dir

--- a/mne-cpp.pro
+++ b/mne-cpp.pro
@@ -64,3 +64,4 @@ libraries.depends =
 applications.depends = libraries
 examples.depends = libraries
 testframes.depends = libraries
+

--- a/mne-cpp.pro
+++ b/mne-cpp.pro
@@ -35,6 +35,27 @@
 
 include(mne-cpp.pri)
 
+# Check versions
+!minQtVersion(5, 10, 0) {
+    error("You are trying to build with Qt version $${QT_VERSION}. However, the minimal Qt version to build MNE-CPP is 5.10.0.")
+}
+
+# Build static version if wasm flag was defined
+contains(MNECPP_CONFIG, wasm) {
+    message("The wasm flag was detected. Building static version of MNE-CPP. Disable QOpenGLWidget support.")
+    MNECPP_CONFIG += static noQOpenGLWidget
+}
+
+contains(MNECPP_CONFIG, static) {
+    message("The static flag was detected. Building static version of MNE-CPP.")
+}
+
+# Do not support QOpenGLWidget support on macx because signal backgrounds are not plotted correctly (tested on Qt 5.15.0 and Qt 5.15.1)
+macx:minQtVersion(5, 15, 0) {
+    message("Excluding QOpenGLWidget on MacOS for Qt version greater than 5.15.0")
+    MNECPP_CONFIG += noQOpenGLWidget
+}
+
 TEMPLATE = subdirs
 
 SUBDIRS += \


### PR DESCRIPTION
This PR includes:

- Bump CI to Qt 5.15.1
- Rename `noOpenGL` to `noQOpenGLWidget` flag
- For Qt version >= 5.15.0 set noQOpenGLWidget automatically. There are some problems with that version and the QOpenGLWidget.