### PR TITLE
[FIX] - Solve compilation issues on linux platform

### DIFF
--- a/libraries/disp/viewers/helpers/scalecontrol.cpp
+++ b/libraries/disp/viewers/helpers/scalecontrol.cpp
@@ -34,6 +34,7 @@
 
 #include "scalecontrol.h"
 #include "ui_scalecontrol.h"
+#include <math.h>
 
 using namespace DISPLIB;
 


### PR DESCRIPTION
Adding <math.h> dependency to the new scalecontrol class implementation.