### PR TITLE
[FIX] Show file and filter info beneath the data viewer

### DIFF
--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
@@ -230,7 +230,7 @@ void FiffRawView::setModel(const QSharedPointer<FiffRawViewModel>& pModel)
 //    m_pTableView->grabGesture(Qt::PinchGesture);
 //    m_pTableView->grabGesture(Qt::TapAndHoldGesture);
     updateLabels(0);
-    updatePluginWindowTitle();
+    updateFileLabel();
 }
 
 //=============================================================================================================
@@ -479,7 +479,7 @@ void FiffRawView::setFilter(const FilterKernel& filterData)
     }
 
     m_pModel->setFilter(filterData);
-    updatePluginWindowTitle();
+    updateFileLabel();
 }
 
 //=============================================================================================================
@@ -490,7 +490,7 @@ void FiffRawView::setFilterActive(bool state)
         return;
     }
     m_pModel->setFilterActive(state);
-    updatePluginWindowTitle();
+    updateFileLabel();
 }
 
 //=============================================================================================================
@@ -519,7 +519,17 @@ void FiffRawView::createBottomLabels()
     m_pEndTimeLabel->setText(" ");
     m_pEndTimeLabel->setAlignment(Qt::AlignRight);
 
+    m_pFileLabel = new QLabel(this);
+    m_pFileLabel->setText(" ");
+    m_pFileLabel->setAlignment(Qt::AlignRight);
+
+    m_pFilterLabel = new QLabel(this);
+    m_pFilterLabel->setText(" ");
+    m_pFilterLabel->setAlignment(Qt::AlignRight);
+
     LabelLayout->addWidget(m_pInitialTimeLabel);
+    LabelLayout->addWidget(m_pFileLabel);
+    LabelLayout->addWidget(m_pFilterLabel);
     LabelLayout->addWidget(m_pEndTimeLabel);
     labelBar->setLayout(LabelLayout);
 
@@ -540,14 +550,21 @@ void FiffRawView::updateLabels(int iValue)
         return;
     }
 
-    QString strLeft, strRight;
+    updateTimeLabels();
+    updateFileLabel();
+    updateFilterLabel();
+}
 
+
+void FiffRawView::updateTimeLabels()
+{
     if(m_pModel->isEmpty()) {
         m_pEndTimeLabel->setText("0 | 0 sec");
         m_pInitialTimeLabel->setText("0 | 0 sec");
         return;
     }
 
+    QString strLeft, strRight;
     //Left Label
     int iSample = static_cast<int>(m_pTableView->horizontalScrollBar()->value() / m_pModel->pixelDifference());
     strLeft = QString("%1 | %2 sec").arg(QString().number(iSample)).arg(QString().number(iSample / m_pModel->getFiffInfo()->sfreq, 'f', 2));
@@ -670,30 +687,36 @@ void FiffRawView::clearView()
 
 //=============================================================================================================
 
-void FiffRawView::updatePluginWindowTitle()
+void FiffRawView::updateFileLabel()
 {
     if(parentWidget())
     {
-        QString title("Signal Viewer");
+        QString label;
 
         float fFrequency = m_pModel->getSamplingFrequency();
 
         int iFileLengthInSamples = m_pModel->absoluteLastSample() - m_pModel->absoluteFirstSample();
         float fFileLengthInSeconds = static_cast<float>(iFileLengthInSamples) / fFrequency;
 
-        title += "   |   " + m_pModel->getModelName();
-        title += "  -  Sampling Freq. " + QString::number(m_pModel->getSamplingFrequency(),'g',5) + "Hz";
-        title += "  -  Lenght: " + QString::number(fFileLengthInSeconds,'g',5) + "s.";
-        if(m_pModel->isFilterActive())
-        {
-            title += "   |   Filter ON";
-        } else
-        {
-            title += "   |   Filter OFF";
-        }
-        title += "  -  " + m_pModel->getFilter().getShortDescription();
-
-        parentWidget()->setWindowTitle(title);
+        label += "   |   " + m_pModel->getModelName();
+        label += "  -  Sampling Freq. " + QString::number(m_pModel->getSamplingFrequency(),'g',5) + "Hz";
+        label += "  -  Length: " + QString::number(fFileLengthInSeconds,'g',5) + "s.";
+        m_pFileLabel->setText(label);
     }
 }
 
+//=============================================================================================================
+
+void FiffRawView::updateFilterLabel()
+{
+    QString label;
+    if(m_pModel->isFilterActive())
+    {
+        label += "   |   Filter ON";
+    } else
+    {
+        label += "   |   Filter OFF";
+    }
+    label += "  -  " + m_pModel->getFilter().getShortDescription() + "  |";
+    m_pFilterLabel->setText(label);
+}

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
@@ -102,7 +102,7 @@ FiffRawView::FiffRawView(QWidget *parent)
     //m_pTableView->setShowGrid(true);
 
     connect(m_pTableView->horizontalScrollBar(), &QScrollBar::valueChanged,
-            this, &FiffRawView::updateLabels, Qt::UniqueConnection);
+            this, &FiffRawView::updateTimeLabels, Qt::UniqueConnection);
 }
 
 //=============================================================================================================
@@ -229,8 +229,9 @@ void FiffRawView::setModel(const QSharedPointer<FiffRawViewModel>& pModel)
 //    //Gestures
 //    m_pTableView->grabGesture(Qt::PinchGesture);
 //    m_pTableView->grabGesture(Qt::TapAndHoldGesture);
-    updateLabels(0);
+    updateTimeLabels(0);
     updateFileLabel();
+    updateFilterLabel();
 }
 
 //=============================================================================================================
@@ -319,7 +320,7 @@ void FiffRawView::setWindowSize(int iT)
 
     m_pTableView->horizontalScrollBar()->setValue(iNewPos);
     m_pTableView->viewport()->repaint();
-    updateLabels(m_pTableView->horizontalScrollBar()->value());
+    updateTimeLabels(m_pTableView->horizontalScrollBar()->value());
 }
 
 //=============================================================================================================
@@ -479,7 +480,7 @@ void FiffRawView::setFilter(const FilterKernel& filterData)
     }
 
     m_pModel->setFilter(filterData);
-    updateFileLabel();
+    updateFilterLabel();
 }
 
 //=============================================================================================================
@@ -490,7 +491,7 @@ void FiffRawView::setFilterActive(bool state)
         return;
     }
     m_pModel->setFilterActive(state);
-    updateFileLabel();
+    updateFilterLabel();
 }
 
 //=============================================================================================================
@@ -542,22 +543,10 @@ void FiffRawView::createBottomLabels()
 
 //=============================================================================================================
 
-void FiffRawView::updateLabels(int iValue)
+void FiffRawView::updateTimeLabels(int iValue)
 {
     Q_UNUSED(iValue);
 
-    if(!m_pModel) {
-        return;
-    }
-
-    updateTimeLabels();
-    updateFileLabel();
-    updateFilterLabel();
-}
-
-
-void FiffRawView::updateTimeLabels()
-{
     if(m_pModel->isEmpty()) {
         m_pEndTimeLabel->setText("0 | 0 sec");
         m_pInitialTimeLabel->setText("0 | 0 sec");
@@ -575,6 +564,7 @@ void FiffRawView::updateTimeLabels()
     strRight = QString("%1 | %2 sec").arg(QString().number(iSample)).arg(QString().number(iSample / m_pModel->getFiffInfo()->sfreq, 'f', 2));
     m_pEndTimeLabel->setText(strRight);
 }
+
 
 //=============================================================================================================
 

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
@@ -343,13 +343,7 @@ private:
      *
      * @param [in] iValue   Horizontal scroll bar position (unused)
      */
-    void updateLabels(int iValue);
-
-    //=========================================================================================================
-    /**
-     *  Update labels related to the time of the signals shown in the data viewer window.
-     */
-    void updateTimeLabels();
+    void updateTimeLabels(int iValue);
 
     //=========================================================================================================
     /**

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
@@ -347,6 +347,24 @@ private:
 
     //=========================================================================================================
     /**
+     *  Update labels related to the time of the signals shown in the data viewer window.
+     */
+    void updateTimeLabels();
+
+    //=========================================================================================================
+    /**
+     * Updates file labels with info from current set model
+     */
+    void updateFileLabel();
+
+    //=========================================================================================================
+    /**
+     * Updates the information about the filter shown in the filterLabel.
+     */
+    void updateFilterLabel();
+
+    //=========================================================================================================
+    /**
      * Disconnects the model from the view's scrollbar and resizing
      */
     void disconnectModel();
@@ -359,31 +377,27 @@ private:
      */
     void updateVerticalScrollPosition(qint32 newScrollPosition);
 
-    //=========================================================================================================
-    /**
-     * Updates file labels with info from current set model
-     */
-    void updatePluginWindowTitle();
 
-    QPointer<QTableView>                                m_pTableView;                   /**< Pointer to table view ui element */
+    QPointer<QTableView>                                m_pTableView;                   /**< Pointer to table view ui element. */
 
-    QSharedPointer<ANSHAREDLIB::FiffRawViewModel>       m_pModel;                       /**< Pointer to associated Model */
+    QSharedPointer<ANSHAREDLIB::FiffRawViewModel>       m_pModel;                       /**< Pointer to associated Model. */
 
-    QSharedPointer<FiffRawViewDelegate>                 m_pDelegate;                    /**< Pointer to associated Delegate */
+    QSharedPointer<FiffRawViewDelegate>                 m_pDelegate;                    /**< Pointer to associated Delegate. */
 
     QMap<qint32,float>                                  m_qMapChScaling;                /**< Channel scaling values. */
 
-    float                                               m_fDefaultSectionSize;          /**< Default row height */
-    float                                               m_fZoomFactor;                  /**< Zoom factor */
-    float                                               m_fLastClickedSample;           /**< Stores last clicked sample on screen */
+    float                                               m_fDefaultSectionSize;          /**< Default row height. */
+    float                                               m_fZoomFactor;                  /**< Zoom factor. */
+    float                                               m_fLastClickedSample;           /**< Stores last clicked sample on screen. */
 
-    qint32                                              m_iT;                           /**< Display window size in seconds */
+    qint32                                              m_iT;                           /**< Display window size in seconds. */
 
-    QScroller*                                          m_pKineticScroller;             /**< Used for kinetic scrolling through data view */
+    QScroller*                                          m_pKineticScroller;             /**< Used for kinetic scrolling through data view. */
 
-    QLabel*                                             m_pInitialTimeLabel;            /**< Left 'Sample | Seconds' display label */
-    QLabel*                                             m_pEndTimeLabel;                /**< Right 'Sample | Seconds' display label */
-
+    QLabel*                                             m_pInitialTimeLabel;            /**< Left 'Sample | Seconds' display label. */
+    QLabel*                                             m_pEndTimeLabel;                /**< Right 'Sample | Seconds' display label. */
+    QLabel*                                             m_pFileLabel;                   /**< File name and path, Fs and duration. */
+    QLabel*                                             m_pFilterLabel;                 /**< Short filter description to be shown under the time-series. */
 signals:
     void tableViewDataWidthChanged(int iWidth);
 };


### PR DESCRIPTION
Hi, 

There is a problem with the way info is now displayed in the plugin rawdataviewer in mne_analyze. Instead of printing the information of the file and the filter applied in the title bar, we can do it at the bottom in a label bar. 

There is a little bit less space because there are other labels related to the time already printed there, but I think it is fine (at least for now). 
