### PR TITLE
[MAINT,FIX] Fix Wasm CI workflow

### DIFF
--- a/.github/workflows/buildqtbinaries.yml
+++ b/.github/workflows/buildqtbinaries.yml
@@ -128,12 +128,12 @@ jobs:
         cd emsdk
         git pull
         # Download and install the latest SDK tools.
-        ./emsdk install 1.39.8        
+        ./emsdk install 1.39.7        
     - name: Compile wasm Qt version
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.8
+        ./emsdk/emsdk activate 1.39.7
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -642,12 +642,12 @@ jobs:
         cd emsdk
         git pull
         # Download and install the latest SDK tools.
-        ./emsdk install 1.39.8       
+        ./emsdk install 1.39.7       
     - name: Compile wasm Qt version
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.8
+        ./emsdk/emsdk activate 1.39.7
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
@@ -662,7 +662,7 @@ jobs:
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.8
+        ./emsdk/emsdk activate 1.39.7
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Compile MNE-CPP        

--- a/.github/workflows/wasmtest.yml
+++ b/.github/workflows/wasmtest.yml
@@ -22,7 +22,7 @@ jobs:
         cd emsdk
         git pull
         # Download and install the latest SDK tools.
-        ./emsdk install 1.39.8     
+        ./emsdk install 1.39.7     
     # - name: Install Qt
     #   run: |
     #     # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
@@ -34,7 +34,7 @@ jobs:
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.8
+        ./emsdk/emsdk activate 1.39.7
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
@@ -49,7 +49,7 @@ jobs:
       run: |
         cd ..
         # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.8
+        ./emsdk/emsdk activate 1.39.7
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Compile MNE-CPP        

--- a/doc/gh-pages/pages/development/wasm_buildguide.md
+++ b/doc/gh-pages/pages/development/wasm_buildguide.md
@@ -31,10 +31,10 @@ According to the official [Qt Wasm guide](https://wiki.qt.io/Qt_for_WebAssembly)
 Qt 5.12: 1.38.16
 Qt 5.13: 1.38.27 (multithreading: 1.38.30)
 Qt 5.14: it's complicated (1.38.27)
-Qt 5.15: 1.39.8
+Qt 5.15: 1.39.7
 ```
 
- | **Please note:** With the versions above some functions are not able to be linked and produce errors. It is possible that some MNE-CPP functions are not compatible with these emscripten versions. However, emscripten version 1.39.3 and 1.39.8 seem to be working with MNE-CPP code. The following setups should work: **Qt5.13.2 compiled with em++ 1.39.3 with thread support**, **Qt5.14.2 compiled with em++ 1.39.3 with thread support** and  **Qt5.15.0 compiled with em++ 1.39.8 with thread support**. | 
+ | **Please note:** With the versions above some functions are not able to be linked and produce errors. It is possible that some MNE-CPP functions are not compatible with these emscripten versions. However, emscripten version 1.39.3 and 1.39.7 seem to be working with MNE-CPP code. The following setups should work: **Qt5.13.2 compiled with em++ 1.39.3 with thread support**, **Qt5.14.2 compiled with em++ 1.39.3 with thread support** and  **Qt5.15.0 compiled with em++ 1.39.7 with thread support**. | 
 
 ## Setup the Emscripten Compiler
 

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -131,6 +131,31 @@ macx {
     CONFIG += sdk_no_version_check
 }
 
+# Check versions
+!minQtVersion(5, 10, 0) {
+    error("You are trying to build with Qt version $${QT_VERSION}. However, the minimal Qt version to build MNE-CPP is 5.10.0.")
+}
+
+# Build static version if wasm flag was defined
+contains(MNECPP_CONFIG, wasm) {
+    message("The wasm flag was detected. Building static version of MNE-CPP. Disabling QOpenGLWidget support.")
+    MNECPP_CONFIG += static noQOpenGLWidget
+    QMAKE_LFLAGS       += --shared-memory
+    QMAKE_LFLAGS_DEBUG += --shared-memory
+    QMAKE_CFLAGS += --shared-memory
+    QMAKE_CXXFLAGS += --shared-memory
+}
+
+contains(MNECPP_CONFIG, static) {
+    message("The static flag was detected. Building static version of MNE-CPP.")
+}
+
+# Do not support QOpenGLWidget support on macx because signal backgrounds are not plotted correctly (tested on Qt 5.15.0 and Qt 5.15.1)
+macx:minQtVersion(5, 15, 0) {
+    message("Excluding QOpenGLWidget on MacOS for Qt version greater than 5.15.0")
+    MNECPP_CONFIG += noQOpenGLWidget
+}
+
 ########################################### DIRECTORY DEFINITIONS #############################################
 
 # Eigen dir

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -140,10 +140,6 @@ macx {
 contains(MNECPP_CONFIG, wasm) {
     message("The wasm flag was detected. Building static version of MNE-CPP. Disabling QOpenGLWidget support.")
     MNECPP_CONFIG += static noQOpenGLWidget
-    QMAKE_LFLAGS       += --shared-memory
-    QMAKE_LFLAGS_DEBUG += --shared-memory
-    QMAKE_CFLAGS += --shared-memory
-    QMAKE_CXXFLAGS += --shared-memory
 }
 
 contains(MNECPP_CONFIG, static) {

--- a/mne-cpp.pro
+++ b/mne-cpp.pro
@@ -35,27 +35,6 @@
 
 include(mne-cpp.pri)
 
-# Check versions
-!minQtVersion(5, 10, 0) {
-    error("You are trying to build with Qt version $${QT_VERSION}. However, the minimal Qt version to build MNE-CPP is 5.10.0.")
-}
-
-# Build static version if wasm flag was defined
-contains(MNECPP_CONFIG, wasm) {
-    message("The wasm flag was detected. Building static version of MNE-CPP. Disable QOpenGLWidget support.")
-    MNECPP_CONFIG += static noQOpenGLWidget
-}
-
-contains(MNECPP_CONFIG, static) {
-    message("The static flag was detected. Building static version of MNE-CPP.")
-}
-
-# Do not support QOpenGLWidget support on macx because signal backgrounds are not plotted correctly (tested on Qt 5.15.0 and Qt 5.15.1)
-macx:minQtVersion(5, 15, 0) {
-    message("Excluding QOpenGLWidget on MacOS for Qt version greater than 5.15.0")
-    MNECPP_CONFIG += noQOpenGLWidget
-}
-
 TEMPLATE = subdirs
 
 SUBDIRS += \


### PR DESCRIPTION
This PR includes:

- Fix the Wasm CI workflow. The utils library was not able to be compiled with Emscripten v1.39.8 and therefore was decreased to v1.39.7
- Fix compiler flag usage by moving them back to the mne-cpp.pri file which is included by all other .pro files.