### PR TITLE
[FIX,ENH] Fix digitizer visualization and allow removing 3D items

### DIFF
--- a/libraries/disp/viewers/control3dview.cpp
+++ b/libraries/disp/viewers/control3dview.cpp
@@ -45,6 +45,7 @@
 
 #include <QMenu>
 #include <QSettings>
+#include <QMessageBox>
 
 //=============================================================================================================
 // EIGEN INCLUDES
@@ -181,6 +182,15 @@ void Control3DView::onTreeViewHeaderHide()
 
 //=============================================================================================================
 
+void Control3DView::onTreeViewRemoveItem(const QModelIndex& index)
+{
+    if(index.isValid()) {
+        m_pUi->m_treeView_loadedData->model()->removeRow(index.row(), index.parent());
+    }
+}
+
+//=============================================================================================================
+
 void Control3DView::onTreeViewDescriptionHide()
 {
     if(m_pUi->m_treeView_loadedData->isColumnHidden(1)) {
@@ -270,10 +280,20 @@ void Control3DView::onCustomContextMenuRequested(QPoint pos)
     //create custom context menu and actions
     QMenu *menu = new QMenu(this);
 
-    //**************** Hide header ****************
+    // Hide header
     QAction* pHideHeader = menu->addAction(tr("Toggle header"));
     connect(pHideHeader, &QAction::triggered,
             this, &Control3DView::onTreeViewHeaderHide);
+
+    // Remove item
+    QAction* pRemoveItem = menu->addAction(tr("Remove"));
+    connect(pRemoveItem, &QAction::triggered, [=]() {
+        if (QMessageBox::question(this,
+                                  tr("Remove item"),
+                                  tr("Are you sure you want to delete the item?")) == QMessageBox::Yes) {
+            onTreeViewRemoveItem(m_pUi->m_treeView_loadedData->indexAt(pos));
+        }
+    });
 
 //    QAction* pHideDesc = menu->addAction(tr("Toggle description"));
 //    connect(pHideDesc, &QAction::triggered,

--- a/libraries/disp/viewers/control3dview.h
+++ b/libraries/disp/viewers/control3dview.h
@@ -138,6 +138,12 @@ public:
 
     //=========================================================================================================
     /**
+     * Slot called when an item should be removed.
+     */
+    void onTreeViewRemoveItem(const QModelIndex &index);
+
+    //=========================================================================================================
+    /**
      * Slot called when tree view description visibilty changed.
      */
     void onTreeViewDescriptionHide();

--- a/libraries/disp3D/engine/model/items/digitizer/digitizersettreeitem.cpp
+++ b/libraries/disp3D/engine/model/items/digitizer/digitizersettreeitem.cpp
@@ -118,13 +118,16 @@ void DigitizerSetTreeItem::addData(const FIFFLIB::FiffDigPointSet& tDigitizer, Q
             switch (tDigitizer[i].ident) {
                 case FIFFV_POINT_LPA:
                     tLAP.append(tDigitizer[i]);
+                    tLAP.append(tDigitizer[i]);
                 break;
 
                 case FIFFV_POINT_NASION:
                     tNasion.append(tDigitizer[i]);
+                    tNasion.append(tDigitizer[i]);
                 break;
 
                 case FIFFV_POINT_RPA:
+                    tRAP.append(tDigitizer[i]);
                     tRAP.append(tDigitizer[i]);
                 break;
 
@@ -232,22 +235,22 @@ void DigitizerSetTreeItem::addData(const FIFFLIB::FiffDigPointSet& tDigitizer, Q
         }
 
         if(item->text() == "Nasion" && !tNasion.empty()) {
-            item->addData(tNasion, 0.002f, Qt::yellow);
+            item->addData(tNasion, 0.002f, Qt::green);
             bFoundNasionlItem = true;
         }
 
         if(item->text() == "LAP" && !tLAP.empty()) {
-            item->addData(tLAP, 0.002f, Qt::green);
+            item->addData(tLAP, 0.002f, Qt::red);
             bFoundLAPItem = true;
         }
 
         if(item->text() == "RAP" && !tRAP.empty()) {
-            item->addData(tRAP, 0.002f, Qt::magenta);
+            item->addData(tRAP, 0.002f, Qt::blue);
             bFoundRAPItem = true;
         }
 
         if(item->text() == "HPI" && !tHpi.empty()) {
-            item->addData(tHpi, 0.001f, Qt::red);
+            item->addData(tHpi, 0.001f, Qt::darkRed);
             bFoundHPIItem = true;
         }
 
@@ -267,7 +270,7 @@ void DigitizerSetTreeItem::addData(const FIFFLIB::FiffDigPointSet& tDigitizer, Q
         //Create a cardinal digitizer item
         QList<QStandardItem*> itemListCardinal;
         DigitizerTreeItem* digitizerItem = new DigitizerTreeItem(m_pRenderable3DEntity, Data3DTreeModelItemTypes::DigitizerItem,"Nasion");
-        digitizerItem->addData(tNasion, 0.002f, Qt::yellow);
+        digitizerItem->addData(tNasion, 0.002f, Qt::green);
         itemListCardinal << digitizerItem;
         itemListCardinal << new QStandardItem(digitizerItem->toolTip());
         this->appendRow(itemListCardinal);
@@ -277,7 +280,7 @@ void DigitizerSetTreeItem::addData(const FIFFLIB::FiffDigPointSet& tDigitizer, Q
         //Create a cardinal digitizer item
         QList<QStandardItem*> itemListCardinal;
         DigitizerTreeItem* digitizerItem = new DigitizerTreeItem(m_pRenderable3DEntity, Data3DTreeModelItemTypes::DigitizerItem,"LAP");
-        digitizerItem->addData(tLAP, 0.002f, Qt::green);
+        digitizerItem->addData(tLAP, 0.002f, Qt::red);
         itemListCardinal << digitizerItem;
         itemListCardinal << new QStandardItem(digitizerItem->toolTip());
         this->appendRow(itemListCardinal);
@@ -287,7 +290,7 @@ void DigitizerSetTreeItem::addData(const FIFFLIB::FiffDigPointSet& tDigitizer, Q
         //Create a cardinal digitizer item
         QList<QStandardItem*> itemListCardinal;
         DigitizerTreeItem* digitizerItem = new DigitizerTreeItem(m_pRenderable3DEntity, Data3DTreeModelItemTypes::DigitizerItem,"RAP");
-        digitizerItem->addData(tRAP, 0.002f, Qt::magenta);
+        digitizerItem->addData(tRAP, 0.002f, Qt::blue);
         itemListCardinal << digitizerItem;
         itemListCardinal << new QStandardItem(digitizerItem->toolTip());
         this->appendRow(itemListCardinal);
@@ -297,7 +300,7 @@ void DigitizerSetTreeItem::addData(const FIFFLIB::FiffDigPointSet& tDigitizer, Q
         //Create a hpi digitizer item
         QList<QStandardItem*> itemListHPI;
         DigitizerTreeItem* digitizerItem = new DigitizerTreeItem(m_pRenderable3DEntity, Data3DTreeModelItemTypes::DigitizerItem,"HPI");
-        digitizerItem->addData(tHpi, 0.001f, Qt::red);
+        digitizerItem->addData(tHpi, 0.001f, Qt::darkRed);
         itemListHPI << digitizerItem;
         itemListHPI << new QStandardItem(digitizerItem->toolTip());
         this->appendRow(itemListHPI);


### PR DESCRIPTION
This PR includes:

* Fix fiducial coloring problem in Disp3D.
* Change fiducial colors to match the ones of mne-python.
* Add remove option to context menu (right click) in the Control3DView. Subsequently, the 3D data is removed from the 3D data model and view.