### PR TITLE
[FIX] Fix MNE Scan crashing on stop

### DIFF
--- a/libraries/disp/viewers/scalingview.cpp
+++ b/libraries/disp/viewers/scalingview.cpp
@@ -185,13 +185,9 @@ ScalingView::~ScalingView()
 
     delete m_pUi;
 
-    while(m_qMapScaleControls.size() > 0)
+    for(auto control : m_qMapScaleControls)
     {
-        if(m_qMapScaleControls.begin().value())
-        {
-            delete m_qMapScaleControls.begin().value();
-            m_qMapScaleControls.remove(m_qMapScaleControls.begin().key());
-        }
+        delete control;
     }
 }
 

--- a/libraries/disp/viewers/scalingview.cpp
+++ b/libraries/disp/viewers/scalingview.cpp
@@ -190,6 +190,7 @@ ScalingView::~ScalingView()
         if(m_qMapScaleControls.begin().value())
         {
             delete m_qMapScaleControls.begin().value();
+            m_qMapScaleControls.remove(m_qMapScaleControls.begin().key());
         }
     }
 }


### PR DESCRIPTION
- In ScalingView destructor, remove map entry when deleting pointers to avoid infinite loop.