### PR TITLE
[ENH] Make test_win powershell script to be callable from anywhere

### DIFF
--- a/tools/testing/test_win.ps1
+++ b/tools/testing/test_win.ps1
@@ -1,1 +1,4 @@
+$CURRENT_PATH = pwd
+cd $PSScriptRoot/../..
 Get-ChildItem -Filter bin/test_*.exe | ForEach {Write-Output "" "" Starting $_.Fullname; &$_.Fullname}
+cd $CURRENT_PATH


### PR DESCRIPTION
This makes it easier for the developer to be able to test the tests locally, from a terminal. 