### PR TITLE
[MAINT] Update static/dynamic deployment process

### DIFF
--- a/.github/workflows/buildqtbinaries.yml
+++ b/.github/workflows/buildqtbinaries.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   GenerateLinuxStaticBinaries:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
     
     steps:
     - name: Clone repository
@@ -28,7 +28,7 @@ jobs:
         mkdir qt5_shadow
         cd qt5_shadow
         # Configure Qt5
-        ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license
+        ../qt5/configure -static -release -prefix "../Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license -bundled-xcb-xinput -qt-libpng -qt-pcre
         make module-qtbase module-qtsvg module-qtcharts module-qt3d -j4
         make install -j4
     - name: Package binaries

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -235,7 +235,7 @@ jobs:
       if: matrix.os == 'ubuntu-16.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/bfu2pfnmzy9hu2a/qt5_5151_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/ilwo7mu9muk48mf/qt5_5151_static_binaries_linux.tar.gz?dl=1
         mkdir ../Qt5_binaries
         tar xvzf qt5_5151_static_binaries_linux.tar.gz -C ../ -P
     - name: Install Qt (MacOS)

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -216,7 +216,7 @@ jobs:
       max-parallel: 3
       matrix:
         qt: [5.15.1]
-        os: [ubuntu-18.04, macos-latest, windows-2019]
+        os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -227,12 +227,12 @@ jobs:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install OpenGL (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-16.04'
       run: |
         sudo apt-get update -q
         sudo apt-get install build-essential libgl1-mesa-dev
     - name: Install Qt (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-16.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
         wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/bfu2pfnmzy9hu2a/qt5_5151_static_binaries_linux.tar.gz?dl=1
@@ -257,7 +257,7 @@ jobs:
         expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
         echo "::add-path::$HOME\jom"
     - name: Configure and compile MNE-CPP (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
       run: |
         ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=static
         make -j4
@@ -270,7 +270,7 @@ jobs:
         ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=static
         jom -j4
     - name: Deploy binaries (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-16.04'
       run: |
         ./tools/deployment/deploy_linux_static
     - name: Deploy binaries (MacOS)

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -269,6 +269,18 @@ jobs:
         Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
         ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=static
         jom -j4
+    - name: Deploy binaries (Linux)
+      if: matrix.os == 'ubuntu-18.04'
+      run: |
+        ./tools/deployment/deploy_linux_static
+    - name: Deploy binaries (MacOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        ./tools/deployment/deploy_macos_static
+    - name: Deploy binaries (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        ./tools/deployment/deploy_win_static.bat
 
   Tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,7 @@ jobs:
         make install -j4
     - name: Deploy binaries
       run: |
-        # Delete folders which we do not want to ship
-        rm -r bin/mne_rt_server_plugins
-        rm -r bin/mne-cpp-test-data
-        rm -r bin/mne_scan_plugins
-        rm -r bin/mne_analyze_plugins
-        # Creating archive of everything in the bin directory
-        tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/.
+        ./tools/deployment/deploy_linux_static
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -158,10 +152,7 @@ jobs:
         make install -j4
     - name: Deploy binaries
       run: |
-        # Delete folders which we do not want to ship
-        rm -r bin/mne-cpp-test-data
-        # Creating archive of all macos deployed applications
-        tar cfvz mne-cpp-macos-static-x86_64.tar.gz bin/.
+        ./tools/deployment/deploy_macos_static
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -230,12 +221,7 @@ jobs:
         jom -j4
     - name: Deploy binaries
       run: |
-        # Delete folders which we do not want to ship
-        Remove-Item 'bin/mne_rt_server_plugins' -Recurse
-        Remove-Item 'bin/mne-cpp-test-data' -Recurse
-        Remove-Item 'bin/mne_scan_plugins' -Recurse
-        Remove-Item 'bin/mne_analyze_plugins' -Recurse
-        7z a mne-cpp-windows-static-x86_64.zip ./bin
+        ./tools/deployment/deploy_win_static.bat
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:        
     - v0.*
     branches:
-    - mac
+    - ci
 
 jobs:
   CreateRelease:
@@ -71,7 +71,7 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/bfu2pfnmzy9hu2a/qt5_5151_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/ilwo7mu9muk48mf/qt5_5151_static_binaries_linux.tar.gz?dl=1
         mkdir ../Qt5_binaries
         tar xvzf qt5_5151_static_binaries_linux.tar.gz -C ../ -P
     # Uncomment this if you want to build Qt statically in this workflow
@@ -98,6 +98,10 @@ jobs:
     - name: Deploy binaries
       run: |
         ./tools/deployment/deploy_linux_static
+    - uses: actions/upload-artifact@v1
+      with:
+        name: mne-cpp-linux-static-x86_64.tar.gz
+        path: mne-cpp-linux-static-x86_64.tar.gz
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -148,11 +152,15 @@ jobs:
     - name: Configure and compile MNE-CPP
       run: |
         ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static MNECPP_CONFIG+=withAppBundles
-        make -j4
-        make install -j4
+        make -j
+        make install -j
     - name: Deploy binaries
       run: |
         ./tools/deployment/deploy_macos_static
+    - uses: actions/upload-artifact@v1
+      with:
+        name: mne-cpp-macos-static-x86_64.tar.gz
+        path: mne-cpp-macos-static-x86_64.tar.gz
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -172,74 +180,74 @@ jobs:
         tag: dev_build
         overwrite: true
         
-  WinStatic:
-    runs-on: windows-2019
-    needs: CreateRelease
+  # WinStatic:
+  #   runs-on: windows-2019
+  #   needs: CreateRelease
 
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Install Python 3.7 version
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-        architecture: 'x64'
-    - name: Install jom
-      run: |
-        Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
-        expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
-        echo "::add-path::$HOME\jom"  
-    - name: Install Qt
-      run: |
-        # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        Invoke-WebRequest https://www.dropbox.com/s/z745z290s9pknih/qt5_5151_static_binaries_win.zip?dl=1 -OutFile .\qt5_5151_static_binaries_win.zip
-        expand-archive -path "qt5_5151_static_binaries_win.zip" -destinationpath "..\"
-    # Uncomment this if you want to build Qt statically in this workflow
-    # - name: Compile static Qt version
-    #   run: |
-    #     # Clone Qt5 repo
-    #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
-    #     cd qt5
-    #     perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
-    #     # Create shadow build folder
-    #     cd ..
-    #     mkdir qt5_shadow
-    #     cd qt5_shadow
-    #     # Setup the compiler 
-    #     cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
-    #     Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
-    #     # Configure Qt5
-    #     ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
-    #     jom -j4
-    #     nmake install
-    - name: Configure and compile MNE-CPP
-      run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
-        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
-        ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
-        jom -j4
-    - name: Deploy binaries
-      run: |
-        ./tools/deployment/deploy_win_static.bat
-    - name: Deploy binaries with stable release on Github
-      if: endsWith(github.ref, 'master') == false
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: mne-cpp-windows-static-x86_64.zip
-        asset_name: mne-cpp-windows-static-x86_64.zip
-        tag: ${{ github.ref }}
-        overwrite: true
-    - name: Deploy binaries with dev release on Github
-      if: endsWith(github.ref, 'master') == true
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: mne-cpp-windows-static-x86_64.zip
-        asset_name: mne-cpp-windows-static-x86_64.zip
-        tag: dev_build
-        overwrite: true
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Install Python 3.7 version
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: '3.7'
+  #       architecture: 'x64'
+  #   - name: Install jom
+  #     run: |
+  #       Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
+  #       expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
+  #       echo "::add-path::$HOME\jom"  
+  #   - name: Install Qt
+  #     run: |
+  #       # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
+  #       Invoke-WebRequest https://www.dropbox.com/s/z745z290s9pknih/qt5_5151_static_binaries_win.zip?dl=1 -OutFile .\qt5_5151_static_binaries_win.zip
+  #       expand-archive -path "qt5_5151_static_binaries_win.zip" -destinationpath "..\"
+  #   # Uncomment this if you want to build Qt statically in this workflow
+  #   # - name: Compile static Qt version
+  #   #   run: |
+  #   #     # Clone Qt5 repo
+  #   #     cd ..
+  #   #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+  #   #     cd qt5
+  #   #     perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+  #   #     # Create shadow build folder
+  #   #     cd ..
+  #   #     mkdir qt5_shadow
+  #   #     cd qt5_shadow
+  #   #     # Setup the compiler 
+  #   #     cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+  #   #     Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+  #   #     # Configure Qt5
+  #   #     ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
+  #   #     jom -j4
+  #   #     nmake install
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+  #       Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+  #       ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
+  #       jom -j4
+  #   - name: Deploy binaries
+  #     run: |
+  #       ./tools/deployment/deploy_win_static.bat
+  #   - name: Deploy binaries with stable release on Github
+  #     if: endsWith(github.ref, 'master') == false
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #       file: mne-cpp-windows-static-x86_64.zip
+  #       asset_name: mne-cpp-windows-static-x86_64.zip
+  #       tag: ${{ github.ref }}
+  #       overwrite: true
+  #   - name: Deploy binaries with dev release on Github
+  #     if: endsWith(github.ref, 'master') == true
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #       file: mne-cpp-windows-static-x86_64.zip
+  #       asset_name: mne-cpp-windows-static-x86_64.zip
+  #       tag: dev_build
+  #       overwrite: true
 
   LinuxDynamic:
     runs-on: ubuntu-16.04
@@ -285,6 +293,10 @@ jobs:
     - name: Deploy binaries
       run: |
         ./tools/deployment/deploy_linux
+    - uses: actions/upload-artifact@v1
+      with:
+        name: mne-cpp-linux-dynamic-x86_64.tar.gz
+        path: mne-cpp-linux-dynamic-x86_64.tar.gz
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -331,7 +343,7 @@ jobs:
         cd applications/mne_scan/plugins/brainflowboard/brainflow/build
         cmake -DCMAKE_INSTALL_PREFIX=../installed -DCMAKE_BUILD_TYPE=Release ..
         make -j
-        make install
+        make install -j
     - name: Compile LSL submodule
       run: |
         cd applications/mne_scan/plugins/lsladapter/liblsl
@@ -347,6 +359,10 @@ jobs:
     - name: Deploy binaries (MacOS)
       run: |
         ./tools/deployment/deploy_macos
+    - uses: actions/upload-artifact@v1
+      with:
+        name: mne-cpp-macos-dynamic-x86_64.tar.gz
+        path: mne-cpp-macos-dynamic-x86_64.tar.gz
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -366,274 +382,274 @@ jobs:
         tag: dev_build
         overwrite: true
 
-  WinDynamic:
-    runs-on: windows-2019
-    needs: CreateRelease
+  # WinDynamic:
+  #   runs-on: windows-2019
+  #   needs: CreateRelease
 
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Install Python 3.7 version
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-        architecture: 'x64'   
-    - name: Install BrainFlow and LSL submodules
-      run: |
-        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
-        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2
-      with:
-        version: 5.15.1
-        arch: win64_msvc2019_64
-        modules: qtcharts
-    - name: Install jom
-      run: |
-        Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
-        expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
-        echo "::add-path::$HOME\jom"
-    - name: Compile BrainFlow submodule
-      run: |
-        cd applications\mne_scan\plugins\brainflowboard\brainflow
-        mkdir build
-        cd build
-        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
-        cmake --build . --target install --config Release
-    - name: Compile LSL submodule
-      run: |
-        cd applications\mne_scan\plugins\lsladapter\liblsl
-        mkdir build
-        cd build
-        cmake .. -G "Visual Studio 16 2019" -A x64
-        cmake --build . --config Release --target install
-    - name: Configure and compile MNE-CPP
-      run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
-        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
-        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-        jom -j4
-    - name: Deploy binaries (Windows)
-      run: |
-        ./tools/deployment/deploy_win.bat
-    - name: Deploy binaries with stable release on Github
-      if: endsWith(github.ref, 'master') == false
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: mne-cpp-windows-dynamic-x86_64.zip
-        asset_name: mne-cpp-windows-dynamic-x86_64.zip
-        tag: ${{ github.ref }}
-        overwrite: true
-    - name: Deploy binaries with dev release on Github
-      if: endsWith(github.ref, 'master') == true
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: mne-cpp-windows-dynamic-x86_64.zip
-        asset_name: mne-cpp-windows-dynamic-x86_64.zip
-        tag: dev_build
-        overwrite: true
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Install Python 3.7 version
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: '3.7'
+  #       architecture: 'x64'   
+  #   - name: Install BrainFlow and LSL submodules
+  #     run: |
+  #       git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+  #       git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+  #   - name: Install Qt
+  #     uses: jurplel/install-qt-action@v2
+  #     with:
+  #       version: 5.15.1
+  #       arch: win64_msvc2019_64
+  #       modules: qtcharts
+  #   - name: Install jom
+  #     run: |
+  #       Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
+  #       expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
+  #       echo "::add-path::$HOME\jom"
+  #   - name: Compile BrainFlow submodule
+  #     run: |
+  #       cd applications\mne_scan\plugins\brainflowboard\brainflow
+  #       mkdir build
+  #       cd build
+  #       cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+  #       cmake --build . --target install --config Release
+  #   - name: Compile LSL submodule
+  #     run: |
+  #       cd applications\mne_scan\plugins\lsladapter\liblsl
+  #       mkdir build
+  #       cd build
+  #       cmake .. -G "Visual Studio 16 2019" -A x64
+  #       cmake --build . --config Release --target install
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+  #       Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+  #       qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+  #       jom -j4
+  #   - name: Deploy binaries (Windows)
+  #     run: |
+  #       ./tools/deployment/deploy_win.bat
+  #   - name: Deploy binaries with stable release on Github
+  #     if: endsWith(github.ref, 'master') == false
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #       file: mne-cpp-windows-dynamic-x86_64.zip
+  #       asset_name: mne-cpp-windows-dynamic-x86_64.zip
+  #       tag: ${{ github.ref }}
+  #       overwrite: true
+  #   - name: Deploy binaries with dev release on Github
+  #     if: endsWith(github.ref, 'master') == true
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #       file: mne-cpp-windows-dynamic-x86_64.zip
+  #       asset_name: mne-cpp-windows-dynamic-x86_64.zip
+  #       tag: dev_build
+  #       overwrite: true
         
-  Tests:
-    # Only run for dev releases
-    if: endsWith(github.ref, 'master') == true
-    runs-on: ubuntu-16.04
-    needs: CreateRelease
+  # Tests:
+  #   # Only run for dev releases
+  #   if: endsWith(github.ref, 'master') == true
+  #   runs-on: ubuntu-16.04
+  #   needs: CreateRelease
 
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Install Python 3.7 version
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-        architecture: 'x64'
-    - name: Install Codecov
-      run: |
-        sudo pip install codecov 
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2
-      with:
-        version: 5.15.1
-        modules: qtcharts
-    - name: Configure and compile MNE-CPP
-      run: |
-        qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
-        make -j4
-    - name: Run tests and upload results to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        QTEST_FUNCTION_TIMEOUT: 900000
-      run: |
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
-        git clone https://github.com/mne-tools/mne-cpp-test-data.git ./bin/mne-cpp-test-data
-        for test in ./bin/test_*;
-        do
-          # Run all tests and call gcov on all cpp files after each test run. Then upload to codecov for every test run.
-          # Codecov is able to process multiple uploads and merge them as soon as the CI job is done.          
-          echo ">> Starting $test"
-          $test
-          find ./libraries -type f -name "*.cpp" -execdir gcov {} \; > /dev/null
-          # Hide codecov output since it corrupts the log too much
-          codecov > /dev/null
-        done
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Install Python 3.7 version
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: '3.7'
+  #       architecture: 'x64'
+  #   - name: Install Codecov
+  #     run: |
+  #       sudo pip install codecov 
+  #   - name: Install Qt
+  #     uses: jurplel/install-qt-action@v2
+  #     with:
+  #       version: 5.15.1
+  #       modules: qtcharts
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
+  #       make -j4
+  #   - name: Run tests and upload results to Codecov
+  #     env:
+  #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  #       QTEST_FUNCTION_TIMEOUT: 900000
+  #     run: |
+  #       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
+  #       git clone https://github.com/mne-tools/mne-cpp-test-data.git ./bin/mne-cpp-test-data
+  #       for test in ./bin/test_*;
+  #       do
+  #         # Run all tests and call gcov on all cpp files after each test run. Then upload to codecov for every test run.
+  #         # Codecov is able to process multiple uploads and merge them as soon as the CI job is done.          
+  #         echo ">> Starting $test"
+  #         $test
+  #         find ./libraries -type f -name "*.cpp" -execdir gcov {} \; > /dev/null
+  #         # Hide codecov output since it corrupts the log too much
+  #         codecov > /dev/null
+  #       done
         
-  Doxygen:
-    runs-on: ubuntu-16.04
-    needs: CreateRelease
+  # Doxygen:
+  #   runs-on: ubuntu-16.04
+  #   needs: CreateRelease
 
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Install Qt Dev Tools, Doxygen and Graphviz
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -qq qttools5-dev-tools doxygen graphviz
-    - name: Run Doxygen and package result
-      run: |
-        git fetch --all
-        git checkout origin/master
-        cd doc/doxygen
-        doxygen mne-cpp_doxyfile
-    - name: Setup Github credentials
-      uses: fusion-engineering/setup-git-credentials@v2
-      with:
-        credentials: ${{secrets.GIT_CREDENTIALS}}    
-    - name: Deploy qch docu data base with stable release on Github
-      if: endsWith(github.ref, 'master') == false
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: doc/doxygen/qt-creator_doc/mne-cpp.qch
-        asset_name: mne-cpp-doc-qtcreator.qch
-        tag: ${{ github.ref }}
-        overwrite: true
-    - name: Deploy qch docu data base with dev release on Github
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: doc/doxygen/qt-creator_doc/mne-cpp.qch
-        asset_name: mne-cpp-doc-qtcreator.qch
-        tag: dev_build
-        overwrite: true
-    - name: Update documentation at Github pages
-      run: |
-        cd doc/doxygen
-        git config --global user.email lorenzesch@hotmail.com
-        git config --global user.name LorenzE
-        git clone -b gh-pages https://github.com/mne-cpp/doxygen-api gh-pages
-        cd gh-pages
-        # Remove all files first
-        git rm * -r
-        git commit --amend -a -m 'Update docu' --allow-empty
-        touch .nojekyll        
-        # Copy doxygen files
-        cp -r ../html/* .
-        # Add all new files, commit and push
-        git add *
-        git add .nojekyll
-        git commit --amend -a -m 'Update docu'
-        git push -f --all
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Install Qt Dev Tools, Doxygen and Graphviz
+  #     run: |
+  #       sudo apt-get update -qq
+  #       sudo apt-get install -qq qttools5-dev-tools doxygen graphviz
+  #   - name: Run Doxygen and package result
+  #     run: |
+  #       git fetch --all
+  #       git checkout origin/master
+  #       cd doc/doxygen
+  #       doxygen mne-cpp_doxyfile
+  #   - name: Setup Github credentials
+  #     uses: fusion-engineering/setup-git-credentials@v2
+  #     with:
+  #       credentials: ${{secrets.GIT_CREDENTIALS}}    
+  #   - name: Deploy qch docu data base with stable release on Github
+  #     if: endsWith(github.ref, 'master') == false
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #       file: doc/doxygen/qt-creator_doc/mne-cpp.qch
+  #       asset_name: mne-cpp-doc-qtcreator.qch
+  #       tag: ${{ github.ref }}
+  #       overwrite: true
+  #   - name: Deploy qch docu data base with dev release on Github
+  #     uses: svenstaro/upload-release-action@v1-release
+  #     with:
+  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #       file: doc/doxygen/qt-creator_doc/mne-cpp.qch
+  #       asset_name: mne-cpp-doc-qtcreator.qch
+  #       tag: dev_build
+  #       overwrite: true
+  #   - name: Update documentation at Github pages
+  #     run: |
+  #       cd doc/doxygen
+  #       git config --global user.email lorenzesch@hotmail.com
+  #       git config --global user.name LorenzE
+  #       git clone -b gh-pages https://github.com/mne-cpp/doxygen-api gh-pages
+  #       cd gh-pages
+  #       # Remove all files first
+  #       git rm * -r
+  #       git commit --amend -a -m 'Update docu' --allow-empty
+  #       touch .nojekyll        
+  #       # Copy doxygen files
+  #       cp -r ../html/* .
+  #       # Add all new files, commit and push
+  #       git add *
+  #       git add .nojekyll
+  #       git commit --amend -a -m 'Update docu'
+  #       git push -f --all
 
-  gh-pages:
-    # Only run for dev releases
-    if: endsWith(github.ref, 'master') == true
-    runs-on: ubuntu-latest
-    needs: CreateRelease
+  # gh-pages:
+  #   # Only run for dev releases
+  #   if: endsWith(github.ref, 'master') == true
+  #   runs-on: ubuntu-latest
+  #   needs: CreateRelease
 
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Setup Github credentials
-      uses: fusion-engineering/setup-git-credentials@v2
-      with:
-        credentials: ${{secrets.GIT_CREDENTIALS}}
-    - name: Clone doc/gh-pages into gh-pages branch
-      run: |
-        git config --global user.email lorenzesch@hotmail.com
-        git config --global user.name LorenzE
-        git clone -b master --single-branch https://github.com/mne-cpp/mne-cpp.github.io.git
-        cd mne-cpp.github.io
-        # Remove all files first
-        git rm * -r
-        git commit --amend -a -m 'Update docu' --allow-empty
-        cd ..
-        cp -RT doc/gh-pages mne-cpp.github.io
-        cd mne-cpp.github.io
-        git add .
-        git commit --amend -a -m 'Update docu'
-        git push -f --all
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Setup Github credentials
+  #     uses: fusion-engineering/setup-git-credentials@v2
+  #     with:
+  #       credentials: ${{secrets.GIT_CREDENTIALS}}
+  #   - name: Clone doc/gh-pages into gh-pages branch
+  #     run: |
+  #       git config --global user.email lorenzesch@hotmail.com
+  #       git config --global user.name LorenzE
+  #       git clone -b master --single-branch https://github.com/mne-cpp/mne-cpp.github.io.git
+  #       cd mne-cpp.github.io
+  #       # Remove all files first
+  #       git rm * -r
+  #       git commit --amend -a -m 'Update docu' --allow-empty
+  #       cd ..
+  #       cp -RT doc/gh-pages mne-cpp.github.io
+  #       cd mne-cpp.github.io
+  #       git add .
+  #       git commit --amend -a -m 'Update docu'
+  #       git push -f --all
 
-  WebAssembly:
-    # Only run for dev releases
-    if: endsWith(github.ref, 'master') == true
-    runs-on: ubuntu-latest
-    needs: CreateRelease
+  # WebAssembly:
+  #   # Only run for dev releases
+  #   if: endsWith(github.ref, 'master') == true
+  #   runs-on: ubuntu-latest
+  #   needs: CreateRelease
 
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v2
-    - name: Setup emscripten compiler 
-      run: |
-        cd ..
-        # Get the emsdk repo
-        git clone https://github.com/emscripten-core/emsdk.git
-        # Enter that directory and pull
-        cd emsdk
-        git pull
-        # Download and install the latest SDK tools.
-        ./emsdk install 1.39.7       
-    - name: Compile wasm Qt version
-      run: |
-        cd ..
-        # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.7
-        # Activate PATH and other environment variables in the current terminal
-        source ./emsdk/emsdk_env.sh
-        # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
-        cd qt5
-        ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
-        # Configure Qt5
-        ./configure -xplatform wasm-emscripten -feature-thread -skip webengine -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license -prefix "$PWD/../Qt5_binaries"
-        make module-qtbase module-qtsvg module-qtcharts -j4
-        make install -j4
-    - name: Configure and compile MNE-CPP
-      run: |
-        cd ..
-        # Make the "latest" emscripten SDK "active" for the current user.
-        ./emsdk/emsdk activate 1.39.7
-        # Activate PATH and other environment variables in the current terminal
-        source ./emsdk/emsdk_env.sh
-        # Compile MNE-CPP        
-        cd mne-cpp
-        ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG=wasm
-        make -j4
-    - name: Setup Github credentials
-      uses: fusion-engineering/setup-git-credentials@v2
-      with:
-        credentials: ${{secrets.GIT_CREDENTIALS}}
-    - name: Clone and update mne-cpp/wasm:gh-pages
-      run: |
-        # Delete folders which we do not want to ship
-        rm -r bin/mne_analyze_plugins
-        rm -r bin/mne-cpp-test-data
-        rm -r bin/MNE-sample-data
-        # Replace logo
-        cp -RT tools/design/logos/qtlogo.svg bin/qtlogo.svg
-        # Clone repo and update with new wasm versions
-        git config --global user.email lorenzesch@hotmail.com
-        git config --global user.name LorenzE
-        git clone -b gh-pages --single-branch https://github.com/mne-cpp/wasm.git
-        cd wasm
-        # Remove all files first
-        git rm * -r
-        git commit --amend -a -m 'Update wasm builds' --allow-empty
-        # Copy wasm files
-        cd ..
-        cp -RT bin wasm
-        cd wasm
-        git add .
-        git commit --amend -a -m 'Update wasm builds'
-        git push -f --all
+  #   steps:
+  #   - name: Clone repository
+  #     uses: actions/checkout@v2
+  #   - name: Setup emscripten compiler 
+  #     run: |
+  #       cd ..
+  #       # Get the emsdk repo
+  #       git clone https://github.com/emscripten-core/emsdk.git
+  #       # Enter that directory and pull
+  #       cd emsdk
+  #       git pull
+  #       # Download and install the latest SDK tools.
+  #       ./emsdk install 1.39.7       
+  #   - name: Compile wasm Qt version
+  #     run: |
+  #       cd ..
+  #       # Make the "latest" emscripten SDK "active" for the current user.
+  #       ./emsdk/emsdk activate 1.39.7
+  #       # Activate PATH and other environment variables in the current terminal
+  #       source ./emsdk/emsdk_env.sh
+  #       # Clone Qt5 repo
+  #       git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+  #       cd qt5
+  #       ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
+  #       # Configure Qt5
+  #       ./configure -xplatform wasm-emscripten -feature-thread -skip webengine -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license -prefix "$PWD/../Qt5_binaries"
+  #       make module-qtbase module-qtsvg module-qtcharts -j4
+  #       make install -j4
+  #   - name: Configure and compile MNE-CPP
+  #     run: |
+  #       cd ..
+  #       # Make the "latest" emscripten SDK "active" for the current user.
+  #       ./emsdk/emsdk activate 1.39.7
+  #       # Activate PATH and other environment variables in the current terminal
+  #       source ./emsdk/emsdk_env.sh
+  #       # Compile MNE-CPP        
+  #       cd mne-cpp
+  #       ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG=wasm
+  #       make -j4
+  #   - name: Setup Github credentials
+  #     uses: fusion-engineering/setup-git-credentials@v2
+  #     with:
+  #       credentials: ${{secrets.GIT_CREDENTIALS}}
+  #   - name: Clone and update mne-cpp/wasm:gh-pages
+  #     run: |
+  #       # Delete folders which we do not want to ship
+  #       rm -r bin/mne_analyze_plugins
+  #       rm -r bin/mne-cpp-test-data
+  #       rm -r bin/MNE-sample-data
+  #       # Replace logo
+  #       cp -RT tools/design/logos/qtlogo.svg bin/qtlogo.svg
+  #       # Clone repo and update with new wasm versions
+  #       git config --global user.email lorenzesch@hotmail.com
+  #       git config --global user.name LorenzE
+  #       git clone -b gh-pages --single-branch https://github.com/mne-cpp/wasm.git
+  #       cd wasm
+  #       # Remove all files first
+  #       git rm * -r
+  #       git commit --amend -a -m 'Update wasm builds' --allow-empty
+  #       # Copy wasm files
+  #       cd ..
+  #       cp -RT bin wasm
+  #       cd wasm
+  #       git add .
+  #       git commit --amend -a -m 'Update wasm builds'
+  #       git push -f --all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:        
     - v0.*
     branches:
-    - ci
+    - master
 
 jobs:
   CreateRelease:
@@ -98,10 +98,6 @@ jobs:
     - name: Deploy binaries
       run: |
         ./tools/deployment/deploy_linux_static
-    - uses: actions/upload-artifact@v1
-      with:
-        name: mne-cpp-linux-static-x86_64.tar.gz
-        path: mne-cpp-linux-static-x86_64.tar.gz
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -157,10 +153,6 @@ jobs:
     - name: Deploy binaries
       run: |
         ./tools/deployment/deploy_macos_static
-    - uses: actions/upload-artifact@v1
-      with:
-        name: mne-cpp-macos-static-x86_64.tar.gz
-        path: mne-cpp-macos-static-x86_64.tar.gz
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -180,74 +172,74 @@ jobs:
         tag: dev_build
         overwrite: true
         
-  # WinStatic:
-  #   runs-on: windows-2019
-  #   needs: CreateRelease
+  WinStatic:
+    runs-on: windows-2019
+    needs: CreateRelease
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Install Python 3.7 version
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: '3.7'
-  #       architecture: 'x64'
-  #   - name: Install jom
-  #     run: |
-  #       Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
-  #       expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
-  #       echo "::add-path::$HOME\jom"  
-  #   - name: Install Qt
-  #     run: |
-  #       # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-  #       Invoke-WebRequest https://www.dropbox.com/s/z745z290s9pknih/qt5_5151_static_binaries_win.zip?dl=1 -OutFile .\qt5_5151_static_binaries_win.zip
-  #       expand-archive -path "qt5_5151_static_binaries_win.zip" -destinationpath "..\"
-  #   # Uncomment this if you want to build Qt statically in this workflow
-  #   # - name: Compile static Qt version
-  #   #   run: |
-  #   #     # Clone Qt5 repo
-  #   #     cd ..
-  #   #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
-  #   #     cd qt5
-  #   #     perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
-  #   #     # Create shadow build folder
-  #   #     cd ..
-  #   #     mkdir qt5_shadow
-  #   #     cd qt5_shadow
-  #   #     # Setup the compiler 
-  #   #     cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
-  #   #     Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
-  #   #     # Configure Qt5
-  #   #     ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
-  #   #     jom -j4
-  #   #     nmake install
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
-  #       Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
-  #       ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
-  #       jom -j4
-  #   - name: Deploy binaries
-  #     run: |
-  #       ./tools/deployment/deploy_win_static.bat
-  #   - name: Deploy binaries with stable release on Github
-  #     if: endsWith(github.ref, 'master') == false
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #       file: mne-cpp-windows-static-x86_64.zip
-  #       asset_name: mne-cpp-windows-static-x86_64.zip
-  #       tag: ${{ github.ref }}
-  #       overwrite: true
-  #   - name: Deploy binaries with dev release on Github
-  #     if: endsWith(github.ref, 'master') == true
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #       file: mne-cpp-windows-static-x86_64.zip
-  #       asset_name: mne-cpp-windows-static-x86_64.zip
-  #       tag: dev_build
-  #       overwrite: true
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install jom
+      run: |
+        Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
+        expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
+        echo "::add-path::$HOME\jom"  
+    - name: Install Qt
+      run: |
+        # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
+        Invoke-WebRequest https://www.dropbox.com/s/z745z290s9pknih/qt5_5151_static_binaries_win.zip?dl=1 -OutFile .\qt5_5151_static_binaries_win.zip
+        expand-archive -path "qt5_5151_static_binaries_win.zip" -destinationpath "..\"
+    # Uncomment this if you want to build Qt statically in this workflow
+    # - name: Compile static Qt version
+    #   run: |
+    #     # Clone Qt5 repo
+    #     cd ..
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+    #     cd qt5
+    #     perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
+    #     # Create shadow build folder
+    #     cd ..
+    #     mkdir qt5_shadow
+    #     cd qt5_shadow
+    #     # Setup the compiler 
+    #     cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+    #     Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+    #     # Configure Qt5
+    #     ..\qt5\configure.bat -release -static -no-pch -optimize-size -opengl desktop -platform win32-msvc -prefix "..\Qt5_binaries" -skip webengine -nomake tools -nomake tests -nomake examples -opensource -confirm-license
+    #     jom -j4
+    #     nmake install
+    - name: Configure and compile MNE-CPP
+      run: |
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+        ..\Qt5_binaries\bin\qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=static
+        jom -j4
+    - name: Deploy binaries
+      run: |
+        ./tools/deployment/deploy_win_static.bat
+    - name: Deploy binaries with stable release on Github
+      if: endsWith(github.ref, 'master') == false
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: mne-cpp-windows-static-x86_64.zip
+        asset_name: mne-cpp-windows-static-x86_64.zip
+        tag: ${{ github.ref }}
+        overwrite: true
+    - name: Deploy binaries with dev release on Github
+      if: endsWith(github.ref, 'master') == true
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: mne-cpp-windows-static-x86_64.zip
+        asset_name: mne-cpp-windows-static-x86_64.zip
+        tag: dev_build
+        overwrite: true
 
   LinuxDynamic:
     runs-on: ubuntu-16.04
@@ -293,10 +285,6 @@ jobs:
     - name: Deploy binaries
       run: |
         ./tools/deployment/deploy_linux
-    - uses: actions/upload-artifact@v1
-      with:
-        name: mne-cpp-linux-dynamic-x86_64.tar.gz
-        path: mne-cpp-linux-dynamic-x86_64.tar.gz
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -359,10 +347,6 @@ jobs:
     - name: Deploy binaries (MacOS)
       run: |
         ./tools/deployment/deploy_macos
-    - uses: actions/upload-artifact@v1
-      with:
-        name: mne-cpp-macos-dynamic-x86_64.tar.gz
-        path: mne-cpp-macos-dynamic-x86_64.tar.gz
     - name: Deploy binaries with stable release on Github
       if: endsWith(github.ref, 'master') == false
       uses: svenstaro/upload-release-action@v1-release
@@ -382,274 +366,274 @@ jobs:
         tag: dev_build
         overwrite: true
 
-  # WinDynamic:
-  #   runs-on: windows-2019
-  #   needs: CreateRelease
+  WinDynamic:
+    runs-on: windows-2019
+    needs: CreateRelease
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Install Python 3.7 version
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: '3.7'
-  #       architecture: 'x64'   
-  #   - name: Install BrainFlow and LSL submodules
-  #     run: |
-  #       git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
-  #       git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
-  #   - name: Install Qt
-  #     uses: jurplel/install-qt-action@v2
-  #     with:
-  #       version: 5.15.1
-  #       arch: win64_msvc2019_64
-  #       modules: qtcharts
-  #   - name: Install jom
-  #     run: |
-  #       Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
-  #       expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
-  #       echo "::add-path::$HOME\jom"
-  #   - name: Compile BrainFlow submodule
-  #     run: |
-  #       cd applications\mne_scan\plugins\brainflowboard\brainflow
-  #       mkdir build
-  #       cd build
-  #       cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
-  #       cmake --build . --target install --config Release
-  #   - name: Compile LSL submodule
-  #     run: |
-  #       cd applications\mne_scan\plugins\lsladapter\liblsl
-  #       mkdir build
-  #       cd build
-  #       cmake .. -G "Visual Studio 16 2019" -A x64
-  #       cmake --build . --config Release --target install
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
-  #       Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
-  #       qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
-  #       jom -j4
-  #   - name: Deploy binaries (Windows)
-  #     run: |
-  #       ./tools/deployment/deploy_win.bat
-  #   - name: Deploy binaries with stable release on Github
-  #     if: endsWith(github.ref, 'master') == false
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #       file: mne-cpp-windows-dynamic-x86_64.zip
-  #       asset_name: mne-cpp-windows-dynamic-x86_64.zip
-  #       tag: ${{ github.ref }}
-  #       overwrite: true
-  #   - name: Deploy binaries with dev release on Github
-  #     if: endsWith(github.ref, 'master') == true
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #       file: mne-cpp-windows-dynamic-x86_64.zip
-  #       asset_name: mne-cpp-windows-dynamic-x86_64.zip
-  #       tag: dev_build
-  #       overwrite: true
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'   
+    - name: Install BrainFlow and LSL submodules
+      run: |
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: 5.15.1
+        arch: win64_msvc2019_64
+        modules: qtcharts
+    - name: Install jom
+      run: |
+        Invoke-WebRequest https://www.dropbox.com/s/dku543gtw7ik7hr/jom.zip?dl=1 -OutFile .\jom.zip
+        expand-archive -path "jom.zip" -destinationpath "$HOME\jom"
+        echo "::add-path::$HOME\jom"
+    - name: Compile BrainFlow submodule
+      run: |
+        cd applications\mne_scan\plugins\brainflowboard\brainflow
+        mkdir build
+        cd build
+        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake --build . --target install --config Release
+    - name: Compile LSL submodule
+      run: |
+        cd applications\mne_scan\plugins\lsladapter\liblsl
+        mkdir build
+        cd build
+        cmake .. -G "Visual Studio 16 2019" -A x64
+        cmake --build . --config Release --target install
+    - name: Configure and compile MNE-CPP
+      run: |
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=noExamples MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        jom -j4
+    - name: Deploy binaries (Windows)
+      run: |
+        ./tools/deployment/deploy_win.bat
+    - name: Deploy binaries with stable release on Github
+      if: endsWith(github.ref, 'master') == false
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: mne-cpp-windows-dynamic-x86_64.zip
+        asset_name: mne-cpp-windows-dynamic-x86_64.zip
+        tag: ${{ github.ref }}
+        overwrite: true
+    - name: Deploy binaries with dev release on Github
+      if: endsWith(github.ref, 'master') == true
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: mne-cpp-windows-dynamic-x86_64.zip
+        asset_name: mne-cpp-windows-dynamic-x86_64.zip
+        tag: dev_build
+        overwrite: true
         
-  # Tests:
-  #   # Only run for dev releases
-  #   if: endsWith(github.ref, 'master') == true
-  #   runs-on: ubuntu-16.04
-  #   needs: CreateRelease
+  Tests:
+    # Only run for dev releases
+    if: endsWith(github.ref, 'master') == true
+    runs-on: ubuntu-16.04
+    needs: CreateRelease
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Install Python 3.7 version
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: '3.7'
-  #       architecture: 'x64'
-  #   - name: Install Codecov
-  #     run: |
-  #       sudo pip install codecov 
-  #   - name: Install Qt
-  #     uses: jurplel/install-qt-action@v2
-  #     with:
-  #       version: 5.15.1
-  #       modules: qtcharts
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
-  #       make -j4
-  #   - name: Run tests and upload results to Codecov
-  #     env:
-  #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  #       QTEST_FUNCTION_TIMEOUT: 900000
-  #     run: |
-  #       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
-  #       git clone https://github.com/mne-tools/mne-cpp-test-data.git ./bin/mne-cpp-test-data
-  #       for test in ./bin/test_*;
-  #       do
-  #         # Run all tests and call gcov on all cpp files after each test run. Then upload to codecov for every test run.
-  #         # Codecov is able to process multiple uploads and merge them as soon as the CI job is done.          
-  #         echo ">> Starting $test"
-  #         $test
-  #         find ./libraries -type f -name "*.cpp" -execdir gcov {} \; > /dev/null
-  #         # Hide codecov output since it corrupts the log too much
-  #         codecov > /dev/null
-  #       done
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install Codecov
+      run: |
+        sudo pip install codecov 
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: 5.15.1
+        modules: qtcharts
+    - name: Configure and compile MNE-CPP
+      run: |
+        qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
+        make -j4
+    - name: Run tests and upload results to Codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        QTEST_FUNCTION_TIMEOUT: 900000
+      run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
+        git clone https://github.com/mne-tools/mne-cpp-test-data.git ./bin/mne-cpp-test-data
+        for test in ./bin/test_*;
+        do
+          # Run all tests and call gcov on all cpp files after each test run. Then upload to codecov for every test run.
+          # Codecov is able to process multiple uploads and merge them as soon as the CI job is done.          
+          echo ">> Starting $test"
+          $test
+          find ./libraries -type f -name "*.cpp" -execdir gcov {} \; > /dev/null
+          # Hide codecov output since it corrupts the log too much
+          codecov > /dev/null
+        done
         
-  # Doxygen:
-  #   runs-on: ubuntu-16.04
-  #   needs: CreateRelease
+  Doxygen:
+    runs-on: ubuntu-16.04
+    needs: CreateRelease
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Install Qt Dev Tools, Doxygen and Graphviz
-  #     run: |
-  #       sudo apt-get update -qq
-  #       sudo apt-get install -qq qttools5-dev-tools doxygen graphviz
-  #   - name: Run Doxygen and package result
-  #     run: |
-  #       git fetch --all
-  #       git checkout origin/master
-  #       cd doc/doxygen
-  #       doxygen mne-cpp_doxyfile
-  #   - name: Setup Github credentials
-  #     uses: fusion-engineering/setup-git-credentials@v2
-  #     with:
-  #       credentials: ${{secrets.GIT_CREDENTIALS}}    
-  #   - name: Deploy qch docu data base with stable release on Github
-  #     if: endsWith(github.ref, 'master') == false
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #       file: doc/doxygen/qt-creator_doc/mne-cpp.qch
-  #       asset_name: mne-cpp-doc-qtcreator.qch
-  #       tag: ${{ github.ref }}
-  #       overwrite: true
-  #   - name: Deploy qch docu data base with dev release on Github
-  #     uses: svenstaro/upload-release-action@v1-release
-  #     with:
-  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #       file: doc/doxygen/qt-creator_doc/mne-cpp.qch
-  #       asset_name: mne-cpp-doc-qtcreator.qch
-  #       tag: dev_build
-  #       overwrite: true
-  #   - name: Update documentation at Github pages
-  #     run: |
-  #       cd doc/doxygen
-  #       git config --global user.email lorenzesch@hotmail.com
-  #       git config --global user.name LorenzE
-  #       git clone -b gh-pages https://github.com/mne-cpp/doxygen-api gh-pages
-  #       cd gh-pages
-  #       # Remove all files first
-  #       git rm * -r
-  #       git commit --amend -a -m 'Update docu' --allow-empty
-  #       touch .nojekyll        
-  #       # Copy doxygen files
-  #       cp -r ../html/* .
-  #       # Add all new files, commit and push
-  #       git add *
-  #       git add .nojekyll
-  #       git commit --amend -a -m 'Update docu'
-  #       git push -f --all
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Qt Dev Tools, Doxygen and Graphviz
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -qq qttools5-dev-tools doxygen graphviz
+    - name: Run Doxygen and package result
+      run: |
+        git fetch --all
+        git checkout origin/master
+        cd doc/doxygen
+        doxygen mne-cpp_doxyfile
+    - name: Setup Github credentials
+      uses: fusion-engineering/setup-git-credentials@v2
+      with:
+        credentials: ${{secrets.GIT_CREDENTIALS}}    
+    - name: Deploy qch docu data base with stable release on Github
+      if: endsWith(github.ref, 'master') == false
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: doc/doxygen/qt-creator_doc/mne-cpp.qch
+        asset_name: mne-cpp-doc-qtcreator.qch
+        tag: ${{ github.ref }}
+        overwrite: true
+    - name: Deploy qch docu data base with dev release on Github
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: doc/doxygen/qt-creator_doc/mne-cpp.qch
+        asset_name: mne-cpp-doc-qtcreator.qch
+        tag: dev_build
+        overwrite: true
+    - name: Update documentation at Github pages
+      run: |
+        cd doc/doxygen
+        git config --global user.email lorenzesch@hotmail.com
+        git config --global user.name LorenzE
+        git clone -b gh-pages https://github.com/mne-cpp/doxygen-api gh-pages
+        cd gh-pages
+        # Remove all files first
+        git rm * -r
+        git commit --amend -a -m 'Update docu' --allow-empty
+        touch .nojekyll        
+        # Copy doxygen files
+        cp -r ../html/* .
+        # Add all new files, commit and push
+        git add *
+        git add .nojekyll
+        git commit --amend -a -m 'Update docu'
+        git push -f --all
 
-  # gh-pages:
-  #   # Only run for dev releases
-  #   if: endsWith(github.ref, 'master') == true
-  #   runs-on: ubuntu-latest
-  #   needs: CreateRelease
+  gh-pages:
+    # Only run for dev releases
+    if: endsWith(github.ref, 'master') == true
+    runs-on: ubuntu-latest
+    needs: CreateRelease
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Setup Github credentials
-  #     uses: fusion-engineering/setup-git-credentials@v2
-  #     with:
-  #       credentials: ${{secrets.GIT_CREDENTIALS}}
-  #   - name: Clone doc/gh-pages into gh-pages branch
-  #     run: |
-  #       git config --global user.email lorenzesch@hotmail.com
-  #       git config --global user.name LorenzE
-  #       git clone -b master --single-branch https://github.com/mne-cpp/mne-cpp.github.io.git
-  #       cd mne-cpp.github.io
-  #       # Remove all files first
-  #       git rm * -r
-  #       git commit --amend -a -m 'Update docu' --allow-empty
-  #       cd ..
-  #       cp -RT doc/gh-pages mne-cpp.github.io
-  #       cd mne-cpp.github.io
-  #       git add .
-  #       git commit --amend -a -m 'Update docu'
-  #       git push -f --all
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Setup Github credentials
+      uses: fusion-engineering/setup-git-credentials@v2
+      with:
+        credentials: ${{secrets.GIT_CREDENTIALS}}
+    - name: Clone doc/gh-pages into gh-pages branch
+      run: |
+        git config --global user.email lorenzesch@hotmail.com
+        git config --global user.name LorenzE
+        git clone -b master --single-branch https://github.com/mne-cpp/mne-cpp.github.io.git
+        cd mne-cpp.github.io
+        # Remove all files first
+        git rm * -r
+        git commit --amend -a -m 'Update docu' --allow-empty
+        cd ..
+        cp -RT doc/gh-pages mne-cpp.github.io
+        cd mne-cpp.github.io
+        git add .
+        git commit --amend -a -m 'Update docu'
+        git push -f --all
 
-  # WebAssembly:
-  #   # Only run for dev releases
-  #   if: endsWith(github.ref, 'master') == true
-  #   runs-on: ubuntu-latest
-  #   needs: CreateRelease
+  WebAssembly:
+    # Only run for dev releases
+    if: endsWith(github.ref, 'master') == true
+    runs-on: ubuntu-latest
+    needs: CreateRelease
 
-  #   steps:
-  #   - name: Clone repository
-  #     uses: actions/checkout@v2
-  #   - name: Setup emscripten compiler 
-  #     run: |
-  #       cd ..
-  #       # Get the emsdk repo
-  #       git clone https://github.com/emscripten-core/emsdk.git
-  #       # Enter that directory and pull
-  #       cd emsdk
-  #       git pull
-  #       # Download and install the latest SDK tools.
-  #       ./emsdk install 1.39.7       
-  #   - name: Compile wasm Qt version
-  #     run: |
-  #       cd ..
-  #       # Make the "latest" emscripten SDK "active" for the current user.
-  #       ./emsdk/emsdk activate 1.39.7
-  #       # Activate PATH and other environment variables in the current terminal
-  #       source ./emsdk/emsdk_env.sh
-  #       # Clone Qt5 repo
-  #       git clone https://code.qt.io/qt/qt5.git -b 5.15.1
-  #       cd qt5
-  #       ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
-  #       # Configure Qt5
-  #       ./configure -xplatform wasm-emscripten -feature-thread -skip webengine -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license -prefix "$PWD/../Qt5_binaries"
-  #       make module-qtbase module-qtsvg module-qtcharts -j4
-  #       make install -j4
-  #   - name: Configure and compile MNE-CPP
-  #     run: |
-  #       cd ..
-  #       # Make the "latest" emscripten SDK "active" for the current user.
-  #       ./emsdk/emsdk activate 1.39.7
-  #       # Activate PATH and other environment variables in the current terminal
-  #       source ./emsdk/emsdk_env.sh
-  #       # Compile MNE-CPP        
-  #       cd mne-cpp
-  #       ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG=wasm
-  #       make -j4
-  #   - name: Setup Github credentials
-  #     uses: fusion-engineering/setup-git-credentials@v2
-  #     with:
-  #       credentials: ${{secrets.GIT_CREDENTIALS}}
-  #   - name: Clone and update mne-cpp/wasm:gh-pages
-  #     run: |
-  #       # Delete folders which we do not want to ship
-  #       rm -r bin/mne_analyze_plugins
-  #       rm -r bin/mne-cpp-test-data
-  #       rm -r bin/MNE-sample-data
-  #       # Replace logo
-  #       cp -RT tools/design/logos/qtlogo.svg bin/qtlogo.svg
-  #       # Clone repo and update with new wasm versions
-  #       git config --global user.email lorenzesch@hotmail.com
-  #       git config --global user.name LorenzE
-  #       git clone -b gh-pages --single-branch https://github.com/mne-cpp/wasm.git
-  #       cd wasm
-  #       # Remove all files first
-  #       git rm * -r
-  #       git commit --amend -a -m 'Update wasm builds' --allow-empty
-  #       # Copy wasm files
-  #       cd ..
-  #       cp -RT bin wasm
-  #       cd wasm
-  #       git add .
-  #       git commit --amend -a -m 'Update wasm builds'
-  #       git push -f --all
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Setup emscripten compiler 
+      run: |
+        cd ..
+        # Get the emsdk repo
+        git clone https://github.com/emscripten-core/emsdk.git
+        # Enter that directory and pull
+        cd emsdk
+        git pull
+        # Download and install the latest SDK tools.
+        ./emsdk install 1.39.7       
+    - name: Compile wasm Qt version
+      run: |
+        cd ..
+        # Make the "latest" emscripten SDK "active" for the current user.
+        ./emsdk/emsdk activate 1.39.7
+        # Activate PATH and other environment variables in the current terminal
+        source ./emsdk/emsdk_env.sh
+        # Clone Qt5 repo
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+        cd qt5
+        ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
+        # Configure Qt5
+        ./configure -xplatform wasm-emscripten -feature-thread -skip webengine -nomake tests -nomake examples -no-dbus -no-ssl -no-pch -opensource -confirm-license -prefix "$PWD/../Qt5_binaries"
+        make module-qtbase module-qtsvg module-qtcharts -j4
+        make install -j4
+    - name: Configure and compile MNE-CPP
+      run: |
+        cd ..
+        # Make the "latest" emscripten SDK "active" for the current user.
+        ./emsdk/emsdk activate 1.39.7
+        # Activate PATH and other environment variables in the current terminal
+        source ./emsdk/emsdk_env.sh
+        # Compile MNE-CPP        
+        cd mne-cpp
+        ../Qt5_binaries/bin/qmake -r MNECPP_CONFIG=wasm
+        make -j4
+    - name: Setup Github credentials
+      uses: fusion-engineering/setup-git-credentials@v2
+      with:
+        credentials: ${{secrets.GIT_CREDENTIALS}}
+    - name: Clone and update mne-cpp/wasm:gh-pages
+      run: |
+        # Delete folders which we do not want to ship
+        rm -r bin/mne_analyze_plugins
+        rm -r bin/mne-cpp-test-data
+        rm -r bin/MNE-sample-data
+        # Replace logo
+        cp -RT tools/design/logos/qtlogo.svg bin/qtlogo.svg
+        # Clone repo and update with new wasm versions
+        git config --global user.email lorenzesch@hotmail.com
+        git config --global user.name LorenzE
+        git clone -b gh-pages --single-branch https://github.com/mne-cpp/wasm.git
+        cd wasm
+        # Remove all files first
+        git rm * -r
+        git commit --amend -a -m 'Update wasm builds' --allow-empty
+        # Copy wasm files
+        cd ..
+        cp -RT bin wasm
+        cd wasm
+        git add .
+        git commit --amend -a -m 'Update wasm builds'
+        git push -f --all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:        
     - v0.*
     branches:
-    - master
+    - mac
 
 jobs:
   CreateRelease:
@@ -58,7 +58,7 @@ jobs:
         hub release create -m "Development Builds" dev_build --prerelease
         
   LinuxStatic:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
     needs: CreateRelease
     
     steps:

--- a/doc/gh-pages/pages/development/ci_deployment.md
+++ b/doc/gh-pages/pages/development/ci_deployment.md
@@ -7,38 +7,36 @@ nav_order: 2
 
 # Deployment
 
-|**Please note:** The information below only hold for dynamically linked builds of MNE-CPP. When building statically, no dependency solving is necessary. Due to their larger file size our CI excludes statically pre-built examples and tests from the satic release binaries.|
-
-This page explains how MNE-CPP handles build setups, solves for exernal as well as internal dependencies, prepares resources, and does packaging.
+This page explains how MNE-CPP handles deployment on Win, Linux and MacOS.
 
 ## Build Rules
 
 All MNE-CPP libraries are built to the `mne-cpp/lib` folder. All applications, test, and examples are built to the `mne-cpp/bin` folder.
 
 ## Dependency Solving
-MNE-CPP depends on [Qt](https://www.qt.io/){:target="_blank" rel="noopener"} and [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page){:target="_blank" rel="noopener"}. Eigen, as a lightweight template library, [is included in the MNE-CPP repository by default](https://github.com/mne-tools/mne-cpp/tree/master/include/3rdParty/eigen3){:target="_blank" rel="noopener"} and does not need further dependency solving. For Qt dependencies we use Qt speficic deployment tools (`windeployqt`, `linuxdeployqt`, `macdeployqt`).
+MNE-CPP depends on [Qt](https://www.qt.io/){:target="_blank" rel="noopener"} and [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page){:target="_blank" rel="noopener"}. Eigen, as a lightweight template library, [is included in the MNE-CPP repository by default](https://github.com/mne-tools/mne-cpp/tree/master/include/3rdParty/eigen3){:target="_blank" rel="noopener"} and does not need further dependency solving. For Qt dependencies we use Qt specific deployment tools (`windeployqt`, `linuxdeployqt`, `macdeployqt`).
 
 ### Windows
 The `WinDynamic` workflow run in [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} is configured to exclude examples as well as tests. Next to `mne-cpp/lib` the MNE-CPP libraries are also copied to the `mne-cpp/bin` folder. This is performed in the libraries' .pro files. 
 
-Dependency solving for libraries and executables is done via the `windeployqt` tool, which is officially developed and maintained by Qt. Calling `windeployqt` is performed in the [deploy_win.bat](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_win.bat){:target="_blank" rel="noopener"} file. `windeployqt` is called on MNE Scan .exe and the Disp3D .dll file. Disp3D is the most top level library and links against all needed Qt modules. MNE Scan links against all relevant Qt modules application wise. Subsequently, Qt and all needed system libraries reside in the `mne-cpp/bin` folder.
+Dependency solving for libraries and executables is done via the `windeployqt` tool, which is officially developed and maintained by Qt. Calling `windeployqt` is performed in the [deploy_win.bat](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_win.bat){:target="_blank" rel="noopener"} file. `windeployqt` is called on the MNE Scan .exe and the Disp3D .dll file. Disp3D is the most top level library and links against all needed Qt modules. MNE Scan links against all relevant Qt modules application wise. Subsequently, Qt and all needed system libraries reside in the `mne-cpp/bin` folder.
 
-The folder `mne-cpp/bin` is compressed to a .zip file and uploaded as release asset to the corresponding GitHub release.
+The no longer needed folder `mne-cpp/bin/mne-cpp-test-data`is deleted before packaging. The folder `mne-cpp/bin` is compressed to a .zip file and uploaded as release asset to the corresponding GitHub release.
 
 ### Linux
 The `LinuxDynamic` workflow run in [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} is configured to exclude examples as well as tests. The `RPATH` is specified in the executable's .pro file in order to link to the libraries in `mne-cpp/lib`.
 
 Dependency solving for libraries and executables is done via the [linuxdeployqt](https://github.com/probonopd/linuxdeployqt){:target="_blank" rel="noopener"} tool. Calling `linuxdeployqt` is performed in the [deploy_linux](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_linux){:target="_blank" rel="noopener"} file.
 
-The folders `mne-cpp/bin`, `mne-cpp/lib`, `mne-cpp/plugins`, `mne-cpp/translations` are compressed to a .tar.gz file and uploaded as release assets to the corresponding GitHub release. 
+The no longer needed folder `mne-cpp/bin/mne-cpp-test-data`is deleted before packaging.  The folders `mne-cpp/bin`, `mne-cpp/lib`, `mne-cpp/plugins`, `mne-cpp/translations` are compressed to a .tar.gz file and uploaded as release assets to the corresponding GitHub release. 
 
 ### MacOS
 The `MacOSDynamic` workflow run in [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} is configured to exclude examples as well as tests. All applications are build as .app bundles using the `withAppBundles` configuration flag.
 
-Dependency solving for libraries and executables is done via the `macdeployqt` tool, which is officially developed and maintained by Qt. Calling `macdeployqt` is performed in the [deploy_macos](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_macos){:target="_blank" rel="noopener"} file. All MNE-CPP libraries are manually copied to the .app's `Contents/Frameworks` folder. The resource folder containing layouts, selection groups and so on is copied from `mne-cpp/bin/resources` to `mne-cpp/bin/<app_name>.app/MacOs/resources`. 
+Dependency solving for libraries and executables is done via the `macdeployqt` tool, which is officially developed and maintained by Qt. Calling `macdeployqt` is performed in the [deploy_macos](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_macos){:target="_blank" rel="noopener"} file. All MNE-CPP libraries are manually copied to the .app's `Contents/Frameworks` folder. The resource and applications' plugins folders are copied to the corresponding `mne-cpp/bin/<app_name>.app/` folders. 
 
-The folder `mne-cpp/bin` is compressed to a .tar.gz file and uploaded as release assets to the corresponding GitHub release.
+The no longer needed folders `mne-cpp/bin/mne-cpp-test-data`, `mne-cpp/bin/mne_scan_plugins`, `mne-cpp/bin/mne_analyze_plugins`, `mne-cpp/bin/mne_rt_server_plugins` and `mne-cpp/bin/resources` are deleted before packaging. The folder `mne-cpp/bin` is compressed to a .tar.gz file and uploaded as release assets to the corresponding GitHub release.
 
-## Resource Handling
+## Static Builds
 
-Files which are needed by applications (layout files, selection groups, etc.) are considrered resources and reside in `mne-cpp/bin/resources`. In case of .app images on MacOS, the needed resources are copied from `mne-cpp/resources` to `mne-cpp/bin/mne_scan.app/MacOs/resources`. 
+The information above corresponds to deploying the dynamically build version of MNE-CPP. In case of static deployment the process differs a bit. See the [deploy_win_static.bat](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_win_static.bat){:target="_blank" rel="noopener"} , [deploy_macos_static](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_macos_static){:target="_blank" rel="noopener"} and [deploy_linux_static](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_linux_static){:target="_blank" rel="noopener"} files.

--- a/doc/gh-pages/pages/development/ci_deployment.md
+++ b/doc/gh-pages/pages/development/ci_deployment.md
@@ -16,37 +16,29 @@ This page explains how MNE-CPP handles build setups, solves for exernal as well 
 All MNE-CPP libraries are built to the `mne-cpp/lib` folder. All applications, test, and examples are built to the `mne-cpp/bin` folder.
 
 ## Dependency Solving
+MNE-CPP depends on [Qt](https://www.qt.io/){:target="_blank" rel="noopener"} and [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page){:target="_blank" rel="noopener"}. Eigen, as a lightweight template library, [is included in the MNE-CPP repository by default](https://github.com/mne-tools/mne-cpp/tree/master/include/3rdParty/eigen3){:target="_blank" rel="noopener"} and does not need further dependency solving. For Qt dependencies we use Qt speficic deployment tools (`windeployqt`, `linuxdeployqt`, `macdeployqt`).
 
-On Windows and MacOS, dependency solving for libraries and executables is done via the `windeployqt` and `macdeployqt` tools, which are officially developed and maintained by Qt. For Linux we use the unoffical [linuxdeployqt](https://github.com/probonopd/linuxdeployqt){:target="_blank" rel="noopener"} tool. Calling these tools is performed in our workflow [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} file which again calls the deployment scripts in `tools/deployment`.
+### Windows
+The `WinDynamic` workflow run in [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} is configured to exclude examples as well as tests. Next to `mne-cpp/lib` the MNE-CPP libraries are also copied to the `mne-cpp/bin` folder. This is performed in the libraries' .pro files. 
 
-### Internal Dependencies (MNE-CPP libraries) 
+Dependency solving for libraries and executables is done via the `windeployqt` tool, which is officially developed and maintained by Qt. Calling `windeployqt` is performed in the [deploy_win.bat](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_win.bat){:target="_blank" rel="noopener"} file. `windeployqt` is called on MNE Scan .exe and the Disp3D .dll file. Disp3D is the most top level library and links against all needed Qt modules. MNE Scan links against all relevant Qt modules application wise. Subsequently, Qt and all needed system libraries reside in the `mne-cpp/bin` folder.
 
-Applications, tests and examples link against MNE-CPP libraries (internal dependencies). Dependencies between MNE-CPP libraries exist as well and can be seen in the [libraries.pro file](https://github.com/mne-tools/mne-cpp/blob/master/libraries/libraries.pro){:target="_blank" rel="noopener"}. The following table describes how we solve for internal dependencies:
+The folder `mne-cpp/bin` is compressed to a .zip file and uploaded as release asset to the corresponding GitHub release.
 
-| Platform                    | Dependency solving                     |
-| --------------------------- | -------------------------------------- |
-| Windows | All MNE-CPP libraries are copied from `mne-cpp/lib` to `mne-cpp/bin` via the library's .pro file. This is needed since Windows does not support rpaths and `windeployqt` only takes care of Qt related dependencies.| 
-| Linux | MNE-CPP libraries reside in `mne-cpp/lib`. The `RPATH` is specified in the executable's .pro file in order to link to the libraries in `mne-cpp/lib`. | 
-| MacOS | For .app bundles MNE-CPP libraries are copied to the .app `Contents/Frameworks` folder by the [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} workflow file. For none .app bundles, tests and examples the rpath is setup in the library's and application's .pro file pointing to `mne-cpp/lib`. |
+### Linux
+The `LinuxDynamic` workflow run in [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} is configured to exclude examples as well as tests. The `RPATH` is specified in the executable's .pro file in order to link to the libraries in `mne-cpp/lib`.
 
-### External Dependencies (Qt, Eigen and System Libraries)
+Dependency solving for libraries and executables is done via the [linuxdeployqt](https://github.com/probonopd/linuxdeployqt){:target="_blank" rel="noopener"} tool. Calling `linuxdeployqt` is performed in the [deploy_linux](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_linux){:target="_blank" rel="noopener"} file.
 
-MNE-CPP depends on [Qt](https://www.qt.io/){:target="_blank" rel="noopener"} and [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page){:target="_blank" rel="noopener"}. Eigen, as a lightweight template library, [is included in the MNE-CPP repository by default](https://github.com/mne-tools/mne-cpp/tree/master/include/3rdParty/eigen3){:target="_blank" rel="noopener"} and does not need further dependency solving. For Qt dependencies we do the following:
+The folders `mne-cpp/bin`, `mne-cpp/lib`, `mne-cpp/plugins`, `mne-cpp/translations` are compressed to a .tar.gz file and uploaded as release assets to the corresponding GitHub release. 
 
-| Platform                    | Dependency solving                     |
-| --------------------------- | -------------------------------------- |
-| Windows | Call `windeployqt` on MNE Scan and the Disp3D library DLL. Disp3D is the most top level library and links against all needed Qt modules. MNE Scan links against all relevant Qt modules. Subsequently, Qt and all needed system libraries reside in `mne-cpp/bin`. |
-| Linux | Call `linuxdeployqt` on MNE Scan only, see the [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} workflow file. This will copy Qt libraries to `mne-cpp/lib` and Qt plugins to `mne-cpp/plugins`. The `RPATH` is specified in the executable's .pro file in order to link to the libraries in `mne-cpp/lib`. |
-| MacOS | All applications, examples and tests can be created as .app bundles (via the `withAppBundles` flag). In this case `macdeployqt` is used to solve for Qt dependencies, see the [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} workflow file. Please note, `macdeployqt` only works on .app bundles. In the non .app bundle case you need to specify `export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:<Qt_path>/lib` in orer to find the Qt dependencies. |
+### MacOS
+The `MacOSDynamic` workflow run in [release.yml](https://github.com/mne-tools/mne-cpp/blob/master/.github/workflows/release.yml){:target="_blank" rel="noopener"} is configured to exclude examples as well as tests. All applications are build as .app bundles using the `withAppBundles` configuration flag.
+
+Dependency solving for libraries and executables is done via the `macdeployqt` tool, which is officially developed and maintained by Qt. Calling `macdeployqt` is performed in the [deploy_macos](https://github.com/mne-tools/mne-cpp/blob/master/tools/deployment/deploy_macos){:target="_blank" rel="noopener"} file. All MNE-CPP libraries are manually copied to the .app's `Contents/Frameworks` folder. The resource folder containing layouts, selection groups and so on is copied from `mne-cpp/bin/resources` to `mne-cpp/bin/<app_name>.app/MacOs/resources`. 
+
+The folder `mne-cpp/bin` is compressed to a .tar.gz file and uploaded as release assets to the corresponding GitHub release.
 
 ## Resource Handling
 
 Files which are needed by applications (layout files, selection groups, etc.) are considrered resources and reside in `mne-cpp/bin/resources`. In case of .app images on MacOS, the needed resources are copied from `mne-cpp/resources` to `mne-cpp/bin/mne_scan.app/MacOs/resources`. 
-
-## Packaging and Uploading
-
-| Platform                    | Packaged folders                      |
-| --------------------------- | ------------------------------------ |
-| Windows | Folder `mne-cpp/bin` is compressed to a zip file and uploaded as release asset to the corresponding GitHub release. |
-| Linux | Folders `mne-cpp/bin`, `mne-cpp/lib`, `mne-cpp/plugins`, `mne-cpp/translations` are compressed to a tar.gz file and uploaded as release assets to the corresponding GitHub release. |
-| MacOS | Folders `mne-cpp/bin`, `mne-cpp/lib` are compressed to a tar.gz file and uploaded as release assets to the corresponding GitHub release.  |

--- a/doc/gh-pages/pages/install/binaries.md
+++ b/doc/gh-pages/pages/install/binaries.md
@@ -13,14 +13,14 @@ Stable Releases
 
 | Version | Release | Download link |
 |-------|-------|-------|
-| [0.1.7](changelog.md#version-017) | 2020-10-26 | <span class="fs-2"> [Windows](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-windows-static-x86_64.zip){: .btn .btn-blue } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-linux-static-x86_64.tar.gz){: .btn .btn-blue } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-macos-static-x86_64.tar.gz){: .btn .btn-blue } </span> |
+| [0.1.7](changelog.md#version-017) | 2020-10-26 | <span class="fs-2"> [Windows](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-windows-static-x86_64.zip){: .btn .btn-blue } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-linux-static-x86_64.tar.gz){: .btn .btn-blue } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-macos-dynamic-x86_64.tar.gz){: .btn .btn-blue } </span> |
 
 Development Release
 {: .label .label-green }
 
 | Version | Release | Download link |
 |-------|-------|-------|
-| dev_build | [Latest commit](https://github.com/mne-tools/mne-cpp/commits/master){:target="_blank" rel="noopener"} | <span class="fs-2"> [Windows](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-windows-static-x86_64.zip){: .btn .btn-green } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-linux-static-x86_64.tar.gz){: .btn .btn-green } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-macos-static-x86_64.tar.gz){: .btn .btn-green } </span> |
+| dev_build | [Latest commit](https://github.com/mne-tools/mne-cpp/commits/master){:target="_blank" rel="noopener"} | <span class="fs-2"> [Windows](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-windows-static-x86_64.zip){: .btn .btn-green } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-linux-static-x86_64.tar.gz){: .btn .btn-green } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-macos-dynamic-x86_64.tar.gz){: .btn .btn-green } </span> |
 
 WebAssembly Releases
 {: .label .label-purple }

--- a/doc/gh-pages/pages/install/binaries.md
+++ b/doc/gh-pages/pages/install/binaries.md
@@ -13,14 +13,14 @@ Stable Releases
 
 | Version | Release | Download link |
 |-------|-------|-------|
-| [0.1.7](changelog.md#version-017) | 2020-10-26 | <span class="fs-2"> [Windows](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-windows-static-x86_64.zip){: .btn .btn-blue } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-linux-static-x86_64.tar.gz){: .btn .btn-blue } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-macos-dynamic-x86_64.tar.gz){: .btn .btn-blue } </span> |
+| [0.1.7](changelog.md#version-017) | 2020-10-26 | <span class="fs-2"> [Windows](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-windows-dynamic-x86_64.zip){: .btn .btn-blue } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-linux-dynamic-x86_64.tar.gz){: .btn .btn-blue } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/v0.1.7/mne-cpp-macos-dynamic-x86_64.tar.gz){: .btn .btn-blue } </span> |
 
 Development Release
 {: .label .label-green }
 
 | Version | Release | Download link |
 |-------|-------|-------|
-| dev_build | [Latest commit](https://github.com/mne-tools/mne-cpp/commits/master){:target="_blank" rel="noopener"} | <span class="fs-2"> [Windows](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-windows-static-x86_64.zip){: .btn .btn-green } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-linux-static-x86_64.tar.gz){: .btn .btn-green } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-macos-dynamic-x86_64.tar.gz){: .btn .btn-green } </span> |
+| dev_build | [Latest commit](https://github.com/mne-tools/mne-cpp/commits/master){:target="_blank" rel="noopener"} | <span class="fs-2"> [Windows](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-windows-dynamic-x86_64.zip){: .btn .btn-green } [Linux](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-linux-dynamic-x86_64.tar.gz){: .btn .btn-green } [MacOS](https://github.com/mne-tools/mne-cpp/releases/download/dev_build/mne-cpp-macos-dynamic-x86_64.tar.gz){: .btn .btn-green } </span> |
 
 WebAssembly Releases
 {: .label .label-purple }

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -51,7 +51,7 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2020 Authors of MNE-CPP. All rights reser
 # To build MNE Scan with TMSI support run: qmake MNECPP_CONFIG+=withTmsi
 
 # Default flags
-MNECPP_CONFIG += #static withAppBundles noExamples noTests
+MNECPP_CONFIG +=
 
 # Suppress untested SDK version checks on MacOS
 macx {

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -51,7 +51,7 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2020 Authors of MNE-CPP. All rights reser
 # To build MNE Scan with TMSI support run: qmake MNECPP_CONFIG+=withTmsi
 
 # Default flags
-MNECPP_CONFIG +=
+MNECPP_CONFIG += static withAppBundles noExamples noTests
 
 # Suppress untested SDK version checks on MacOS
 macx {

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -51,7 +51,7 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2020 Authors of MNE-CPP. All rights reser
 # To build MNE Scan with TMSI support run: qmake MNECPP_CONFIG+=withTmsi
 
 # Default flags
-MNECPP_CONFIG += static withAppBundles noExamples noTests
+MNECPP_CONFIG += #static withAppBundles noExamples noTests
 
 # Suppress untested SDK version checks on MacOS
 macx {

--- a/tools/deployment/deploy_linux
+++ b/tools/deployment/deploy_linux
@@ -34,5 +34,16 @@ cd mne-cpp
 ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2 -extra-plugins=renderers
 ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_analyze -verbose2 -extra-plugins=renderers
 
+# Manually copy in the libxcb-xinerama library which is needed by plugins/platforms/libxcb.so
+cp /usr/lib/x86_64-linux-gnu/libxcb-xinerama.so.0 ./lib/
+
+echo 
+echo ldd ./bin/mne_scan
+ldd ./bin/mne_scan
+
+echo 
+echo ldd ./plugins/platforms/libqxcb.so
+ldd ./plugins/platforms/libqxcb.so
+
 # Creating archive of everything in current directory
 tar cfvz ../mne-cpp-linux-dynamic-x86_64.tar.gz ./*

--- a/tools/deployment/deploy_linux
+++ b/tools/deployment/deploy_linux
@@ -1,7 +1,4 @@
 # This script needs to be run from the top level mne-cpp repo folder
-# Delete folders which we do not want to ship
-rm -r bin/mne-cpp-test-data
-
 # Copy additional brainflow libs
 cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. lib/
 
@@ -44,6 +41,9 @@ ldd ./bin/mne_scan
 echo 
 echo ldd ./plugins/platforms/libqxcb.so
 ldd ./plugins/platforms/libqxcb.so
+
+# Delete folders which we do not want to ship
+rm -r bin/mne-cpp-test-data
 
 # Creating archive of everything in current directory
 tar cfvz ../mne-cpp-linux-dynamic-x86_64.tar.gz ./*

--- a/tools/deployment/deploy_linux
+++ b/tools/deployment/deploy_linux
@@ -8,7 +8,7 @@ cp -a applications/mne_scan/plugins/brainflowboard/brainflow/installed/lib/. lib
 # Copy additional LSL libs
 cp -a applications/mne_scan/plugins/lsladapter/liblsl/build/install/lib/. lib/
 
-# Install libxkbcommon and libbluetooth3 so linuxdeployqt can find it
+# Install some additional packages so linuxdeployqt can find them
 sudo apt-get update
 sudo apt-get install libxkbcommon-x11-0
 sudo apt-get install libxcb-icccm4
@@ -29,9 +29,10 @@ sudo mkdir -p -m777 mne-cpp
 # Copying built data to folder for easy packaging   
 cp -r ./bin ./lib mne-cpp/
 
-# linuxdeployqt uses mne_scan binary to resolve dependencies in current directory. 
+# linuxdeployqt uses mne_scan and mne_analyze binary to resolve dependencies
 cd mne-cpp
 ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2 -extra-plugins=renderers
+../linuxdeployqt-continuous-x86_64.AppImage bin/mne_analyze -verbose2 -extra-plugins=renderers
 
 # Creating archive of everything in current directory
 tar cfvz ../mne-cpp-linux-dynamic-x86_64.tar.gz ./*

--- a/tools/deployment/deploy_linux_static
+++ b/tools/deployment/deploy_linux_static
@@ -1,10 +1,4 @@
 # This script needs to be run from the top level mne-cpp repo folder
-# Delete folders which we do not want to ship
-rm -r bin/mne_rt_server_plugins
-rm -r bin/mne-cpp-test-data
-rm -r bin/mne_scan_plugins
-rm -r bin/mne_analyze_plugins
-
 # Install some additional packages so linuxdeployqt can find them
 sudo apt-get update
 sudo apt-get install libxkbcommon-x11-0
@@ -34,6 +28,12 @@ cd mne-cpp
 echo
 echo ldd ./bin/mne_scan
 ldd ./bin/mne_scan
+
+# Delete folders which we do not want to ship
+rm -r bin/mne_rt_server_plugins
+rm -r bin/mne-cpp-test-data
+rm -r bin/mne_scan_plugins
+rm -r bin/mne_analyze_plugins
 
 # Creating archive of everything in the bin directory
 tar cfvz ../mne-cpp-linux-static-x86_64.tar.gz bin/. lib/.

--- a/tools/deployment/deploy_linux_static
+++ b/tools/deployment/deploy_linux_static
@@ -1,0 +1,8 @@
+# Delete folders which we do not want to ship
+rm -r bin/mne_rt_server_plugins
+rm -r bin/mne-cpp-test-data
+rm -r bin/mne_scan_plugins
+rm -r bin/mne_analyze_plugins
+
+# Creating archive of everything in the bin directory
+tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/.

--- a/tools/deployment/deploy_linux_static
+++ b/tools/deployment/deploy_linux_static
@@ -31,5 +31,9 @@ cd mne-cpp
 ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2 -extra-plugins=renderers
 ../linuxdeployqt-continuous-x86_64.AppImage bin/mne_analyze -verbose2 -extra-plugins=renderers
 
+echo
+echo ldd ./bin/mne_scan
+ldd ./bin/mne_scan
+
 # Creating archive of everything in the bin directory
-tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/. lib/.
+tar cfvz ../mne-cpp-linux-static-x86_64.tar.gz bin/. lib/.

--- a/tools/deployment/deploy_linux_static
+++ b/tools/deployment/deploy_linux_static
@@ -1,8 +1,35 @@
+# This script needs to be run from the top level mne-cpp repo folder
 # Delete folders which we do not want to ship
 rm -r bin/mne_rt_server_plugins
 rm -r bin/mne-cpp-test-data
 rm -r bin/mne_scan_plugins
 rm -r bin/mne_analyze_plugins
 
+# Install some additional packages so linuxdeployqt can find them
+sudo apt-get update
+sudo apt-get install libxkbcommon-x11-0
+sudo apt-get install libxcb-icccm4
+sudo apt-get install libxcb-image0
+sudo apt-get install libxcb-keysyms1
+sudo apt-get install libxcb-render-util0
+sudo apt-get install libbluetooth3
+sudo apt-get install libxcb-xinerama0
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
+
+# Downloading linuxdeployqt from continious release
+wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+sudo chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+
+# Creating a directory for linuxdeployqt to create results 
+sudo mkdir -p -m777 mne-cpp
+
+# Copying built data to folder for easy packaging   
+cp -r ./bin ./lib mne-cpp/
+
+# linuxdeployqt uses mne_scan and mne_analyze binary to resolve dependencies
+cd mne-cpp
+../linuxdeployqt-continuous-x86_64.AppImage bin/mne_scan -verbose2 -extra-plugins=renderers
+../linuxdeployqt-continuous-x86_64.AppImage bin/mne_analyze -verbose2 -extra-plugins=renderers
+
 # Creating archive of everything in the bin directory
-tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/.
+tar cfvz mne-cpp-linux-static-x86_64.tar.gz bin/. lib/.

--- a/tools/deployment/deploy_macos
+++ b/tools/deployment/deploy_macos
@@ -38,6 +38,7 @@ rm -r bin/mne-cpp-test-data
 rm -r bin/mne_scan_plugins
 rm -r bin/mne_analyze_plugins
 rm -r bin/mne_rt_server_plugins
+rm -r bin/resources
 
 # Creating archive of all macos deployed applications
-tar cfvz mne-cpp-macos-dynamic-x86_64.tar.gz bin/. lib/.
+tar cfvz mne-cpp-macos-dynamic-x86_64.tar.gz bin/.

--- a/tools/deployment/deploy_macos_static
+++ b/tools/deployment/deploy_macos_static
@@ -1,0 +1,28 @@
+# This script needs to be run from the top level mne-cpp repo folder
+# Solve for dependencies for mne_scan.app bundle
+cp -a bin/resources/. bin/mne_scan.app/Contents/MacOS/resources
+
+# Solve for dependencies for mne_analyze.app bundle
+cp -a bin/resources/. bin/mne_analyze.app/Contents/MacOS/resources
+
+# Solve for dependencies for mne_rt_server.app bundle
+cp -a bin/resources/. bin/mne_rt_server.app/Contents/MacOS/resources
+
+# Solve for dependencies for mne_forward_solution.app bundle
+cp -a bin/resources/. bin/mne_forward_solution.app/Contents/MacOS/resources
+
+# Solve for dependencies for mne_dipole_fit.app bundle
+cp -a bin/resources/. bin/mne_dipole_fit.app/Contents/MacOS/resources
+
+# Solve for dependencies for mne_anonymize.app bundle
+cp -a bin/resources/. bin/mne_anonymize.app/Contents/MacOS/resources
+
+# Delete folders which we do not want to ship
+rm -r bin/mne-cpp-test-data
+rm -r bin/mne_scan_plugins
+rm -r bin/mne_analyze_plugins
+rm -r bin/mne_rt_server_plugins
+rm -r bin/resources
+
+# Creating archive of all macos deployed applications
+tar cfvz mne-cpp-macos-static-x86_64.tar.gz bin/.

--- a/tools/deployment/deploy_win.bat
+++ b/tools/deployment/deploy_win.bat
@@ -1,12 +1,14 @@
 Rem This script needs to be run from the top level mne-cpp repo folder
-# Solve for dependencies only mne_scan.exe and mnecppDisp3D.dll since it links all needed qt and mne-cpp libs
+Rem Solve for dependencies only mne_scan.exe and mnecppDisp3D.dll since it links all needed qt and mne-cpp libs
 windeployqt .\bin\mne_scan.exe
 windeployqt .\bin\mnecppDisp3D.dll
+
+Rem Copy LSL and Brainflowlibraries manually
 xcopy .\applications\mne_scan\plugins\brainflowboard\brainflow\installed\lib\* .\bin\ /s /i
 xcopy .\applications\mne_scan\plugins\lsladapter\liblsl\build\install\bin\lsl.dll .\bin\ /i
 
-# Delete folders which we do not want to ship
+Rem Delete folders which we do not want to ship
 Remove-Item 'bin/mne-cpp-test-data' -Recurse
 
-# Creating archive of all win deployed applications
+Rem Creating archive of all win deployed applications
 7z a mne-cpp-windows-dynamic-x86_64.zip ./bin

--- a/tools/deployment/deploy_win_static.bat
+++ b/tools/deployment/deploy_win_static.bat
@@ -1,0 +1,8 @@
+# Delete folders which we do not want to ship
+Remove-Item 'bin/mne_rt_server_plugins' -Recurse
+Remove-Item 'bin/mne-cpp-test-data' -Recurse
+Remove-Item 'bin/mne_scan_plugins' -Recurse
+Remove-Item 'bin/mne_analyze_plugins' -Recurse
+
+# Creating archive of everything in the bin directory
+7z a mne-cpp-windows-static-x86_64.zip ./bin

--- a/tools/deployment/deploy_win_static.bat
+++ b/tools/deployment/deploy_win_static.bat
@@ -1,3 +1,4 @@
+# This script needs to be run from the top level mne-cpp repo folder
 # Delete folders which we do not want to ship
 Remove-Item 'bin/mne_rt_server_plugins' -Recurse
 Remove-Item 'bin/mne-cpp-test-data' -Recurse


### PR DESCRIPTION
This PR includes:

- Update ubuntu runners
- Update dropbox links
- Update mne-cpp-test-data submodule to newest commit
- Create new static deployment scripts
- Use linuxdeployqt for linux static builds as well
- Update deployment documentation
- Link download links on our website to always point to dynamic versions

Note:

- Static deployment for Linux builds is still problematic, since the xcb platform plugin is not working. Static deployment for Win and MacOS work fine.