### PR TITLE
[FIX]  MNEAnonymize Use QDate instead of QDateTime when reffering to birthday date.

### DIFF
--- a/applications/mne_anonymize/fiffanonymizer.cpp
+++ b/applications/mne_anonymize/fiffanonymizer.cpp
@@ -88,7 +88,7 @@ FiffAnonymizer::FiffAnonymizer()
 , m_sSubjectFirstName(m_sDefaultString)
 , m_sSubjectMidName("mne")
 , m_sSubjectLastName(m_sDefaultString)
-, m_dSubjectBirthday(m_dDefaultDate)
+, m_dSubjectBirthday(QDate(2000,1,1))
 , m_iSubjectBirthdayOffset(0)
 , m_bUseSubjectBirthdayOffset(false)
 , m_sSubjectComment(m_sDefaultString)
@@ -382,9 +382,9 @@ void FiffAnonymizer::censorTag()
     }
     case FIFF_SUBJ_BIRTH_DAY:
     {
-        QDateTime inBirthday(QDate::fromJulianDay(*m_pTag->toJulian()));
+        QDate inBirthday(QDate::fromJulianDay(*m_pTag->toJulian()));
         emit readingSubjectBirthday(inBirthday);
-        QDateTime outBirthday;
+        QDate outBirthday;
 
         if(m_bUseSubjectBirthdayOffset)
         {
@@ -394,7 +394,7 @@ void FiffAnonymizer::censorTag()
         }
 
         FIFFLIB::fiff_int_t outData[1];
-        outData[0] = static_cast<int32_t> (outBirthday.date().toJulianDay());
+        outData[0] = static_cast<int32_t> (outBirthday.toJulianDay());
         memcpy(m_pTag->data(),reinterpret_cast<char*>(outData),sizeof(FIFFLIB::fiff_int_t));
         printIfVerbose("Subject birthday date changed: " + inBirthday.toString("dd.MM.yyyy hh:mm:ss.zzz t") + " -> " + outBirthday.toString("dd.MM.yyyy hh:mm:ss.zzz t"));
         break;
@@ -795,19 +795,19 @@ void FiffAnonymizer::setUseMeasurementDateOffset(bool b)
 
 void FiffAnonymizer::setSubjectBirthday(const QString& sSubjBirthday)
 {
-    m_dSubjectBirthday = QDateTime(QDate::fromString(sSubjBirthday,"ddMMyyyy"),QTime(1, 1, 0));
+    m_dSubjectBirthday = QDate::fromString(sSubjBirthday,"ddMMyyyy");
 }
 
 //=============================================================================================================
 
-void FiffAnonymizer::setSubjectBirthday(const QDateTime& sSubjBirthday)
+void FiffAnonymizer::setSubjectBirthday(const QDate& dSubjBirthday)
 {
-    m_dSubjectBirthday = QDateTime(sSubjBirthday);
+    m_dSubjectBirthday = QDate(dSubjBirthday);
 }
 
 //=============================================================================================================
 
-QDateTime FiffAnonymizer::getSubjectBirthday()
+QDate FiffAnonymizer::getSubjectBirthday()
 {
     return m_dSubjectBirthday;
 }

--- a/applications/mne_anonymize/fiffanonymizer.h
+++ b/applications/mne_anonymize/fiffanonymizer.h
@@ -273,7 +273,7 @@ signals:
      * @param [in] b Subject birthday, in the current file.
      *
      */
-    void readingSubjectBirthday(QDateTime b);
+    void readingSubjectBirthday(QDate b);
 
     //=========================================================================================================
     /**
@@ -529,7 +529,7 @@ public slots:
      *
      * @param [in] sSubjBirtday String containing the desired subject birthday date.
      */
-    void setSubjectBirthday(const QDateTime& sSubjBirthday);
+    void setSubjectBirthday(const QDate& sSubjBirthday);
 
     //=========================================================================================================
     /**
@@ -631,7 +631,7 @@ public:
     /**
      * Get value of Subject's birthday.
      */
-    QDateTime getSubjectBirthday();
+    QDate getSubjectBirthday();
 
     //=========================================================================================================
     /**
@@ -815,7 +815,7 @@ private:
     QString m_sSubjectFirstName;        /**< Subject's first name substitutor.*/
     QString m_sSubjectMidName;          /**< Subject's middle name substitutor.*/
     QString m_sSubjectLastName;         /**< Subject's last name substitutor.*/
-    QDateTime m_dSubjectBirthday;       /**< Subject's birthday substitutor.*/
+    QDate m_dSubjectBirthday;       /**< Subject's birthday substitutor.*/
     int m_iSubjectBirthdayOffset;       /**< Subjects's birthday offset.*/
     bool m_bUseSubjectBirthdayOffset;   /**< Flags use of Subject's birthday offset.*/
     QString m_sSubjectComment;          /**< Subject's comment substitutor.*/

--- a/applications/mne_anonymize/mainwindow.cpp
+++ b/applications/mne_anonymize/mainwindow.cpp
@@ -588,7 +588,7 @@ void MainWindow::setLineEditProjectId(int id)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditProjectName(QString p)
+void MainWindow::setLineEditProjectName(const QString& p)
 {
     m_pUi->lineEditProjectNameExtra->setEnabled(true);
     m_pUi->lineEditProjectNameExtra->setText(p);
@@ -596,7 +596,7 @@ void MainWindow::setLineEditProjectName(QString p)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditProjectAim(QString p)
+void MainWindow::setLineEditProjectAim(const QString& p)
 {
     m_pUi->lineEditProjectAimExtra->setEnabled(true);
     m_pUi->lineEditProjectAimExtra->setText(p);
@@ -604,7 +604,7 @@ void MainWindow::setLineEditProjectAim(QString p)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditProjectPersons(QString p)
+void MainWindow::setLineEditProjectPersons(const QString& p)
 {
     m_pUi->lineEditProjectPersonsExtra->setEnabled(true);
     m_pUi->lineEditProjectPersonsExtra->setText(p);
@@ -612,7 +612,7 @@ void MainWindow::setLineEditProjectPersons(QString p)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditProjectComment(QString c)
+void MainWindow::setLineEditProjectComment(const QString& c)
 {
     m_pUi->plainTextEditProjectCommentExtra->setEnabled(true);
     m_pUi->plainTextEditProjectCommentExtra->setPlainText(c);
@@ -627,7 +627,7 @@ void MainWindow::setLabelMriDataFoundVisible(bool b)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditMNEWorkingDir(QString s)
+void MainWindow::setLineEditMNEWorkingDir(const QString& s)
 {
     m_pUi->lineEditMNEEnvironmentWorkingDirExtra->setEnabled(true);
     m_pUi->lineEditMNEEnvironmentWorkingDirExtra->setText(s);
@@ -635,7 +635,7 @@ void MainWindow::setLineEditMNEWorkingDir(QString s)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditMNECommand(QString s)
+void MainWindow::setLineEditMNECommand(const QString& s)
 {
     m_pUi->lineEditMNEEnvironmentCommandExtra->setEnabled(true);
     m_pUi->lineEditMNEEnvironmentCommandExtra->setText(s);

--- a/applications/mne_anonymize/mainwindow.cpp
+++ b/applications/mne_anonymize/mainwindow.cpp
@@ -207,7 +207,6 @@ void MainWindow::setDefautlStateUi()
     m_pUi->spinBoxMeasurementDateOffset->setToolTip("Specify number of days to subtract to the measurement.");
 
     m_pUi->labelSubjectBirthday->setToolTip("Specify the subject’s birthday.");
-    m_pUi->dateTimeBirthdayDate->setToolTip("Specify the subject’s birthday.");
     m_pUi->checkBoxBirthdayDateOffset->setToolTip("Specify a number of to subtract from the subject's birthday.");
     m_pUi->spinBoxBirthdayDateOffset->setToolTip("Specify a number of to subtract from the subject's birthday.");
 
@@ -234,7 +233,7 @@ void MainWindow::setDefautlStateUi()
     m_pUi->lineEditSubjectFirstNameExtra->setToolTip("Default substitution value: mne_anonymize");
     m_pUi->lineEditSubjectMiddleNameExtra->setToolTip("Default substitution value: mne-cpp");
     m_pUi->lineEditSubjectLastNameExtra->setToolTip("Default substitution value: mne_anonyze");
-    m_pUi->dateTimeBirthdayDate->setToolTip("Default substitution value: 01/01/2000 00:01:01");
+    m_pUi->dateEditBirthdayDate->setToolTip("Default substitution value: 01/01/2000");
     m_pUi->spinBoxBirthdayDateOffset->setToolTip("Default substitution value: 0");
     m_pUi->lineEditSubjectCommentExtra->setToolTip("Default substitution value: mne_anonymize");
     m_pUi->comboBoxSubjectSexExtra->setToolTip("Default substitution value: unknown");
@@ -359,8 +358,9 @@ void MainWindow::setupConnections()
 
     QObject::connect(m_pUi->checkBoxBirthdayDateOffset,&QCheckBox::stateChanged,
                      this,&MainWindow::checkBoxBirthdayDateOffsetStateChanged);
-    QObject::connect(m_pUi->dateTimeBirthdayDate,&QDateTimeEdit::dateTimeChanged,
-                     this,&MainWindow::dateTimeBirthdayDateDateTimeChanged);
+    QObject::connect(m_pUi->dateEditBirthdayDate,&QDateEdit::dateChanged,
+                     this,&MainWindow::dateEditBirthdayDateDateChanged);
+
     QObject::connect(m_pUi->spinBoxBirthdayDateOffset,QOverload<int>::of(&QSpinBox::valueChanged),
                      this,&MainWindow::spinBoxBirthdayDateOffsetValueChanged);
 
@@ -414,6 +414,13 @@ void MainWindow::setMeasurementDateOffset(int d)
 
 //=============================================================================================================
 
+void MainWindow::setSubjectBirthday(const QDate &d)
+{
+    m_pUi->dateEditBirthdayDate->setDate(d);
+}
+
+//=============================================================================================================
+
 void MainWindow::setCheckBoxSubjectBirthdayOffset(bool b)
 {
     m_pUi->checkBoxBirthdayDateOffset->setChecked(b);
@@ -443,7 +450,7 @@ void MainWindow::setLineEditIdFileVersion(double v)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditIdMeasurementDate(QDateTime d)
+void MainWindow::setLineEditIdMeasurementDate(const QDateTime& d)
 {
     m_pUi->dateTimeIdMeasurementDateExtra->setEnabled(true);
     m_pUi->dateTimeIdMeasurementDateExtra->setDateTime(d);
@@ -451,7 +458,7 @@ void MainWindow::setLineEditIdMeasurementDate(QDateTime d)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditIdMacAddress(QString mac)
+void MainWindow::setLineEditIdMacAddress(const QString& mac)
 {
     m_pUi->lineEditIdMACAddressExtra->setEnabled(true);
     m_pUi->lineEditIdMACAddressExtra->setText(mac);
@@ -459,7 +466,7 @@ void MainWindow::setLineEditIdMacAddress(QString mac)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditFileMeasurementDate(QDateTime d)
+void MainWindow::setLineEditFileMeasurementDate(const QDateTime& d)
 {
     m_pUi->dateTimeFileMeasurementDateExtra->setEnabled(true);
     m_pUi->dateTimeFileMeasurementDateExtra->setDateTime(d);
@@ -467,7 +474,7 @@ void MainWindow::setLineEditFileMeasurementDate(QDateTime d)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditFileComment(QString c)
+void MainWindow::setLineEditFileComment(const QString& c)
 {
     m_pUi->plainTextFileCommentExtra->setEnabled(true);
     m_pUi->plainTextFileCommentExtra->setPlainText(c);
@@ -475,7 +482,7 @@ void MainWindow::setLineEditFileComment(QString c)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditFileExperimenter(QString e)
+void MainWindow::setLineEditFileExperimenter(const QString& e)
 {
     m_pUi->lineEditFileExperimenterExtra->setEnabled(true);
     m_pUi->lineEditFileExperimenterExtra->setText(e);
@@ -491,7 +498,7 @@ void MainWindow::setLineEditSubjectId(int i)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditSubjectFirstName(QString fn)
+void MainWindow::setLineEditSubjectFirstName(const QString& fn)
 {
     m_pUi->lineEditSubjectFirstNameExtra->setEnabled(true);
     m_pUi->lineEditSubjectFirstNameExtra->setText(fn);
@@ -499,7 +506,7 @@ void MainWindow::setLineEditSubjectFirstName(QString fn)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditSubjectMiddleName(QString mn)
+void MainWindow::setLineEditSubjectMiddleName(const QString& mn)
 {
     m_pUi->lineEditSubjectMiddleNameExtra->setEnabled(true);
     m_pUi->lineEditSubjectMiddleNameExtra->setText(mn);
@@ -507,7 +514,7 @@ void MainWindow::setLineEditSubjectMiddleName(QString mn)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditSubjectLastName(QString ln)
+void MainWindow::setLineEditSubjectLastName(const QString& ln)
 {
     m_pUi->lineEditSubjectLastNameExtra->setEnabled(true);
     m_pUi->lineEditSubjectLastNameExtra->setText(ln);
@@ -515,10 +522,10 @@ void MainWindow::setLineEditSubjectLastName(QString ln)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditSubjectBirthday(QDateTime b)
+void MainWindow::setLineEditSubjectBirthday(QDate b)
 {
-    m_pUi->dateTimeBirthdayDate->setEnabled(true);
-    m_pUi->dateTimeBirthdayDate->setDateTime(b);
+    m_pUi->dateEditBirthdayDate->setEnabled(true);
+    m_pUi->dateEditBirthdayDate->setDate(b);
 }
 
 //=============================================================================================================
@@ -557,7 +564,7 @@ void MainWindow::setLineEditSubjectHeight(float h)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditSubjectComment(QString c)
+void MainWindow::setLineEditSubjectComment(const QString& c)
 {
     m_pUi->lineEditSubjectCommentExtra->setEnabled(true);
     m_pUi->lineEditSubjectCommentExtra->setText(c);
@@ -565,7 +572,7 @@ void MainWindow::setLineEditSubjectComment(QString c)
 
 //=============================================================================================================
 
-void MainWindow::setLineEditSubjectHisId(QString his)
+void MainWindow::setLineEditSubjectHisId(const QString& his)
 {
     m_pUi->lineEditSubjectHisIdExtra->setEnabled(true);
     m_pUi->lineEditSubjectHisIdExtra->setText(his);

--- a/applications/mne_anonymize/mainwindow.cpp
+++ b/applications/mne_anonymize/mainwindow.cpp
@@ -826,7 +826,7 @@ void MainWindow::checkBoxBirthdayDateOffsetStateChanged(int arg)
     bool state(m_pUi->checkBoxBirthdayDateOffset->isChecked());
     m_pUi->spinBoxBirthdayDateOffset->setEnabled(state);
     emit useBirthdayOffset(state);
-    m_pUi->dateTimeBirthdayDate->setEnabled(!state);
+    m_pUi->dateEditBirthdayDate->setEnabled(!state);
     if(state)
     {
         statusMsg("Specify a subject's birthday offset.",2000);
@@ -837,7 +837,7 @@ void MainWindow::checkBoxBirthdayDateOffsetStateChanged(int arg)
 
 //=============================================================================================================
 
-void MainWindow::dateTimeMeasurementDateDateTimeChanged(const QDateTime &dateTime)
+void MainWindow::dateTimeMeasurementDateDateTimeChanged(const QDateTime& dateTime)
 {
     emit measurementDateChanged(dateTime);
 }
@@ -851,9 +851,9 @@ void MainWindow::spinBoxMeasurementDateOffsetValueChanged(int offset)
 
 //=============================================================================================================
 
-void MainWindow::dateTimeBirthdayDateDateTimeChanged(const QDateTime &dateTime)
+void MainWindow::dateEditBirthdayDateDateChanged(const QDate& date)
 {
-    emit birthdayDateChanged(dateTime);
+    emit birthdayDateChanged(date);
 }
 
 //=============================================================================================================
@@ -872,7 +872,7 @@ void MainWindow::lineEditSubjectHisIdEditingFinished()
 
 //=============================================================================================================
 
-void MainWindow::winPopup(QString s)
+void MainWindow::winPopup(const QString& s)
 {
     QMessageBox msgBox;
     msgBox.setText(s);
@@ -882,7 +882,7 @@ void MainWindow::winPopup(QString s)
 
 //=============================================================================================================
 
-void MainWindow::statusMsg(const QString s,int to)
+void MainWindow::statusMsg(const QString& s,int to)
 {
     m_pUi->statusbar->clearMessage();
     m_pUi->statusbar->showMessage(s,to);

--- a/applications/mne_anonymize/mainwindow.h
+++ b/applications/mne_anonymize/mainwindow.h
@@ -119,7 +119,7 @@ public:
      * @param [in] s QString containing the complete absolute path of the output file.
      *
      */
-    void setOutFile(const QString &s);
+    void setOutFile(const QString& s);
 
     //=========================================================================================================
     /**
@@ -178,7 +178,7 @@ public:
      * @param [in] d Birthday of the subject.
      *
      */
-    void setSubjectBirthday(const QDateTime& d);
+    void setSubjectBirthday(const QDate& d);
 
     //=========================================================================================================
     /**
@@ -232,7 +232,7 @@ public:
      * @param [in] to time to show the message for.
      *
      */
-    void statusMsg(const QString s, int to = 0);
+    void statusMsg(const QString& s, int to = 0);
 
     //=========================================================================================================
     /**
@@ -304,7 +304,7 @@ signals:
      * @param [in] o Number of days to offset the measurement.
      *
      */
-    void birthdayDateChanged(const QDateTime& d) const;
+    void birthdayDateChanged(const QDate& d) const;
 
     //=========================================================================================================
     /**
@@ -365,7 +365,7 @@ public slots:
      * @param [in] s Text to show in the popup window.
      *
      */
-    void winPopup(QString s);
+    void winPopup(const QString& s);
 
     //=========================================================================================================
     /**
@@ -387,7 +387,7 @@ public slots:
      * @param [in] d Measurement date.
      *
      */
-    void setLineEditIdMeasurementDate(QDateTime d);
+    void setLineEditIdMeasurementDate(const QDateTime& d);
 
     //=========================================================================================================
     /**
@@ -396,7 +396,7 @@ public slots:
      * @param [in] mac MAC address as text.
      *
      */
-    void setLineEditIdMacAddress(QString mac);
+    void setLineEditIdMacAddress(const QString& mac);
 
     //=========================================================================================================
     /**
@@ -408,7 +408,7 @@ public slots:
      * @param [in] d Date and time to show.
      *
      */
-    void setLineEditFileMeasurementDate(QDateTime d);
+    void setLineEditFileMeasurementDate(const QDateTime& d);
 
     //=========================================================================================================
     /**
@@ -417,7 +417,7 @@ public slots:
      * @param [in] s File comment.
      *
      */
-    void setLineEditFileComment(QString c);
+    void setLineEditFileComment(const QString& c);
 
     //=========================================================================================================
     /**
@@ -426,7 +426,7 @@ public slots:
      * @param [in] e Experimenter text.
      *
      */
-    void setLineEditFileExperimenter(QString e);
+    void setLineEditFileExperimenter(const QString& e);
 
     //=========================================================================================================
     /**
@@ -444,7 +444,7 @@ public slots:
      * @param [in] fn First name of the subject.
      *
      */
-    void setLineEditSubjectFirstName(QString fn);
+    void setLineEditSubjectFirstName(const QString& fn);
 
     //=========================================================================================================
     /**
@@ -453,7 +453,7 @@ public slots:
      * @param [in] mn Subject's middle name.
      *
      */
-    void setLineEditSubjectMiddleName(QString mn);
+    void setLineEditSubjectMiddleName(const QString& mn);
 
     //=========================================================================================================
     /**
@@ -462,7 +462,7 @@ public slots:
      * @param [in] ln Subject's last name.
      *
      */
-    void setLineEditSubjectLastName(QString ln);
+    void setLineEditSubjectLastName(const QString& ln);
 
     //=========================================================================================================
     /**
@@ -471,7 +471,7 @@ public slots:
      * @param [in] b Date and time for the birthday of the subject.
      *
      */
-    void setLineEditSubjectBirthday(QDateTime b);
+    void setLineEditSubjectBirthday(QDate b);
 
     //=========================================================================================================
     /**
@@ -524,7 +524,7 @@ public slots:
      * @param [in] c String to show.
      *
      */
-    void setLineEditSubjectComment(QString c);
+    void setLineEditSubjectComment(const QString& c);
 
     //=========================================================================================================
     /**
@@ -533,7 +533,7 @@ public slots:
      * @param [in] his String to show.
      *
      */
-    void setLineEditSubjectHisId(QString his);
+    void setLineEditSubjectHisId(const QString& his);
 
     //=========================================================================================================
     /**
@@ -551,7 +551,7 @@ public slots:
      * @param [in] pname Text with the name of the project.
      *
      */
-    void setLineEditProjectName(QString pname);
+    void setLineEditProjectName(const QString& pname);
 
     //=========================================================================================================
     /**
@@ -560,7 +560,7 @@ public slots:
      * @param [in] pAim Text containing the project aim.
      *
      */
-    void setLineEditProjectAim(QString pAim);
+    void setLineEditProjectAim(const QString& pAim);
 
     //=========================================================================================================
     /**
@@ -569,7 +569,7 @@ public slots:
      * @param [in] pPersons String text containing the persons involved in the project.
      *
      */
-    void setLineEditProjectPersons(QString pPersons);
+    void setLineEditProjectPersons(const QString& pPersons);
 
     //=========================================================================================================
     /**
@@ -578,7 +578,7 @@ public slots:
      * @param [in] pComment Text containing the project comment.
      *
      */
-    void setLineEditProjectComment(QString pComment);
+    void setLineEditProjectComment(const QString& pComment);
 
     //=========================================================================================================
     /**
@@ -596,7 +596,7 @@ public slots:
      * @param [in] s Text containing the working directory.
      *
      */
-    void setLineEditMNEWorkingDir(QString s);
+    void setLineEditMNEWorkingDir(const QString& s);
 
     //=========================================================================================================
     /**
@@ -605,7 +605,7 @@ public slots:
      * @param [in] s Text containing the command shown.
      *
      */
-    void setLineEditMNECommand(QString s);
+    void setLineEditMNECommand(const QString& s);
 
     //=========================================================================================================
     /**
@@ -676,7 +676,7 @@ private slots:
      * @brief Allows to manage the event of the measurement date control being changed.
      *
      */
-    void dateTimeMeasurementDateDateTimeChanged(const QDateTime &dateTime);
+    void dateTimeMeasurementDateDateTimeChanged(const QDateTime& dateTime);
 
     //=========================================================================================================
     /**
@@ -690,7 +690,7 @@ private slots:
      * @brief Allows to manage the event of the birthday date control being changed.
      *
      */
-    void dateTimeBirthdayDateDateTimeChanged(const QDateTime &dateTime);
+    void dateEditBirthdayDateDateChanged(const QDate& dateTime);
 
     //=========================================================================================================
     /**

--- a/applications/mne_anonymize/mainwindow.ui
+++ b/applications/mne_anonymize/mainwindow.ui
@@ -76,8 +76,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>638</width>
-         <height>611</height>
+         <width>644</width>
+         <height>622</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -304,53 +304,14 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QGridLayout" name="gridLayout_3">
-              <item row="12" column="0">
-               <widget class="QCheckBox" name="checkBoxMNEEnvironment">
-                <property name="text">
-                 <string>MNE Environment</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QDateTimeEdit" name="dateTimeMeasurementDate">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="time">
-                 <time>
-                  <hour>0</hour>
-                  <minute>0</minute>
-                  <second>0</second>
-                 </time>
-                </property>
-                <property name="calendarPopup">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="labelMeasDate_2">
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>20</height>
-                 </size>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">font:14pt;</string>
-                </property>
-                <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Options Menu&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
               <item row="9" column="0">
+               <widget class="QCheckBox" name="checkBoxBirthdayDateOffset">
+                <property name="text">
+                 <string>Subject birthday offset</string>
+                </property>
+               </widget>
+              </item>
+              <item row="10" column="0">
                <widget class="QSpinBox" name="spinBoxBirthdayDateOffset">
                 <property name="maximumSize">
                  <size>
@@ -366,20 +327,10 @@
                 </property>
                </widget>
               </item>
-              <item row="8" column="0">
-               <widget class="QCheckBox" name="checkBoxBirthdayDateOffset">
+              <item row="13" column="0">
+               <widget class="QCheckBox" name="checkBoxMNEEnvironment">
                 <property name="text">
-                 <string>Subject birthday offset</string>
-                </property>
-               </widget>
-              </item>
-              <item row="11" column="0">
-               <widget class="QLineEdit" name="lineEditSubjectHisId"/>
-              </item>
-              <item row="4" column="0">
-               <widget class="QCheckBox" name="checkBoxMeasurementDateOffset">
-                <property name="text">
-                 <string>Measurement date offset</string>
+                 <string>MNE Environment</string>
                 </property>
                </widget>
               </item>
@@ -405,7 +356,69 @@
                 </property>
                </widget>
               </item>
-              <item row="10" column="0">
+              <item row="6" column="0">
+               <widget class="QLabel" name="labelSubjectBirthday">
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Subject birthday&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="labelMeasDate_2">
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">font:14pt;</string>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Options Menu&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="12" column="0">
+               <widget class="QLineEdit" name="lineEditSubjectHisId"/>
+              </item>
+              <item row="3" column="0">
+               <widget class="QDateTimeEdit" name="dateTimeMeasurementDate">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="time">
+                 <time>
+                  <hour>0</hour>
+                  <minute>0</minute>
+                  <second>0</second>
+                 </time>
+                </property>
+                <property name="calendarPopup">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QCheckBox" name="checkBoxMeasurementDateOffset">
+                <property name="text">
+                 <string>Measurement date offset</string>
+                </property>
+               </widget>
+              </item>
+              <item row="11" column="0">
                <widget class="QLabel" name="labelSubjectHisId">
                 <property name="maximumSize">
                  <size>
@@ -438,26 +451,10 @@
                 </property>
                </widget>
               </item>
-              <item row="6" column="0">
-               <widget class="QLabel" name="labelSubjectBirthday">
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>20</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Subject birthday&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-               </widget>
-              </item>
               <item row="7" column="0">
-               <widget class="QDateTimeEdit" name="dateTimeBirthdayDate">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+               <widget class="QDateEdit" name="dateEditBirthdayDate">
+                <property name="showGroupSeparator" stdset="0">
+                 <bool>false</bool>
                 </property>
                 <property name="calendarPopup">
                  <bool>true</bool>
@@ -468,7 +465,6 @@
              <zorder>checkBoxBirthdayDateOffset</zorder>
              <zorder>labelSubjectHisId</zorder>
              <zorder>checkBoxMeasurementDateOffset</zorder>
-             <zorder>dateTimeBirthdayDate</zorder>
              <zorder>labelMeasDate</zorder>
              <zorder>spinBoxMeasurementDateOffset</zorder>
              <zorder>dateTimeMeasurementDate</zorder>
@@ -478,6 +474,7 @@
              <zorder>checkBoxBruteMode</zorder>
              <zorder>labelMeasDate_2</zorder>
              <zorder>checkBoxMNEEnvironment</zorder>
+             <zorder>dateEditBirthdayDate</zorder>
             </widget>
            </item>
            <item>
@@ -526,7 +523,7 @@
                  <bool>true</bool>
                 </property>
                 <property name="currentIndex">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <widget class="QWidget" name="tab">
                  <attribute name="title">
@@ -956,7 +953,6 @@
   <tabstop>dateTimeMeasurementDate</tabstop>
   <tabstop>checkBoxMeasurementDateOffset</tabstop>
   <tabstop>spinBoxMeasurementDateOffset</tabstop>
-  <tabstop>dateTimeBirthdayDate</tabstop>
   <tabstop>checkBoxBirthdayDateOffset</tabstop>
   <tabstop>spinBoxBirthdayDateOffset</tabstop>
   <tabstop>lineEditSubjectHisId</tabstop>

--- a/applications/mne_anonymize/settingscontrollergui.cpp
+++ b/applications/mne_anonymize/settingscontrollergui.cpp
@@ -223,7 +223,7 @@ void SettingsControllerGui::setupCommunication()
     QObject::connect(m_pWin.data(),&MainWindow::measurementDateOffsetChanged,
                      m_pAnonymizer.data(),&FiffAnonymizer::setMeasurementDateOffset);
     QObject::connect(m_pWin.data(),&MainWindow::birthdayDateChanged,
-                     m_pAnonymizer.data(),QOverload<const QDateTime&>::of(&FiffAnonymizer::setSubjectBirthday));
+                     m_pAnonymizer.data(),QOverload<const QDate&>::of(&FiffAnonymizer::setSubjectBirthday));
     QObject::connect(m_pWin.data(),&MainWindow::useBirthdayOffset,
                      m_pAnonymizer.data(),&FiffAnonymizer::setUseSubjectBirthdayOffset);
     QObject::connect(m_pWin.data(),&MainWindow::birthdayOffsetChanged,
@@ -308,6 +308,7 @@ void SettingsControllerGui::initializeOptionsState()
     m_pWin->setCheckBoxMeasurementDateOffset(m_pAnonymizer->getUseMeasurementDayOffset());
     m_pWin->setMeasurementDateOffset(m_pAnonymizer->getMeasurementDayOffset());
     m_pWin->setCheckBoxSubjectBirthdayOffset(m_pAnonymizer->getUseSubjectBirthdayOffset());
+    m_pWin->setSubjectBirthday(m_pAnonymizer->getSubjectBirthday());
     m_pWin->setSubjectBirthdayOffset(m_pAnonymizer->getSubjectBirthdayOffset());
     if(m_bHisIdSpecified)
     {


### PR DESCRIPTION
In fiff files, birthday date is coded in julian calendar (with an integer number).  It is just a date, not a date and time. Thus, I change here the use of QDateTime for the use of QDate for a more correct use. 

I also got to change the use of const references more to gain a bit of simplicity/efficiency. 

Let's see what I break.