### PR TITLE
[ENH] MNE-Lib: Implement triangle picking 

### DIFF
--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -66,6 +66,12 @@
 #include <Qt3DExtras/QSphereMesh>
 #include <Qt3DRender/QRenderSettings>
 
+#include <QObjectPicker>
+#include <QPickingSettings>
+#include <QRenderSettings>
+#include <QPickEvent>
+#include <QPickTriangleEvent>
+
 //=============================================================================================================
 // USED NAMESPACES
 //=============================================================================================================
@@ -104,6 +110,7 @@ View3D::View3D()
     m_pCamera->setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
     m_pCamera->setUpVector(QVector3D(0.0f, 1.0f, 0.0f));
     m_pCamera->tiltAboutViewCenter(180);
+    m_pCamera->lens()->setPerspectiveProjection(45.0f, this->width()/this->height(), 0.01f, 5000.0f);
     m_pFrameGraph->setCamera(m_pCamera);
 
     OrbitalCameraController *pCamController = new OrbitalCameraController(m_pRootEntity);
@@ -111,6 +118,37 @@ View3D::View3D()
 
     createCoordSystem(m_pRootEntity);
     toggleCoordAxis(false);
+
+    //picking
+    Qt3DRender::QObjectPicker *picker = new Qt3DRender::QObjectPicker(m_pRootEntity);
+    m_pRootEntity->addComponent(picker);
+    connect(picker, &Qt3DRender::QObjectPicker::pressed,
+            this, &View3D::handlePickerPress);
+
+    Qt3DRender::QRenderSettings* renderSettings = new Qt3DRender::QRenderSettings(m_pRootEntity);
+    renderSettings->pickingSettings()->setPickMethod(Qt3DRender::QPickingSettings::PrimitivePicking);
+    renderSettings->pickingSettings()->setPickResultMode(Qt3DRender::QPickingSettings::NearestPick);
+    renderSettings->pickingSettings()->setWorldSpaceTolerance(0.00000001f);
+
+    m_pRootEntity->addComponent(renderSettings);
+}
+
+//=============================================================================================================
+
+int k = 0;
+void View3D::handlePickerPress(Qt3DRender::QPickEvent *event)
+{
+    qInfo() << "View3D::handlePickerPress" << k++ ;
+
+    // // "event" will give me clicked coordinates like this:
+    qDebug() << __func__ << ": global Coord: " << event->worldIntersection();
+
+    //    // // Also I can get picked/clicked triangle index and its vertices by casting event pointer type:
+    //    Qt3DRender::QPickTriangleEvent *eventTri = static_cast<Qt3DRender::QPickTriangleEvent *>(event);
+    //    qDebug() << __func__ << "Pick Triangle Index: " << eventTri->triangleIndex();
+    //    qDebug() << __func__ << "Pick Triangle Vertex 1: " << eventTri->vertex1Index();
+    //    qDebug() << __func__ << "Pick Triangle Vertex 2: " << eventTri->vertex2Index();
+    //    qDebug() << __func__ << "Pick Triangle Vertex 3: " << eventTri->vertex3Index();
 }
 
 //=============================================================================================================

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -91,6 +91,7 @@ View3D::View3D()
 , m_p3DObjectsEntity(new Qt3DCore::QEntity(m_pRootEntity))
 , m_pLightEntity(new Qt3DCore::QEntity(m_pRootEntity))
 , m_pCamera(this->camera())
+, m_pPicker(new Qt3DRender::QObjectPicker(m_pRootEntity))
 {
     //Root entity
     this->setRootEntity(m_pRootEntity);
@@ -127,12 +128,11 @@ View3D::View3D()
 
 void View3D::initObjectPicking()
 {
-    // create Object picker and add to root entity
-    Qt3DRender::QObjectPicker *picker = new Qt3DRender::QObjectPicker(m_pRootEntity);
-    m_pRootEntity->addComponent(picker);
+    // add object picker to root entity
+    m_pRootEntity->addComponent(m_pPicker);
 
     // emit signal whenever pick event occured
-    connect(picker, &Qt3DRender::QObjectPicker::pressed,
+    connect(m_pPicker, &Qt3DRender::QObjectPicker::pressed,
             this, &View3D::handlePickerPress);
 
     // define renderSettings
@@ -146,17 +146,17 @@ void View3D::initObjectPicking()
 
 void View3D::activatePicker(const bool bActivatePicker)
 {
-    this->renderSettings()->setEnabled(bActivatePicker)
+    m_pPicker->setEnabled(bActivatePicker);
 }
 
 //=============================================================================================================
 
-void View3D::handlePickerPress(Qt3DRender::QPickEvent *event)
+void View3D::handlePickerPress(Qt3DRender::QPickEvent *qPickEvent)
 {
     // only catch click events for left mouse button
-    if(event->button() == event->LeftButton) {
-        emit pickEventOccured(event);
-        qInfo() << __func__ << ": global Coord: " << event->worldIntersection();
+    if(qPickEvent->button() == qPickEvent->LeftButton) {
+        emit pickEventOccured(qPickEvent);
+        qInfo() << __func__ << ": global Coord: " << qPickEvent->worldIntersection();
     }
 }
 

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -125,12 +125,13 @@ View3D::View3D()
     connect(picker, &Qt3DRender::QObjectPicker::pressed,
             this, &View3D::handlePickerPress);
 
-    Qt3DRender::QRenderSettings* renderSettings = new Qt3DRender::QRenderSettings(m_pRootEntity);
-    renderSettings->pickingSettings()->setPickMethod(Qt3DRender::QPickingSettings::PrimitivePicking);
-    renderSettings->pickingSettings()->setPickResultMode(Qt3DRender::QPickingSettings::NearestPick);
-    renderSettings->pickingSettings()->setWorldSpaceTolerance(0.00000001f);
-
-    m_pRootEntity->addComponent(renderSettings);
+    // Qt3DRender::QRenderSettings* renderSettings = new Qt3DRender::QRenderSettings(m_pRootEntity);
+    this->renderSettings()->setActiveFrameGraph(m_pFrameGraph);
+    this->renderSettings()->pickingSettings()->setPickMethod(Qt3DRender::QPickingSettings::PrimitivePicking);
+    this->renderSettings()->pickingSettings()->setPickResultMode(Qt3DRender::QPickingSettings::NearestPick);
+    this->renderSettings()->pickingSettings()->setWorldSpaceTolerance(0.00000001f);
+    // renderSettings->setRenderPolicy(Qt3DRender::QRenderSettings::OnDemand);
+    // m_pRootEntity->addComponent(renderSettings);
 }
 
 //=============================================================================================================
@@ -142,6 +143,7 @@ void View3D::handlePickerPress(Qt3DRender::QPickEvent *event)
 
     // // "event" will give me clicked coordinates like this:
     qDebug() << __func__ << ": global Coord: " << event->worldIntersection();
+    qDebug() << __func__ << ": local Coord: " <<event->localIntersection();
 
     //    // // Also I can get picked/clicked triangle index and its vertices by casting event pointer type:
     //    Qt3DRender::QPickTriangleEvent *eventTri = static_cast<Qt3DRender::QPickTriangleEvent *>(event);

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -119,38 +119,45 @@ View3D::View3D()
     createCoordSystem(m_pRootEntity);
     toggleCoordAxis(false);
 
-    //picking
+    initObjectPicking();
+}
+
+
+//=============================================================================================================
+
+void View3D::initObjectPicking()
+{
+    // create Object picker and add to root entity
     Qt3DRender::QObjectPicker *picker = new Qt3DRender::QObjectPicker(m_pRootEntity);
     m_pRootEntity->addComponent(picker);
+
+    // emit signal whenever pick event occured
     connect(picker, &Qt3DRender::QObjectPicker::pressed,
             this, &View3D::handlePickerPress);
 
-    // Qt3DRender::QRenderSettings* renderSettings = new Qt3DRender::QRenderSettings(m_pRootEntity);
+    // define renderSettings
     this->renderSettings()->setActiveFrameGraph(m_pFrameGraph);
     this->renderSettings()->pickingSettings()->setPickMethod(Qt3DRender::QPickingSettings::PrimitivePicking);
     this->renderSettings()->pickingSettings()->setPickResultMode(Qt3DRender::QPickingSettings::NearestPick);
     this->renderSettings()->pickingSettings()->setWorldSpaceTolerance(0.00000001f);
-    // renderSettings->setRenderPolicy(Qt3DRender::QRenderSettings::OnDemand);
-    // m_pRootEntity->addComponent(renderSettings);
 }
 
 //=============================================================================================================
 
-int k = 0;
+void View3D::activatePicker(const bool bActivatePicker)
+{
+    this->renderSettings()->setEnabled(bActivatePicker)
+}
+
+//=============================================================================================================
+
 void View3D::handlePickerPress(Qt3DRender::QPickEvent *event)
 {
-    qInfo() << "View3D::handlePickerPress" << k++ ;
-
-    // // "event" will give me clicked coordinates like this:
-    qDebug() << __func__ << ": global Coord: " << event->worldIntersection();
-    qDebug() << __func__ << ": local Coord: " <<event->localIntersection();
-
-    //    // // Also I can get picked/clicked triangle index and its vertices by casting event pointer type:
-    //    Qt3DRender::QPickTriangleEvent *eventTri = static_cast<Qt3DRender::QPickTriangleEvent *>(event);
-    //    qDebug() << __func__ << "Pick Triangle Index: " << eventTri->triangleIndex();
-    //    qDebug() << __func__ << "Pick Triangle Vertex 1: " << eventTri->vertex1Index();
-    //    qDebug() << __func__ << "Pick Triangle Vertex 2: " << eventTri->vertex2Index();
-    //    qDebug() << __func__ << "Pick Triangle Vertex 3: " << eventTri->vertex3Index();
+    // only catch click events for left mouse button
+    if(event->button() == event->LeftButton) {
+        emit pickEventOccured(event);
+        qInfo() << __func__ << ": global Coord: " << event->worldIntersection();
+    }
 }
 
 //=============================================================================================================

--- a/libraries/disp3D/engine/view/view3D.h
+++ b/libraries/disp3D/engine/view/view3D.h
@@ -59,6 +59,7 @@ class QPropertyAnimation;
 namespace Qt3DRender {
     class QPointLight;
     class QRenderCaptureReply;
+    class QPickEvent;
 }
 
 //=============================================================================================================
@@ -186,6 +187,14 @@ protected:
      * @param[in] pObject         The parent of the children to be rotated.
      */
     void startModelRotationRecursive(QObject* pObject);
+
+    //=========================================================================================================
+    /**
+     * Handle Picking events.
+     *
+     * @param[in] event         The event that occured.
+     */
+    void handlePickerPress(Qt3DRender::QPickEvent *event);
 
     QPointer<Qt3DCore::QEntity>                 m_pRootEntity;                  /**< The root/most top level entity buffer. */
     QPointer<Qt3DCore::QEntity>                 m_p3DObjectsEntity;             /**< The root/most top level entity buffer. */

--- a/libraries/disp3D/engine/view/view3D.h
+++ b/libraries/disp3D/engine/view/view3D.h
@@ -207,6 +207,14 @@ protected:
 
     QList<QPointer<QPropertyAnimation> >  m_lPropertyAnimations;         /**< The animations for each 3D object. */
     QList<QPointer<Qt3DRender::QPointLight> >  m_lLightSources;          /**< The light sources. */
+
+signals:
+    /*
+     * Send whenever a pick event occured
+     *
+     */
+    void pickEvent(Qt3DRender::QPickEvent *event);
+
 };
 } // NAMESPACE
 

--- a/libraries/disp3D/engine/view/view3D.h
+++ b/libraries/disp3D/engine/view/view3D.h
@@ -49,6 +49,7 @@
 #include <Qt3DExtras/Qt3DWindow>
 #include <QVector3D>
 #include <QPointer>
+#include <QObjectPicker>
 
 //=============================================================================================================
 // FORWARD DECLARATIONS
@@ -156,6 +157,15 @@ public:
      */
     void takeScreenshot();
 
+
+    //=========================================================================================================
+    /**
+     * Initilize the object picking.
+     *
+     * @param [in] bActivatePicker     Wheater to activate the object picker.
+     */
+    void activatePicker(const bool bActivatePicker);
+
 protected:
 
     void saveScreenshot();
@@ -165,6 +175,12 @@ protected:
      * Init the light for the 3D view
      */
     void initLight();
+
+    //=========================================================================================================
+    /**
+     * Initilize the object picking.
+     */
+    void initObjectPicking();
 
     //=========================================================================================================
     /**
@@ -205,15 +221,14 @@ protected:
     QPointer<Qt3DRender::QCamera>               m_pCamera;                      /**< The camera entity. */
     QPointer<Qt3DRender::QRenderCaptureReply>   m_pScreenCaptureReply;          /**< The capture reply object to save screenshots. */
 
-    QList<QPointer<QPropertyAnimation> >  m_lPropertyAnimations;         /**< The animations for each 3D object. */
-    QList<QPointer<Qt3DRender::QPointLight> >  m_lLightSources;          /**< The light sources. */
+    QList<QPointer<QPropertyAnimation> >        m_lPropertyAnimations;          /**< The animations for each 3D object. */
+    QList<QPointer<Qt3DRender::QPointLight> >   m_lLightSources;                /**< The light sources. */
 
 signals:
     /*
      * Send whenever a pick event occured
-     *
      */
-    void pickEvent(Qt3DRender::QPickEvent *event);
+    void pickEventOccured(Qt3DRender::QPickEvent *event);
 
 };
 } // NAMESPACE

--- a/libraries/disp3D/engine/view/view3D.h
+++ b/libraries/disp3D/engine/view/view3D.h
@@ -208,9 +208,9 @@ protected:
     /**
      * Handle Picking events.
      *
-     * @param[in] event         The event that occured.
+     * @param[in] qPickEvent         The picking event that occured.
      */
-    void handlePickerPress(Qt3DRender::QPickEvent *event);
+    void handlePickerPress(Qt3DRender::QPickEvent *qPickEvent);
 
     QPointer<Qt3DCore::QEntity>                 m_pRootEntity;                  /**< The root/most top level entity buffer. */
     QPointer<Qt3DCore::QEntity>                 m_p3DObjectsEntity;             /**< The root/most top level entity buffer. */
@@ -220,6 +220,7 @@ protected:
     QPointer<CustomFrameGraph>                  m_pFrameGraph;                  /**< The frameGraph entity. */
     QPointer<Qt3DRender::QCamera>               m_pCamera;                      /**< The camera entity. */
     QPointer<Qt3DRender::QRenderCaptureReply>   m_pScreenCaptureReply;          /**< The capture reply object to save screenshots. */
+    QPointer<Qt3DRender::QObjectPicker>         m_pPicker;                      /**< The Picker entity. */
 
     QList<QPointer<QPropertyAnimation> >        m_lPropertyAnimations;          /**< The animations for each 3D object. */
     QList<QPointer<Qt3DRender::QPointLight> >   m_lLightSources;                /**< The light sources. */
@@ -228,7 +229,7 @@ signals:
     /*
      * Send whenever a pick event occured
      */
-    void pickEventOccured(Qt3DRender::QPickEvent *event);
+    void pickEventOccured(Qt3DRender::QPickEvent *qPickEvent);
 
 };
 } // NAMESPACE


### PR DESCRIPTION
This PR implements triangle picking of custom mashes, such as the Bem surface.

Therefore following member functions and variables were implemented into DISP3DLIB::View3D.

Public:
- `void activatePicker(const bool bActivatePicker);` activates/deactivates the Picker. Picking can need quite some performance if a lot of Triangles/Vertices/etc. are involved. Therefore, it is helpful only to activate it if necessary.
 

Protected:
- `void initObjectPicking();` - initialize the QObjectPicker
- `void handlePickerPress(Qt3DRender::QPickEvent *qPickEvent);` - called whenever a picking event occure. Emits an signal if the left mouse button is the origin.

Signal:
- `void pickEventOccured(Qt3DRender::QPickEvent *qPickEvent);` Emitten, when picking event occured
