### PR TITLE
[FIX] MNE Analyze leak fix, library get function fix

### DIFF
--- a/applications/mne_analyze/libs/anShared/Model/averagingdatamodel.cpp
+++ b/applications/mne_analyze/libs/anShared/Model/averagingdatamodel.cpp
@@ -151,5 +151,5 @@ QSharedPointer<FIFFLIB::FiffInfo> AveragingDataModel::getFiffInfo()
 
 QSharedPointer<FIFFLIB::FiffEvokedSet> AveragingDataModel::getEvokedSet()
 {
-    return Q_NULLPTR;
+    return m_pFiffEvokedSet;
 }

--- a/applications/mne_analyze/plugins/annotationmanager/annotationmanager.cpp
+++ b/applications/mne_analyze/plugins/annotationmanager/annotationmanager.cpp
@@ -84,7 +84,7 @@ QSharedPointer<AbstractPlugin> AnnotationManager::clone() const
 
 void AnnotationManager::init()
 {
-    m_pCommu = new Communicator(this);
+    m_pCommu = QSharedPointer<ANSHAREDLIB::Communicator>(new ANSHAREDLIB::Communicator(this));
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/plugins/annotationmanager/annotationmanager.h
+++ b/applications/mne_analyze/plugins/annotationmanager/annotationmanager.h
@@ -169,7 +169,7 @@ private:
      */
     void triggerLoadingEnd(const QString& sMessage);
 
-    QPointer<ANSHAREDLIB::Communicator>                     m_pCommu;                   /**< To broadcst signals */
+    QSharedPointer<ANSHAREDLIB::Communicator>                     m_pCommu;                   /**< To broadcst signals */
 
 signals:
     void newAnnotationAvailable(int iAnnotation);

--- a/applications/mne_analyze/plugins/averaging/averaging.cpp
+++ b/applications/mne_analyze/plugins/averaging/averaging.cpp
@@ -711,10 +711,10 @@ void Averaging::onModelRemoved(QSharedPointer<ANSHAREDLIB::AbstractModel> pRemov
 {
     //Butterfly view
     if(pRemovedModel->getType() == MODEL_TYPE::ANSHAREDLIB_AVERAGING_MODEL) {
-        if(m_pButterflyView->getEvokedSetModel()->getEvokedSet() == qSharedPointerCast<AveragingDataModel>(pRemovedModel)->getEvokedSet()) {
+        if(m_pButterflyView->getEvokedSetModel()->getEvokedSet().data() == qSharedPointerCast<AveragingDataModel>(pRemovedModel)->getEvokedSet().data()) {
             m_pButterflyView->clearView();
         }
-        if(m_pAverageLayoutView->getEvokedSetModel()->getEvokedSet() == qSharedPointerCast<AveragingDataModel>(pRemovedModel)->getEvokedSet()) {
+        if(m_pAverageLayoutView->getEvokedSetModel()->getEvokedSet().data() == qSharedPointerCast<AveragingDataModel>(pRemovedModel)->getEvokedSet().data()) {
             m_pAverageLayoutView->clearView();
         }
     }


### PR DESCRIPTION
- fix leak in communicator pointer not being deleted (used shared pointer)
- fix clearing of averaging views by returning correct pointer when getting evoked set and evoked model