### PR TITLE
[DOC, BUG, MRG] Fix started.html links

### DIFF
--- a/doc/gh-pages/pages/install/buildguide_dynamic.md
+++ b/doc/gh-pages/pages/install/buildguide_dynamic.md
@@ -79,4 +79,4 @@ make -j8 # On Linux and MacOS
 
 ## Test the Build
 
-You might have to add the folders inclduing the Qt libraries to your OS's corresponding environment variables. In order to run the examples you must download the MNE-Sample-Data-Set from [here](https://osf.io/86qa2/download){:target="_blank" rel="noopener"} and extract the files to `mne-cpp/bin/MNE-sample-data`. Once finished you can try to run one of the examples, e.g., ex_disp3D. If the build was successfull the example should start and display a window including a 3D brain as well as a source localization result.
+You might have to add the folders inclduing the Qt libraries to your OS's corresponding environment variables. In order to run the examples you must download the MNE-Sample-Data-Set from [here](https://osf.io/86qa2/download){:target="_blank" rel="noopener"} and extract the files to `mne-cpp/bin/MNE-sample-data`. Once finished you can try to run one of the examples, e.g., ex_disp_3D. If the build was successfull the example should start and display a window including a 3D brain as well as a source localization result.

--- a/doc/gh-pages/started.md
+++ b/doc/gh-pages/started.md
@@ -10,7 +10,7 @@ This is the quickest way to get MNE-CPP up and running on your machine:
 
 **1 Download MNE-CPP**
 
-  [Download](../install/binaries.md) the latest stable release for the best stability, or the dev_build release for the latest features.
+  [Download](../pages/install/binaries.md) the latest stable release for the best stability, or the dev_build release for the latest features.
 
 **2 Unzip the downloaded file**
 
@@ -18,10 +18,10 @@ This is the quickest way to get MNE-CPP up and running on your machine:
 
 **3 Select the tool you wish to use from the `bin` folder**
 
-  Currently we offer a real-time application: [MNE-Scan](../learn/scan.md); a visualization/analysis application: [MNE Analyze](../learn/analyze.md); and a data anonymization tool: [MNE Anonymize](../learn/anonymize).
+  Currently we offer a real-time application: [MNE-Scan](../pages/learn/scan.md); a visualization/analysis application: [MNE Analyze](../learn/analyze.md); and a data anonymization tool: [MNE Anonymize](../pages/learn/anonymize).
 
-**4 Follow the [guides](../learn/learn.md) on how to use MNE-CPP tools**
+**4 Follow the [guides](../pages/learn/learn.md) on how to use MNE-CPP tools**
 
 ---
 
-If you'd like to develop with and contribute to MNE-CPP you can check out our guide on how to [build from source](../install/buildguide.md).
+If you'd like to develop with and contribute to MNE-CPP you can check out our guide on how to [build from source](../pages/install/buildguide.md).

--- a/doc/gh-pages/started.md
+++ b/doc/gh-pages/started.md
@@ -18,7 +18,7 @@ This is the quickest way to get MNE-CPP up and running on your machine:
 
 **3 Select the tool you wish to use from the `bin` folder**
 
-  Currently we offer a real-time application: [MNE-Scan](../pages/learn/scan.md); a visualization/analysis application: [MNE Analyze](../learn/analyze.md); and a data anonymization tool: [MNE Anonymize](../pages/learn/anonymize).
+  Currently we offer a real-time application: [MNE-Scan](../pages/learn/scan.md); a visualization/analysis application: [MNE Analyze](../pages/learn/analyze.md); and a data anonymization tool: [MNE Anonymize](../pages/learn/anonymize).
 
 **4 Follow the [guides](../pages/learn/learn.md) on how to use MNE-CPP tools**
 


### PR DESCRIPTION
It looks like a pages directory was added which broke the links that were in the directory above pages (i.e. doc).