### PR TITLE
[DOC] Fix links in docu

### DIFF
--- a/doc/gh-pages/pages/install/changelog.md
+++ b/doc/gh-pages/pages/install/changelog.md
@@ -40,12 +40,12 @@ MNE RtServer
 
 ### API librariers
 
-## Disp3D
+Disp3D
  * Fix fiducial coloring problem in Disp3D
  * Change fiducial colors to match the ones of mne-python
  * Add remove option to context menu (right click) in the Control3DView. Subsequently, the 3D data is removed from the 3D data model and view
 
-## Disp
+Disp
  * New Dipole Fit View.
 
 ### Continuous Integration 

--- a/doc/gh-pages/started.md
+++ b/doc/gh-pages/started.md
@@ -10,7 +10,7 @@ This is the quickest way to get MNE-CPP up and running on your machine:
 
 **1 Download MNE-CPP**
 
-  [Download](../pages/install/binaries.md) the latest stable release for the best stability, or the dev_build release for the latest features.
+  [Download](pages/install/binaries.md) the latest stable release for the best stability, or the dev_build release for the latest features.
 
 **2 Unzip the downloaded file**
 
@@ -18,10 +18,10 @@ This is the quickest way to get MNE-CPP up and running on your machine:
 
 **3 Select the tool you wish to use from the `bin` folder**
 
-  Currently we offer a real-time application: [MNE-Scan](../pages/learn/scan.md); a visualization/analysis application: [MNE Analyze](../pages/learn/analyze.md); and a data anonymization tool: [MNE Anonymize](../pages/learn/anonymize).
+  Currently we offer a real-time application: [MNE-Scan](pages/learn/scan.md); a visualization/analysis application: [MNE Analyze](pages/learn/analyze.md); and a data anonymization tool: [MNE Anonymize](pages/learn/anonymize.md).
 
-**4 Follow the [guides](../pages/learn/learn.md) on how to use MNE-CPP tools**
+**4 Follow the [guides](pages/learn/learn.md) on how to use MNE-CPP tools**
 
 ---
 
-If you'd like to develop with and contribute to MNE-CPP you can check out our guide on how to [build from source](../pages/install/buildguide.md).
+If you'd like to develop with and contribute to MNE-CPP you can check out our guide on how to [build from source](pages/install/buildguide.md).


### PR DESCRIPTION
This PR fixes some dead links which were introduced in #730. I did not see these in your PR @alexrockhill. Sry about that. I should have checked your PR by deploying your changes against Github Actions. A guide on how to do so yourself can be found [here](https://mne-cpp.github.io/pages/development/contr_docuimprovements.html). The setup only needs to be done once.

This PR also fixes some layout issues in the changelog.