### PR TITLE
[FIX] Fix speed of model rotation

### DIFF
--- a/libraries/disp3D/engine/model/3dhelpers/renderable3Dentity.cpp
+++ b/libraries/disp3D/engine/model/3dhelpers/renderable3Dentity.cpp
@@ -318,7 +318,7 @@ void Renderable3DEntity::setRotY(float rotY)
         return;
     }
 
-    // Revert X rotation translation because we are in the set (not apply) function
+    // Revert Y rotation translation because we are in the set (not apply) function
     QMatrix4x4 m = m_pTransform->matrix();
     m.rotate(-m_fRotY + rotY, QVector3D(0.0f, 1.0f, 0.0f));
     m_pTransform->setMatrix(m);
@@ -351,7 +351,7 @@ void Renderable3DEntity::setRotZ(float rotZ)
         return;
     }
 
-    // Revert X rotation translation because we are in the set (not apply) function
+    // Revert Z rotation translation because we are in the set (not apply) function
     QMatrix4x4 m = m_pTransform->matrix();
     m.rotate(-m_fRotZ + rotZ, QVector3D(0.0f, 0.0f, 1.0f));
     m_pTransform->setMatrix(m);

--- a/libraries/disp3D/engine/view/view3D.h
+++ b/libraries/disp3D/engine/view/view3D.h
@@ -241,7 +241,8 @@ protected:
     QPointer<Qt3DRender::QRenderCaptureReply>   m_pScreenCaptureReply;          /**< The capture reply object to save screenshots. */
     QPointer<Qt3DRender::QObjectPicker>         m_pPicker;                      /**< The Picker entity. */
 
-    QList<QPointer<QPropertyAnimation> >        m_lPropertyAnimations;          /**< The animations for each 3D object. */
+    QSharedPointer<QParallelAnimationGroup>     m_pParallelAnimationGroup;      /**< The animations for each 3D object. */
+
     QList<QPointer<Qt3DRender::QPointLight> >   m_lLightSources;                /**< The light sources. */
 
 signals:


### PR DESCRIPTION
This PR includes:

- Docu fixes in Renderable3DEntity
- Fix applying the same rotation animation on the parent and children of a Renderable3DEntity. This led to <the number of children> faster animations. We now only apply the animation on the parent. This solves one problem reported in #731.
- Make use of parallel animation starting via `QParallelAnimationGroup`.