### PR TITLE
[MAINT] Update to Qt 5.15.2

### DIFF
--- a/.github/workflows/buildqtbinaries.yml
+++ b/.github/workflows/buildqtbinaries.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         # Clone Qt5 repo
         cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.2
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
         # Create shadow build folder
@@ -34,11 +34,11 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        tar cfvz qt5_5151_static_binaries_linux.tar.gz ../Qt5_binaries/.
+        tar cfvz qt5_5152_static_binaries_linux.tar.gz ../Qt5_binaries/.
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5151_static_binaries_linux.tar.gz
-        path: qt5_5151_static_binaries_linux.tar.gz
+        name: qt5_5152_static_binaries_linux.tar.gz
+        path: qt5_5152_static_binaries_linux.tar.gz
 
   GenerateMacOSStaticBinaries:
     runs-on: macos-latest
@@ -50,7 +50,7 @@ jobs:
       run: |
         # Clone Qt5 repo
         cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.2
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
         # Create shadow build folder
@@ -64,11 +64,11 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        tar cfvz qt5_5151_static_binaries_macos.tar.gz ../Qt5_binaries/.
+        tar cfvz qt5_5152_static_binaries_macos.tar.gz ../Qt5_binaries/.
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5151_static_binaries_macos.tar.gz
-        path: qt5_5151_static_binaries_macos.tar.gz
+        name: qt5_5152_static_binaries_macos.tar.gz
+        path: qt5_5152_static_binaries_macos.tar.gz
 
   GenerateWinStaticBinaries:
     runs-on: windows-2019
@@ -90,7 +90,7 @@ jobs:
       run: |
         # Clone Qt5 repo
         cd ..
-        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.2
         cd qt5
         perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
         # Create shadow build folder
@@ -107,11 +107,11 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        7z a qt5_5151_static_binaries_win.zip ..\Qt5_binaries
+        7z a qt5_5152_static_binaries_win.zip ..\Qt5_binaries
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5151_static_binaries_win.zip
-        path: qt5_5151_static_binaries_win.zip
+        name: qt5_5152_static_binaries_win.zip
+        path: qt5_5152_static_binaries_win.zip
 
   GenerateWasmBinaries:
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.2
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
         # Configure Qt5
@@ -147,8 +147,8 @@ jobs:
     - name: Package binaries
       run: |
         # Create archive of the pre-built Qt binaries
-        tar cfvz qt5_5151_static_binaries_wasm.tar.gz ../Qt5_binaries/.
+        tar cfvz qt5_5152_static_binaries_wasm.tar.gz ../Qt5_binaries/.
     - uses: actions/upload-artifact@v1
       with:
-        name: qt5_5151_static_binaries_wasm.tar.gz
-        path: qt5_5151_static_binaries_wasm.tar.gz
+        name: qt5_5152_static_binaries_wasm.tar.gz
+        path: qt5_5152_static_binaries_wasm.tar.gz

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        qt: [5.15.1]
+        qt: [5.15.2]
         os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
@@ -215,7 +215,6 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        qt: [5.15.1]
         os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
@@ -235,21 +234,21 @@ jobs:
       if: matrix.os == 'ubuntu-16.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/ilwo7mu9muk48mf/qt5_5151_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/cm50t5fl62rspdl/qt5_5152_static_binaries_linux.tar.gz?dl=1
         mkdir ../Qt5_binaries
-        tar xvzf qt5_5151_static_binaries_linux.tar.gz -C ../ -P
+        tar xvzf qt5_5152_static_binaries_linux.tar.gz -C ../ -P
     - name: Install Qt (MacOS)
       if: matrix.os == 'macos-latest'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5151_static_binaries_macos.tar.gz https://www.dropbox.com/s/2hfv7q38k528tfz/qt5_5151_static_binaries_macos.tar.gz?dl=1
-        tar xvzf qt5_5151_static_binaries_macos.tar.gz -P
+        wget -O qt5_5152_static_binaries_macos.tar.gz https://www.dropbox.com/s/2s61xfnod6fwn2w/qt5_5152_static_binaries_macos.tar.gz?dl=1
+        tar xvzf qt5_5152_static_binaries_macos.tar.gz -P
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        Invoke-WebRequest https://www.dropbox.com/s/z745z290s9pknih/qt5_5151_static_binaries_win.zip?dl=1 -OutFile .\qt5_5151_static_binaries_win.zip
-        expand-archive -path "qt5_5151_static_binaries_win.zip" -destinationpath "..\"
+        Invoke-WebRequest https://www.dropbox.com/s/8bizfho6mgifgpb/qt5_5152_static_binaries_win.zip?dl=1 -OutFile .\qt5_5152_static_binaries_win.zip
+        expand-archive -path "qt5_5152_static_binaries_win.zip" -destinationpath "..\"
     - name: Install jom (Windows)
       if: matrix.os == 'windows-2019'
       run: |
@@ -309,13 +308,13 @@ jobs:
       if: (matrix.os == 'ubuntu-16.04') || (matrix.os == 'macos-latest')
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.15.0
+        version: 5.15.2
         modules: qtcharts
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.15.1
+        version: 5.15.2
         arch: win64_msvc2019_64
         modules: qtcharts
     - name: Install jom (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,15 +68,15 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/ilwo7mu9muk48mf/qt5_5151_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/cm50t5fl62rspdl/qt5_5152_static_binaries_linux.tar.gz?dl=1
         mkdir ../Qt5_binaries
-        tar xvzf qt5_5151_static_binaries_linux.tar.gz -C ../ -P
+        tar xvzf qt5_5152_static_binaries_linux.tar.gz -C ../ -P
     # Uncomment this if you want to build Qt statically in this workflow
     # - name: Compile static Qt version
     #   run: |
     #     # Clone Qt5 repo
     #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.2
     #     cd qt5
     #     ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
     #     # Create shadow build folder
@@ -124,14 +124,14 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        wget -O qt5_5151_static_binaries_macos.tar.gz https://www.dropbox.com/s/2hfv7q38k528tfz/qt5_5151_static_binaries_macos.tar.gz?dl=1
-        tar xzf qt5_5151_static_binaries_macos.tar.gz -P
+        wget -O qt5_5152_static_binaries_macos.tar.gz https://www.dropbox.com/s/2s61xfnod6fwn2w/qt5_5152_static_binaries_macos.tar.gz?dl=1
+        tar xzf qt5_5152_static_binaries_macos.tar.gz -P
     # Uncomment this if you want to build Qt statically in this workflow
     # - name: Compile static Qt version
     #   run: |
     #     # Clone Qt5 repo
     #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.2
     #     cd qt5
     #     ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
     #     # Create shadow build folder
@@ -189,14 +189,14 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        Invoke-WebRequest https://www.dropbox.com/s/z745z290s9pknih/qt5_5151_static_binaries_win.zip?dl=1 -OutFile .\qt5_5151_static_binaries_win.zip
-        expand-archive -path "qt5_5151_static_binaries_win.zip" -destinationpath "..\"
+        Invoke-WebRequest https://www.dropbox.com/s/8bizfho6mgifgpb/qt5_5152_static_binaries_win.zip?dl=1 -OutFile .\qt5_5152_static_binaries_win.zip
+        expand-archive -path "qt5_5152_static_binaries_win.zip" -destinationpath "..\"
     # Uncomment this if you want to build Qt statically in this workflow
     # - name: Compile static Qt version
     #   run: |
     #     # Clone Qt5 repo
     #     cd ..
-    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+    #     git clone https://code.qt.io/qt/qt5.git -b 5.15.2
     #     cd qt5
     #     perl init-repository -f --module-subset=qtbase,qtcharts,qtsvg,qt3d
     #     # Create shadow build folder
@@ -257,7 +257,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.15.1
+        version: 5.15.2
         modules: qtcharts
     - name: Compile BrainFlow submodule
       run: |
@@ -382,7 +382,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.15.1
+        version: 5.15.2
         arch: win64_msvc2019_64
         modules: qtcharts
     - name: Install jom
@@ -452,7 +452,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.15.1
+        version: 5.15.2
         modules: qtcharts
     - name: Configure and compile MNE-CPP
       run: |
@@ -589,7 +589,7 @@ jobs:
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.2
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
         # Configure Qt5

--- a/.github/workflows/testci.yml
+++ b/.github/workflows/testci.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        qt: [5.15.1]
+        qt: [5.15.2]
         os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
@@ -215,7 +215,6 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        qt: [5.15.1]
         os: [ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
@@ -235,21 +234,21 @@ jobs:
       if: matrix.os == 'ubuntu-16.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5151_static_binaries_linux.tar.gz https://www.dropbox.com/s/ilwo7mu9muk48mf/qt5_5151_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/ilwo7mu9muk48mf/qt5_5152_static_binaries_linux.tar.gz?dl=1
         mkdir ../Qt5_binaries
-        tar xvzf qt5_5151_static_binaries_linux.tar.gz -C ../ -P
+        tar xvzf qt5_5152_static_binaries_linux.tar.gz -C ../ -P
     - name: Install Qt (MacOS)
       if: matrix.os == 'macos-latest'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5151_static_binaries_macos.tar.gz https://www.dropbox.com/s/2hfv7q38k528tfz/qt5_5151_static_binaries_macos.tar.gz?dl=1
-        tar xvzf qt5_5151_static_binaries_macos.tar.gz -P
+        wget -O qt5_5152_static_binaries_macos.tar.gz https://www.dropbox.com/s/2hfv7q38k528tfz/qt5_5152_static_binaries_macos.tar.gz?dl=1
+        tar xvzf qt5_5152_static_binaries_macos.tar.gz -P
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        Invoke-WebRequest https://www.dropbox.com/s/z745z290s9pknih/qt5_5151_static_binaries_win.zip?dl=1 -OutFile .\qt5_5151_static_binaries_win.zip
-        expand-archive -path "qt5_5151_static_binaries_win.zip" -destinationpath "..\"
+        Invoke-WebRequest https://www.dropbox.com/s/z745z290s9pknih/qt5_5152_static_binaries_win.zip?dl=1 -OutFile .\qt5_5152_static_binaries_win.zip
+        expand-archive -path "qt5_5152_static_binaries_win.zip" -destinationpath "..\"
     - name: Install jom (Windows)
       if: matrix.os == 'windows-2019'
       run: |
@@ -315,7 +314,7 @@ jobs:
       if: matrix.os == 'windows-2019'
       uses: jurplel/install-qt-action@v2
       with:
-        version: 5.15.1
+        version: 5.15.2
         arch: win64_msvc2019_64
         modules: qtcharts
     - name: Install jom (Windows)

--- a/.github/workflows/wasmtest.yml
+++ b/.github/workflows/wasmtest.yml
@@ -28,7 +28,7 @@ jobs:
     #     # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
     #     wget -O qt5_5151_static_binaries_wasm.tar.gz https://www.dropbox.com/s/6uxny1ruajf3q91/qt5_5151_static_binaries_wasm.tar.gz?dl=1
     #     mkdir ../Qt5_binaries
-    #     tar xvzf qt5_5151_static_binaries_wasm.tar.gz -C ../ -P  
+    #     tar xvzf qt5_51512_static_binaries_wasm.tar.gz -C ../ -P  
     # Uncomment this if you want to build Qt statically in this workflow         
     - name: Compile wasm Qt version
       run: |
@@ -38,7 +38,7 @@ jobs:
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk/emsdk_env.sh
         # Clone Qt5 repo
-        git clone https://code.qt.io/qt/qt5.git -b 5.15.1
+        git clone https://code.qt.io/qt/qt5.git -b 5.15.2
         cd qt5
         ./init-repository -f --module-subset=qtbase,qtcharts,qtsvg
         # Configure Qt5

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -73,12 +73,6 @@ contains(MNECPP_CONFIG, static) {
     message("The static flag was detected. Building static version of MNE-CPP.")
 }
 
-# Do not support QOpenGLWidget support on macx because signal backgrounds are not plotted correctly (tested on Qt 5.15.0 and Qt 5.15.1)
-macx:minQtVersion(5, 15, 0) {
-    message("Excluding QOpenGLWidget on MacOS for Qt version greater than 5.15.0")
-    MNECPP_CONFIG += noQOpenGLWidget
-}
-
 ########################################### DIRECTORY DEFINITIONS #############################################
 
 # Repository directory


### PR DESCRIPTION
This PR includes:

- Update CI to use Qt 5.15.2, which solves [a problem](https://bugreports.qt.io/browse/QTBUG-88590) with Qt3D on MacOS
- Remove setting the noOpenGLWidget flag when Qt version is >5.15.0. This basically makes MNE Scan and the signal plotting useless on MacOS.