### PR TITLE
[FIX] add console to CONFIG qt pro file

### DIFF
--- a/applications/mne_anonymize/mne_anonymize.pro
+++ b/applications/mne_anonymize/mne_anonymize.pro
@@ -42,6 +42,8 @@ TEMPLATE = app
 
 QT += widgets network
 
+CONFIG += console
+
 !contains(MNECPP_CONFIG, withAppBundles) {
     CONFIG -= app_bundle
 }


### PR DESCRIPTION
We were experiencing different behavior between platforms. Now it works fine. 