### PR TITLE
[FIX] MNE Scan - writing to file calibration values

### DIFF
--- a/applications/mne_scan/plugins/writetofile/writetofile.cpp
+++ b/applications/mne_scan/plugins/writetofile/writetofile.cpp
@@ -289,7 +289,7 @@ void WriteToFile::run()
                     }
 
                     if(m_pOutfid) {
-                        m_pOutfid->write_raw_buffer(matData);
+                        m_pOutfid->write_raw_buffer(matData, m_mCals);
                     }
                 } else {
                     size = 0;
@@ -392,10 +392,17 @@ void WriteToFile::toggleRecordingFile()
 
         //Start/Prepare writing process. Actual writing is done in run() method.
         m_mutex.lock();
-        RowVectorXd cals;
+        //RowVectorXd cals;
         m_pOutfid = FiffStream::start_writing_raw(m_qFileOut,
                                                   *m_pFiffInfo,
-                                                  cals);
+                                                  m_mCals);
+//        qDebug() << "====== CALS ====";
+////        qDebug() << cals[0] << cals[1] << cals[2] << cals[3];
+
+//        qDebug() << "SIZE OF CALS:" << cals.size();
+
+//        m_mCals = cals;
+
         fiff_int_t first = 0;
         m_pOutfid->write_int(FIFF_FIRST_SAMPLE, &first);
         m_mutex.unlock();
@@ -414,7 +421,7 @@ void WriteToFile::toggleRecordingFile()
 }
 
 //=============================================================================================================
-
+#include <iostream>
 void WriteToFile::splitRecordingFile()
 {
     //qDebug() << "Split recording file";
@@ -445,6 +452,7 @@ void WriteToFile::splitRecordingFile()
                                               cals,
                                               sel,
                                               false);
+
     fiff_int_t first = 0;
     m_pOutfid->write_int(FIFF_FIRST_SAMPLE, &first);
 }

--- a/applications/mne_scan/plugins/writetofile/writetofile.cpp
+++ b/applications/mne_scan/plugins/writetofile/writetofile.cpp
@@ -392,16 +392,9 @@ void WriteToFile::toggleRecordingFile()
 
         //Start/Prepare writing process. Actual writing is done in run() method.
         m_mutex.lock();
-        //RowVectorXd cals;
         m_pOutfid = FiffStream::start_writing_raw(m_qFileOut,
                                                   *m_pFiffInfo,
                                                   m_mCals);
-//        qDebug() << "====== CALS ====";
-////        qDebug() << cals[0] << cals[1] << cals[2] << cals[3];
-
-//        qDebug() << "SIZE OF CALS:" << cals.size();
-
-//        m_mCals = cals;
 
         fiff_int_t first = 0;
         m_pOutfid->write_int(FIFF_FIRST_SAMPLE, &first);
@@ -445,11 +438,10 @@ void WriteToFile::splitRecordingFile()
 
     //start next file
     m_qFileOut.setFileName(nextFileName);
-    RowVectorXd cals;
     MatrixXi sel;
     m_pOutfid = FiffStream::start_writing_raw(m_qFileOut,
                                               *m_pFiffInfo,
-                                              cals,
+                                              m_mCals,
                                               sel,
                                               false);
 

--- a/applications/mne_scan/plugins/writetofile/writetofile.h
+++ b/applications/mne_scan/plugins/writetofile/writetofile.h
@@ -212,6 +212,10 @@ private:
     QSharedPointer<UTILSLIB::CircularBuffer_Matrix_double>                      m_pCircularBuffer;      /**< Holds incoming raw data. */
 
     SCSHAREDLIB::PluginInputData<SCMEASLIB::RealTimeMultiSampleArray>::SPtr      m_pWriteToFileInput;   /**< The RealTimeMultiSampleArray of the WriteToFile input.*/
+
+    Eigen::RowVectorXd                             m_mCals;
+
+    QSharedPointer<Eigen::RowVectorXd>          m_pCals;
 };
 } // NAMESPACE
 

--- a/applications/mne_scan/plugins/writetofile/writetofile.h
+++ b/applications/mne_scan/plugins/writetofile/writetofile.h
@@ -213,9 +213,7 @@ private:
 
     SCSHAREDLIB::PluginInputData<SCMEASLIB::RealTimeMultiSampleArray>::SPtr      m_pWriteToFileInput;   /**< The RealTimeMultiSampleArray of the WriteToFile input.*/
 
-    Eigen::RowVectorXd                             m_mCals;
-
-    QSharedPointer<Eigen::RowVectorXd>          m_pCals;
+    Eigen::RowVectorXd                      m_mCals;                        /**< Row vector with channel calibration values. */
 };
 } // NAMESPACE
 


### PR DESCRIPTION
- Fix writing to file with wrong values by not accounting for calibration (calling correct write_raw_buffer)