### PR TITLE
[BUG] Orbit camera instead of rotating objects in 3D view

### DIFF
--- a/applications/mne_analyze/plugins/view3d/view3d.cpp
+++ b/applications/mne_analyze/plugins/view3d/view3d.cpp
@@ -149,7 +149,7 @@ QWidget *View3D::getView()
     connect(this, &View3D::sceneColorChanged,
             m_pView3D, &DISP3DLIB::View3D::setSceneColor);
     connect(this, &View3D::rotationChanged,
-            m_pView3D, &DISP3DLIB::View3D::startStopModelRotation);
+            m_pView3D, &DISP3DLIB::View3D::startStopCameraRotation);
     connect(this, &View3D::showCoordAxis,
             m_pView3D, &DISP3DLIB::View3D::toggleCoordAxis);
     connect(this, &View3D::showFullScreen,

--- a/applications/mne_scan/libs/scDisp/realtime3dwidget.cpp
+++ b/applications/mne_scan/libs/scDisp/realtime3dwidget.cpp
@@ -374,7 +374,7 @@ void RealTime3DWidget::initDisplayControllWidgets()
             m_p3DView.data(), &View3D::setSceneColor);
 
     connect(pControl3DView, &Control3DView::rotationChanged,
-            m_p3DView.data(), &View3D::startStopModelRotation);
+            m_p3DView.data(), &View3D::startStopCameraRotation);
 
     connect(pControl3DView, &Control3DView::showCoordAxis,
             m_p3DView.data(), &View3D::toggleCoordAxis);

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
@@ -65,7 +65,7 @@ using namespace DISP3DLIB;
 
 OrbitalCameraController::OrbitalCameraController(Qt3DCore::QNode *pParent)
     :QAbstractCameraController(pParent)
-    , m_angle(0.0f)
+    , m_rotating(0.0f)
 {
     initController();
 }
@@ -141,22 +141,16 @@ void OrbitalCameraController::initController()
 
 //=============================================================================================================
 
-void OrbitalCameraController::setAngle(float angle)
+void OrbitalCameraController::setRotating(int count)
 {
     Qt3DRender::QCamera *pCamera = this->camera();
 
-    if (!qFuzzyCompare(angle, m_angle)) {
-        m_angle = angle;
-        pCamera->setPosition(QVector3D(0.0f, -0.4f, -0.25f));
-        pCamera->setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
-        pCamera->setUpVector(QVector3D(0.0f, 1.0f, 0.0f));
-        pCamera->tiltAboutViewCenter(180);
-        QQuaternion quat = QQuaternion::QQuaternion::fromEulerAngles(0,0,angle);
-        pCamera->rotateAboutViewCenter(quat);
-    }
+    m_rotating = count;
+    QQuaternion quat = QQuaternion::QQuaternion::fromEulerAngles(0,0,0.5);
+    pCamera->rotateAboutViewCenter(quat);
 }
 
-float OrbitalCameraController::angle() const
+int OrbitalCameraController::rotating() const
 {
-    return m_angle;
+    return m_rotating;
 }

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
@@ -146,7 +146,7 @@ void OrbitalCameraController::setRotating(int count)
     Qt3DRender::QCamera *pCamera = this->camera();
 
     m_rotating = count;
-    QQuaternion quat = QQuaternion::QQuaternion::fromEulerAngles(0,0,0.5);
+    QQuaternion quat = QQuaternion::QQuaternion::fromEulerAngles(0,0,m_fAutoRotationSpeed);
     pCamera->rotateAboutViewCenter(quat);
 }
 

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
@@ -65,9 +65,6 @@ using namespace DISP3DLIB;
 
 OrbitalCameraController::OrbitalCameraController(Qt3DCore::QNode *pParent)
     :QAbstractCameraController(pParent)
-    , m_target(nullptr)
-    , m_matrix()
-    , m_radius(1.0f)
     , m_angle(0.0f)
 {
     initController();
@@ -144,31 +141,6 @@ void OrbitalCameraController::initController()
 
 //=============================================================================================================
 
-void OrbitalCameraController::setTarget(Qt3DCore::QTransform *target)
-{
-    if (m_target != target) {
-        m_target = target;
-    }
-}
-
-Qt3DCore::QTransform *OrbitalCameraController::target() const
-{
-    return m_target;
-}
-
-void OrbitalCameraController::setRadius(float radius)
-{
-    if (!qFuzzyCompare(radius, m_radius)) {
-        m_radius = radius;
-        updateMatrix();
-    }
-}
-
-float OrbitalCameraController::radius() const
-{
-    return m_radius;
-}
-
 void OrbitalCameraController::setAngle(float angle)
 {
     Qt3DRender::QCamera *pCamera = this->camera();
@@ -187,12 +159,4 @@ void OrbitalCameraController::setAngle(float angle)
 float OrbitalCameraController::angle() const
 {
     return m_angle;
-}
-
-void OrbitalCameraController::updateMatrix()
-{
-    m_matrix.setToIdentity();
-    m_matrix.rotate(m_angle, QVector3D(0.0f, 1.0f, 0.0f));
-    m_matrix.translate(m_radius, 0.0f, 0.0f);
-    m_target->setMatrix(m_matrix);
 }

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
@@ -171,9 +171,16 @@ float OrbitalCameraController::radius() const
 
 void OrbitalCameraController::setAngle(float angle)
 {
+    Qt3DRender::QCamera *pCamera = this->camera();
+
     if (!qFuzzyCompare(angle, m_angle)) {
         m_angle = angle;
-        updateMatrix();
+        pCamera->setPosition(QVector3D(0.0f, -0.4f, -0.25f));
+        pCamera->setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
+        pCamera->setUpVector(QVector3D(0.0f, 1.0f, 0.0f));
+        pCamera->tiltAboutViewCenter(180);
+        QQuaternion quat = QQuaternion::QQuaternion::fromEulerAngles(0,0,angle);
+        pCamera->rotateAboutViewCenter(quat);
     }
 }
 

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
@@ -65,7 +65,7 @@ using namespace DISP3DLIB;
 
 OrbitalCameraController::OrbitalCameraController(Qt3DCore::QNode *pParent)
     :QAbstractCameraController(pParent)
-    , m_rotating(0.0f)
+    , m_iRotating(0.0f)
 {
     initController();
 }
@@ -75,10 +75,10 @@ OrbitalCameraController::OrbitalCameraController(Qt3DCore::QNode *pParent)
 void OrbitalCameraController::invertCameraRotation(bool newStatusFlag)
 {
     if(newStatusFlag == true) {
-        m_rotationInversFactor = -1.0f;
+        m_fRotationInverseFactor = -1.0f;
     }
     else {
-        m_rotationInversFactor = 1.0f;
+        m_fRotationInverseFactor = 1.0f;
     }
 }
 
@@ -102,9 +102,9 @@ void OrbitalCameraController::moveCamera(const Qt3DExtras::QAbstractCameraContro
         }
         else {
             // orbit around view center
-            pCamera->panAboutViewCenter(state.rxAxisValue * this->lookSpeed() * dt * m_rotationInversFactor,
+            pCamera->panAboutViewCenter(state.rxAxisValue * this->lookSpeed() * dt * m_fRotationInverseFactor,
                                         QVector3D(0.0f, 0.0f, 1.0f));
-            pCamera->tiltAboutViewCenter(state.ryAxisValue * this->lookSpeed() * dt * m_rotationInversFactor);
+            pCamera->tiltAboutViewCenter(state.ryAxisValue * this->lookSpeed() * dt * m_fRotationInverseFactor);
         }
     }
 
@@ -125,9 +125,9 @@ void OrbitalCameraController::moveCamera(const Qt3DExtras::QAbstractCameraContro
     }
 
     //Keyboard input: orbit around view center
-    pCamera->panAboutViewCenter(state.txAxisValue * this->lookSpeed() * dt * 0.8f  * m_rotationInversFactor,
+    pCamera->panAboutViewCenter(state.txAxisValue * this->lookSpeed() * dt * 0.8f  * m_fRotationInverseFactor,
                                 QVector3D(0.0f, 0.0f, 1.0f));
-    pCamera->tiltAboutViewCenter(state.tyAxisValue * this->lookSpeed()* dt * 0.8f * m_rotationInversFactor);
+    pCamera->tiltAboutViewCenter(state.tyAxisValue * this->lookSpeed()* dt * 0.8f * m_fRotationInverseFactor);
 }
 
 //=============================================================================================================
@@ -145,12 +145,14 @@ void OrbitalCameraController::setRotating(int count)
 {
     Qt3DRender::QCamera *pCamera = this->camera();
 
-    m_rotating = count;
+    m_iRotating = count;
     QQuaternion quat = QQuaternion::QQuaternion::fromEulerAngles(0,0,m_fAutoRotationSpeed);
     pCamera->rotateAboutViewCenter(quat);
 }
 
+//=============================================================================================================
+
 int OrbitalCameraController::rotating() const
 {
-    return m_rotating;
+    return m_iRotating;
 }

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.cpp
@@ -43,6 +43,7 @@
 //=============================================================================================================
 
 #include <Qt3DRender/QCamera>
+#include <Qt3DCore/qtransform.h>
 
 //=============================================================================================================
 // EIGEN INCLUDES
@@ -64,6 +65,10 @@ using namespace DISP3DLIB;
 
 OrbitalCameraController::OrbitalCameraController(Qt3DCore::QNode *pParent)
     :QAbstractCameraController(pParent)
+    , m_target(nullptr)
+    , m_matrix()
+    , m_radius(1.0f)
+    , m_angle(0.0f)
 {
     initController();
 }
@@ -138,3 +143,49 @@ void OrbitalCameraController::initController()
 }
 
 //=============================================================================================================
+
+void OrbitalCameraController::setTarget(Qt3DCore::QTransform *target)
+{
+    if (m_target != target) {
+        m_target = target;
+    }
+}
+
+Qt3DCore::QTransform *OrbitalCameraController::target() const
+{
+    return m_target;
+}
+
+void OrbitalCameraController::setRadius(float radius)
+{
+    if (!qFuzzyCompare(radius, m_radius)) {
+        m_radius = radius;
+        updateMatrix();
+    }
+}
+
+float OrbitalCameraController::radius() const
+{
+    return m_radius;
+}
+
+void OrbitalCameraController::setAngle(float angle)
+{
+    if (!qFuzzyCompare(angle, m_angle)) {
+        m_angle = angle;
+        updateMatrix();
+    }
+}
+
+float OrbitalCameraController::angle() const
+{
+    return m_angle;
+}
+
+void OrbitalCameraController::updateMatrix()
+{
+    m_matrix.setToIdentity();
+    m_matrix.rotate(m_angle, QVector3D(0.0f, 1.0f, 0.0f));
+    m_matrix.translate(m_radius, 0.0f, 0.0f);
+    m_target->setMatrix(m_matrix);
+}

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.h
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.h
@@ -89,9 +89,7 @@ namespace DISP3DLIB {
 class DISP3DSHARED_EXPORT OrbitalCameraController : public Qt3DExtras::QAbstractCameraController
 {
    Q_OBJECT
-   Q_PROPERTY(Qt3DCore::QTransform* target READ target WRITE setTarget)
-   Q_PROPERTY(float radius READ radius WRITE setRadius)
-   Q_PROPERTY(float angle READ angle WRITE setAngle)
+   Q_PROPERTY(float angle READ angle WRITE setAngle)                 /**< Access for QPropertyAnimation */
 
 public:
     typedef QSharedPointer<OrbitalCameraController> SPtr;            /**< Shared pointer type for OrbitalCameraController. */
@@ -117,17 +115,12 @@ public:
      */
     void invertCameraRotation(bool newStatusFlag);
 
-    void setTarget(Qt3DCore::QTransform *target);
-    Qt3DCore::QTransform *target() const;
-
-    void setRadius(float radius);
-    float radius() const;
-
+    //=========================================================================================================
+    /**
+     * Sets the angle of the camera for rotating around
+     */
     void setAngle(float angle);
     float angle() const;
-
-protected:
-    void updateMatrix();
 
 private:
     //=========================================================================================================
@@ -158,10 +151,7 @@ private:
 
     float m_rotationInversFactor = 1.0f;             /**< The factor used to invers the camera rotation. */
     const float m_fZoomInLimit = 0.04f;         /**< The minimum distance of the camera to the the view center. */
-    Qt3DCore::QTransform *m_target;
-    QMatrix4x4 m_matrix;
-    float m_radius;
-    float m_angle;
+    float m_angle;                             /**< The angle of the camera with regards to the the view center. */
 };
 
 //=============================================================================================================

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.h
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.h
@@ -151,6 +151,7 @@ private:
 
     float m_rotationInversFactor = 1.0f;             /**< The factor used to invers the camera rotation. */
     const float m_fZoomInLimit = 0.04f;         /**< The minimum distance of the camera to the the view center. */
+    const float m_fAutoRotationSpeed = 1.0f;         /**< The speed that automatic rotation rotates */
     int m_rotating;                      /**< How long the camera has been rotating with regards to the view center. */
 };
 

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.h
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.h
@@ -48,6 +48,13 @@
 
 #include <QSharedPointer>
 #include <QVector3D>
+#include <QObject>
+#include <QMatrix4x4>
+
+namespace Qt3DCore {
+class QTransform;
+}
+
 
 //=============================================================================================================
 // EIGEN INCLUDES
@@ -82,6 +89,9 @@ namespace DISP3DLIB {
 class DISP3DSHARED_EXPORT OrbitalCameraController : public Qt3DExtras::QAbstractCameraController
 {
    Q_OBJECT
+   Q_PROPERTY(Qt3DCore::QTransform* target READ target WRITE setTarget)
+   Q_PROPERTY(float radius READ radius WRITE setRadius)
+   Q_PROPERTY(float angle READ angle WRITE setAngle)
 
 public:
     typedef QSharedPointer<OrbitalCameraController> SPtr;            /**< Shared pointer type for OrbitalCameraController. */
@@ -106,6 +116,18 @@ public:
      * @param[in] newStatusFlag      The new status of the inversion
      */
     void invertCameraRotation(bool newStatusFlag);
+
+    void setTarget(Qt3DCore::QTransform *target);
+    Qt3DCore::QTransform *target() const;
+
+    void setRadius(float radius);
+    float radius() const;
+
+    void setAngle(float angle);
+    float angle() const;
+
+protected:
+    void updateMatrix();
 
 private:
     //=========================================================================================================
@@ -136,6 +158,10 @@ private:
 
     float m_rotationInversFactor = 1.0f;             /**< The factor used to invers the camera rotation. */
     const float m_fZoomInLimit = 0.04f;         /**< The minimum distance of the camera to the the view center. */
+    Qt3DCore::QTransform *m_target;
+    QMatrix4x4 m_matrix;
+    float m_radius;
+    float m_angle;
 };
 
 //=============================================================================================================

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.h
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.h
@@ -109,7 +109,7 @@ public:
 
     //=========================================================================================================
     /**
-     * Turns invers rotation of the camera on and off.
+     * Turns inverse rotation of the camera on and off.
      *
      * @param[in] newStatusFlag      The new status of the inversion
      */
@@ -118,8 +118,17 @@ public:
     //=========================================================================================================
     /**
      * Sets the angle of the camera for rotating around
+     *
+     * @param[in] count      The counter for how long the rotation has been happening
      */
-    void setRotating(int count);     /* The counter for how long the rotation has been happening. */
+    void setRotating(int count);
+
+    //=========================================================================================================
+    /**
+     * Queries the camera rotating counter
+     *
+     * @return The rotation counter
+     */
     int rotating() const;
 
 private:
@@ -149,10 +158,11 @@ private:
      */
     inline float distance(const QVector3D &firstPoint, const QVector3D &secondPoint) const;
 
-    float m_rotationInversFactor = 1.0f;             /**< The factor used to invers the camera rotation. */
-    const float m_fZoomInLimit = 0.04f;         /**< The minimum distance of the camera to the the view center. */
-    const float m_fAutoRotationSpeed = 1.0f;         /**< The speed that automatic rotation rotates */
-    int m_rotating;                      /**< How long the camera has been rotating with regards to the view center. */
+    float m_fRotationInverseFactor = 1.0f;      /**< The factor used to invers the camera rotation. */
+    const float m_fZoomInLimit = 0.04f;         /**< The minimum distance of the camera to the view center. */
+    const float m_fAutoRotationSpeed = 1.0f;    /**< The speed that automatic rotation rotates */
+    int m_iRotating;                            /**< How long the camera has been rotating with regards
+                                                     to the view center. */
 };
 
 //=============================================================================================================

--- a/libraries/disp3D/engine/view/orbitalcameracontroller.h
+++ b/libraries/disp3D/engine/view/orbitalcameracontroller.h
@@ -89,7 +89,7 @@ namespace DISP3DLIB {
 class DISP3DSHARED_EXPORT OrbitalCameraController : public Qt3DExtras::QAbstractCameraController
 {
    Q_OBJECT
-   Q_PROPERTY(float angle READ angle WRITE setAngle)                 /**< Access for QPropertyAnimation */
+   Q_PROPERTY(int rotating READ rotating WRITE setRotating)                 /**< Access for QPropertyAnimation */
 
 public:
     typedef QSharedPointer<OrbitalCameraController> SPtr;            /**< Shared pointer type for OrbitalCameraController. */
@@ -119,8 +119,8 @@ public:
     /**
      * Sets the angle of the camera for rotating around
      */
-    void setAngle(float angle);
-    float angle() const;
+    void setRotating(int count);     /* The counter for how long the rotation has been happening. */
+    int rotating() const;
 
 private:
     //=========================================================================================================
@@ -151,7 +151,7 @@ private:
 
     float m_rotationInversFactor = 1.0f;             /**< The factor used to invers the camera rotation. */
     const float m_fZoomInLimit = 0.04f;         /**< The minimum distance of the camera to the the view center. */
-    float m_angle;                             /**< The angle of the camera with regards to the the view center. */
+    int m_rotating;                      /**< How long the camera has been rotating with regards to the view center. */
 };
 
 //=============================================================================================================

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -380,22 +380,15 @@ void View3D::setCameraRotation(float fAngle)
 void View3D::startStopCameraRotation(bool checked)
 {
     if(!m_pCameraAnimation) {
-        //Qt3DCore::QTransform *pCameraTransform = new Qt3DCore::QTransform;
         m_pCameraAnimation = new QPropertyAnimation(m_pCamController, "angle");
-        //m_pCameraAnimation->setTargetObject(m_pCamController);
-        //m_pCamController->setTarget(pCameraTransform);
-        //m_pCamController->setRadius(m_pCamera->position().length());
-        //m_pCameraAnimation->setPropertyName("angle");
-        m_pCameraAnimation->setStartValue(QVariant::fromValue(0));
-        m_pCameraAnimation->setEndValue(QVariant::fromValue(360));
+        m_pCameraAnimation->setStartValue(QVariant::fromValue(m_pCamController->angle()));
+        m_pCameraAnimation->setEndValue(QVariant::fromValue(m_pCamController->angle() + 360));
         m_pCameraAnimation->setDuration(10000);
         m_pCameraAnimation->setLoopCount(-1);
-        //m_pCamera->addComponent(pCameraTransform);
     }
 
     if(checked) {
         //Start animation
-        //m_pCamera->panAboutViewCenter(0.5, QVector3D(0.0f, 0.0f, 1.0f));
         m_pCameraAnimation->start();
     }
     else {

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -380,9 +380,14 @@ void View3D::setCameraRotation(float fAngle)
 void View3D::startStopCameraRotation(bool checked)
 {
     if(!m_pCameraAnimation) {
-        m_pCameraAnimation = new QPropertyAnimation(m_pCamera, QByteArrayLiteral("panAboutViewCenter"));
-        m_pCameraAnimation->setStartValue(QVariant::fromValue(10));
-        m_pCameraAnimation->setEndValue(QVariant::fromValue(10));
+        Qt3DCore::QTransform *pCameraTransform = new Qt3DCore::QTransform;
+        m_pCameraAnimation = new QPropertyAnimation(pCameraTransform);
+        m_pCameraAnimation->setTargetObject(m_pCamController);
+        m_pCamController->setTarget(pCameraTransform);
+        m_pCamController->setRadius(m_pCamera->position().length());
+        m_pCameraAnimation->setPropertyName("angle");
+        m_pCameraAnimation->setStartValue(QVariant::fromValue(0));
+        m_pCameraAnimation->setEndValue(QVariant::fromValue(360));
         m_pCameraAnimation->setDuration(10000);
         m_pCameraAnimation->setLoopCount(-1);
     }

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -114,8 +114,8 @@ View3D::View3D()
     m_pCamera->lens()->setPerspectiveProjection(45.0f, this->width()/this->height(), 0.01f, 5000.0f);
     m_pFrameGraph->setCamera(m_pCamera);
 
-    OrbitalCameraController *pCamController = new OrbitalCameraController(m_pRootEntity);
-    pCamController->setCamera(m_pCamera);
+    OrbitalCameraController *m_pCamController = new OrbitalCameraController(m_pRootEntity);
+    m_pCamController->setCamera(m_pCamera);
 
     createCoordSystem(m_pRootEntity);
     toggleCoordAxis(false);
@@ -358,27 +358,6 @@ void View3D::createCoordSystem(Qt3DCore::QEntity* parent)
 
 //=============================================================================================================
 
-void View3D::startModelRotationRecursive(QObject* pObject)
-{
-    //TODO this won't work with QEntities
-    if(Renderable3DEntity* pItem = dynamic_cast<Renderable3DEntity*>(pObject)) {
-        if(!dynamic_cast<Renderable3DEntity*>(pItem->parent())) {
-            QPropertyAnimation *anim = new QPropertyAnimation(pItem, QByteArrayLiteral("rotZ"));
-            anim->setDuration(30000);
-            anim->setStartValue(QVariant::fromValue(pItem->rotZ()));
-            anim->setEndValue(QVariant::fromValue(pItem->rotZ() + 360.0f));
-            anim->setLoopCount(-1);
-            m_pParallelAnimationGroup->addAnimation(anim);
-        }
-    }
-
-    for(int i = 0; i < pObject->children().size(); ++i) {
-        startModelRotationRecursive(pObject->children().at(i));
-    }
-}
-
-//=============================================================================================================
-
 void View3D::setCameraRotation(float fAngle)
 {
     m_pCamera->setPosition(QVector3D(0.0f, -0.4f, -0.25f));
@@ -398,23 +377,21 @@ void View3D::setCameraRotation(float fAngle)
 
 //=============================================================================================================
 
-void View3D::startStopModelRotation(bool checked)
+void View3D::startStopCameraRotation(bool checked)
 {
-    if(!m_pParallelAnimationGroup) {
-        m_pParallelAnimationGroup = QSharedPointer<QParallelAnimationGroup>::create();
+    if(!m_pCameraAnimation) {
+        m_pCameraAnimation = new QPropertyAnimation(m_pCamera, QByteArrayLiteral("panAboutViewCenter"));
+        m_pCameraAnimation->setStartValue(QVariant::fromValue(10));
+        m_pCameraAnimation->setEndValue(QVariant::fromValue(10));
+        m_pCameraAnimation->setDuration(10000);
+        m_pCameraAnimation->setLoopCount(-1);
     }
 
     if(checked) {
         //Start animation
-        m_pParallelAnimationGroup->clear();
-
-        for(int i = 0; i < m_p3DObjectsEntity->children().size(); ++i) {
-            startModelRotationRecursive(m_p3DObjectsEntity->children().at(i));
-        }
-
-        m_pParallelAnimationGroup->start();
+        m_pCameraAnimation->start();
     }
     else {
-        m_pParallelAnimationGroup->stop();
+        m_pCameraAnimation->stop();
     }
 }

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -92,6 +92,7 @@ View3D::View3D()
 , m_pLightEntity(new Qt3DCore::QEntity(m_pRootEntity))
 , m_pCamera(this->camera())
 , m_pPicker(new Qt3DRender::QObjectPicker(m_pRootEntity))
+, m_pCamController(new OrbitalCameraController(m_pRootEntity))
 {
     //Root entity
     this->setRootEntity(m_pRootEntity);
@@ -114,7 +115,6 @@ View3D::View3D()
     m_pCamera->lens()->setPerspectiveProjection(45.0f, this->width()/this->height(), 0.01f, 5000.0f);
     m_pFrameGraph->setCamera(m_pCamera);
 
-    OrbitalCameraController *m_pCamController = new OrbitalCameraController(m_pRootEntity);
     m_pCamController->setCamera(m_pCamera);
 
     createCoordSystem(m_pRootEntity);
@@ -380,20 +380,22 @@ void View3D::setCameraRotation(float fAngle)
 void View3D::startStopCameraRotation(bool checked)
 {
     if(!m_pCameraAnimation) {
-        Qt3DCore::QTransform *pCameraTransform = new Qt3DCore::QTransform;
-        m_pCameraAnimation = new QPropertyAnimation(pCameraTransform);
-        m_pCameraAnimation->setTargetObject(m_pCamController);
-        m_pCamController->setTarget(pCameraTransform);
-        m_pCamController->setRadius(m_pCamera->position().length());
-        m_pCameraAnimation->setPropertyName("angle");
+        //Qt3DCore::QTransform *pCameraTransform = new Qt3DCore::QTransform;
+        m_pCameraAnimation = new QPropertyAnimation(m_pCamController, "angle");
+        //m_pCameraAnimation->setTargetObject(m_pCamController);
+        //m_pCamController->setTarget(pCameraTransform);
+        //m_pCamController->setRadius(m_pCamera->position().length());
+        //m_pCameraAnimation->setPropertyName("angle");
         m_pCameraAnimation->setStartValue(QVariant::fromValue(0));
         m_pCameraAnimation->setEndValue(QVariant::fromValue(360));
         m_pCameraAnimation->setDuration(10000);
         m_pCameraAnimation->setLoopCount(-1);
+        //m_pCamera->addComponent(pCameraTransform);
     }
 
     if(checked) {
         //Start animation
+        //m_pCamera->panAboutViewCenter(0.5, QVector3D(0.0f, 0.0f, 1.0f));
         m_pCameraAnimation->start();
     }
     else {

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -380,9 +380,9 @@ void View3D::setCameraRotation(float fAngle)
 void View3D::startStopCameraRotation(bool checked)
 {
     if(!m_pCameraAnimation) {
-        m_pCameraAnimation = new QPropertyAnimation(m_pCamController, "angle");
-        m_pCameraAnimation->setStartValue(QVariant::fromValue(m_pCamController->angle()));
-        m_pCameraAnimation->setEndValue(QVariant::fromValue(m_pCamController->angle() + 360));
+        m_pCameraAnimation = new QPropertyAnimation(m_pCamController, "rotating");
+        m_pCameraAnimation->setStartValue(QVariant::fromValue(1));
+        m_pCameraAnimation->setEndValue(QVariant::fromValue(10000));
         m_pCameraAnimation->setDuration(10000);
         m_pCameraAnimation->setLoopCount(-1);
     }

--- a/libraries/disp3D/engine/view/view3D.cpp
+++ b/libraries/disp3D/engine/view/view3D.cpp
@@ -217,16 +217,16 @@ void View3D::setSceneColor(const QColor& colSceneColor)
 
 //=============================================================================================================
 
-void View3D::toggleCoordAxis(bool checked)
+void View3D::toggleCoordAxis(bool bChecked)
 {
-    m_pCoordSysEntity->setEnabled(checked);
+    m_pCoordSysEntity->setEnabled(bChecked);
 }
 
 //=============================================================================================================
 
-void View3D::showFullScreen(bool checked)
+void View3D::showFullScreen(bool bChecked)
 {
-    if(checked) {
+    if(bChecked) {
         this->Qt3DWindow::showFullScreen();
     }
     else {
@@ -377,7 +377,7 @@ void View3D::setCameraRotation(float fAngle)
 
 //=============================================================================================================
 
-void View3D::startStopCameraRotation(bool checked)
+void View3D::startStopCameraRotation(bool bChecked)
 {
     if(!m_pCameraAnimation) {
         m_pCameraAnimation = new QPropertyAnimation(m_pCamController, "rotating");
@@ -387,7 +387,7 @@ void View3D::startStopCameraRotation(bool checked)
         m_pCameraAnimation->setLoopCount(-1);
     }
 
-    if(checked) {
+    if(bChecked) {
         //Start animation
         m_pCameraAnimation->start();
     }

--- a/libraries/disp3D/engine/view/view3D.h
+++ b/libraries/disp3D/engine/view/view3D.h
@@ -51,6 +51,7 @@
 #include <QPointer>
 #include <QObjectPicker>
 #include <Qt3DCore>
+#include "orbitalcameracontroller.h"
 
 //=============================================================================================================
 // FORWARD DECLARATIONS
@@ -122,9 +123,9 @@ public:
 
     //=========================================================================================================
     /**
-     * Starts or stops to rotate all loaded 3D models.
+     * Starts or stops to rotate camera around 3D models.
      */
-    void startStopModelRotation(bool checked);
+    void startStopCameraRotation(bool checked);
 
     //=========================================================================================================
     /**
@@ -217,14 +218,6 @@ protected:
 
     //=========================================================================================================
     /**
-     * Starts the automated rotation animation for all 3D models being childern.
-     *
-     * @param[in] pObject         The parent of the children to be rotated.
-     */
-    void startModelRotationRecursive(QObject* pObject);
-
-    //=========================================================================================================
-    /**
      * Handle Picking events.
      *
      * @param[in] qPickEvent         The picking event that occured.
@@ -241,7 +234,8 @@ protected:
     QPointer<Qt3DRender::QRenderCaptureReply>   m_pScreenCaptureReply;          /**< The capture reply object to save screenshots. */
     QPointer<Qt3DRender::QObjectPicker>         m_pPicker;                      /**< The Picker entity. */
 
-    QSharedPointer<QParallelAnimationGroup>     m_pParallelAnimationGroup;      /**< The animations for each 3D object. */
+    QPointer<OrbitalCameraController>           m_pCamController;               /**< The controller for camera position */
+    QPointer<QPropertyAnimation>                m_pCameraAnimation;             /**< The animations to rotate the camera. */
 
     QList<QPointer<Qt3DRender::QPointLight> >   m_lLightSources;                /**< The light sources. */
 

--- a/libraries/disp3D/engine/view/view3D.h
+++ b/libraries/disp3D/engine/view/view3D.h
@@ -41,6 +41,7 @@
 //=============================================================================================================
 
 #include "../../disp3D_global.h"
+#include "orbitalcameracontroller.h"
 
 //=============================================================================================================
 // QT INCLUDES
@@ -51,7 +52,6 @@
 #include <QPointer>
 #include <QObjectPicker>
 #include <Qt3DCore>
-#include "orbitalcameracontroller.h"
 
 //=============================================================================================================
 // FORWARD DECLARATIONS
@@ -125,7 +125,7 @@ public:
     /**
      * Starts or stops to rotate camera around 3D models.
      */
-    void startStopCameraRotation(bool checked);
+    void startStopCameraRotation(bool bChecked);
 
     //=========================================================================================================
     /**
@@ -149,13 +149,13 @@ public:
     /**
      * Toggle the coord axis visibility.
      */
-    void toggleCoordAxis(bool checked);
+    void toggleCoordAxis(bool bChecked);
 
     //=========================================================================================================
     /**
      * Show fullscreen.
      */
-    void showFullScreen(bool checked);
+    void showFullScreen(bool bChecked);
 
     //=========================================================================================================
     /**

--- a/libraries/disp3D/viewers/abstractview.cpp
+++ b/libraries/disp3D/viewers/abstractview.cpp
@@ -88,7 +88,7 @@ AbstractView::AbstractView(QWidget* parent,
             m_p3DView.data(), &View3D::setSceneColor);
 
     connect(m_pControl3DView.data(), &DISPLIB::Control3DView::rotationChanged,
-            m_p3DView.data(), &View3D::startStopModelRotation);
+            m_p3DView.data(), &View3D::startStopCameraRotation);
 
     connect(m_pControl3DView.data(), &DISPLIB::Control3DView::showCoordAxis,
             m_p3DView.data(), &View3D::toggleCoordAxis);


### PR DESCRIPTION
Sorry this took so long to have a decent enough start to commit @LorenzE! I think I have the lay of the land and can work on a solution. I'm trying to implement it like here https://doc.qt.io/qt-5/qt3d-simple-cpp-example.html (I tried first with `QCamera::panAboutViewCenter` but I guess you can't animate functions only properties?). It's still crashing but I was going to work on it for another hour or so and then maybe ask for help if it's still breaking.