### PR TITLE
[ENH] EventManager sintactic sugar

### DIFF
--- a/applications/mne_analyze/libs/anShared/Management/communicator.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/communicator.cpp
@@ -105,7 +105,7 @@ void Communicator::addSubscriptions(const QVector<EVENT_TYPE> &newsubs)
 {
     m_EventSubscriptions.append(newsubs);
     // add new subscriptions to routing table of event manager
-    EventManager::getEventManager().addSubscriptions(this, newsubs);
+    EventManager::addSubscriptions(this, newsubs);
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/libs/anShared/Management/communicator.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/communicator.cpp
@@ -60,7 +60,7 @@ Communicator::Communicator(const QVector<EVENT_TYPE> &subs)
 : m_ID(nextID())
 , m_EventSubscriptions(subs)
 {
-    EventManager::getEventManager().addCommunicator(this);
+    EventManager::addCommunicator(this);
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/libs/anShared/Management/communicator.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/communicator.cpp
@@ -84,7 +84,7 @@ Communicator::~Communicator()
 void Communicator::publishEvent(EVENT_TYPE etype, const QVariant &data) const
 {
     // simply wrap in smart pointer, fill in the sender pointer, and pass on to EventManager
-    EventManager::getEventManager().issueEvent(QSharedPointer<Event>::create(etype, this, data));
+    EventManager::issueEvent(QSharedPointer<Event>::create(etype, this, data));
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/libs/anShared/Management/communicator.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/communicator.cpp
@@ -92,7 +92,7 @@ void Communicator::publishEvent(EVENT_TYPE etype, const QVariant &data) const
 void Communicator::updateSubscriptions(const QVector<EVENT_TYPE> &subs)
 {
     // update routing table of event manager
-    EventManager::getEventManager().updateSubscriptions(this, subs);
+    EventManager::updateSubscriptions(this, subs);
     // update own subscription list: This HAS to be done AFTER the EventManager::updateSubscriptions,
     // since the latter uses the communicators old list in order to keep execution time low
     m_EventSubscriptions.clear();

--- a/applications/mne_analyze/libs/anShared/Management/communicator.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/communicator.cpp
@@ -76,7 +76,7 @@ Communicator::Communicator(AbstractPlugin* plugin)
 
 Communicator::~Communicator()
 {
-    EventManager::getEventManager().removeCommunicator(this);
+    EventManager::removeCommunicator(this);
 }
 
 //=============================================================================================================
@@ -121,7 +121,7 @@ void Communicator::addSubscriptions(EVENT_TYPE newsub)
 void Communicator::manualDisconnect(void)
 {
     // simply delegate to EventManager
-    EventManager::getEventManager().removeCommunicator(this);
+    EventManager::removeCommunicator(this);
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/libs/anShared/Management/communicator.h
+++ b/applications/mne_analyze/libs/anShared/Management/communicator.h
@@ -152,7 +152,7 @@ public:
      *
      * @return List of subscriptions.
      */
-    inline QVector<EVENT_TYPE> getSubscriptions(void) const;
+    inline const QVector<EVENT_TYPE> getSubscriptions(void) const;
 
     //=========================================================================================================
     /**
@@ -190,7 +190,7 @@ inline Communicator::CommunicatorID Communicator::nextID()
 
 //=============================================================================================================
 
-inline QVector<EVENT_TYPE> Communicator::getSubscriptions(void) const
+inline const QVector<EVENT_TYPE> Communicator::getSubscriptions(void) const
 {
     return m_EventSubscriptions;
 }

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
@@ -72,7 +72,14 @@ EventManager::EventManager()
 
 //=============================================================================================================
 
-void EventManager::addCommunicator(Communicator* commu)
+void EventManager::addCommunicator(Communicator *commu)
+{
+    getEventManager().addCommunicatorInt(commu);
+}
+
+//=============================================================================================================
+
+void EventManager::addCommunicatorInt(Communicator* commu)
 {
     QMutexLocker temp(&m_routingTableMutex);
     const QVector<EVENT_TYPE>& subscriptions = commu->getSubscriptions();

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
@@ -129,6 +129,14 @@ void EventManager::addSubscriptionsInt(Communicator* commu,
 void EventManager::updateSubscriptions(Communicator* commu,
                                        const QVector<EVENT_TYPE> &subs)
 {
+    getEventManager().updateSubscriptionsInt(commu, subs);
+}
+
+//=============================================================================================================
+
+void EventManager::updateSubscriptionsInt(Communicator* commu,
+                                       const QVector<EVENT_TYPE> &subs)
+{
     // remove all old subscriptions from EventManager routing table
     removeCommunicator(commu);
     // add new key-value-pairs into map
@@ -138,6 +146,13 @@ void EventManager::updateSubscriptions(Communicator* commu,
 //=============================================================================================================
 
 void EventManager::removeCommunicator(Communicator* commu)
+{
+    getEventManager().removeCommunicatorInt(commu);
+}
+
+//=============================================================================================================
+
+void EventManager::removeCommunicatorInt(Communicator* commu)
 {
     QMutexLocker temp(&m_routingTableMutex);
     for(const EVENT_TYPE& etype : commu->getSubscriptions())

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
@@ -222,6 +222,13 @@ bool EventManager::stopEventHandlingInt()
 
 bool EventManager::hasBufferedEvents()
 {
+    return getEventManager().hasBufferedEventsInt();
+}
+
+//=============================================================================================================
+
+bool EventManager::hasBufferedEventsInt()
+{
     QMutexLocker temp(&m_eventQMutex);
     return (m_eventQ.isEmpty() == false);
 }

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
@@ -93,6 +93,13 @@ void EventManager::addCommunicatorInt(Communicator* commu)
 
 void EventManager::issueEvent(QSharedPointer<Event> e)
 {
+    getEventManager().issueEventInt(e);
+}
+
+//=============================================================================================================
+
+void EventManager::issueEventInt(QSharedPointer<Event> e)
+{
     QMutexLocker temp(&m_eventQMutex);
     m_eventQ.enqueue(e);
     m_eventSemaphore.release();

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
@@ -107,8 +107,15 @@ void EventManager::issueEventInt(QSharedPointer<Event> e)
 
 //=============================================================================================================
 
-void EventManager::addSubscriptions(Communicator* commu,
+void EventManager::addSubscriptions(Communicator *commu,
                                     QVector<EVENT_TYPE> newsubs)
+{
+    getEventManager().addSubscriptionsInt(commu, newsubs);
+}
+//=============================================================================================================
+
+void EventManager::addSubscriptionsInt(Communicator* commu,
+                                       QVector<EVENT_TYPE> newsubs)
 {
     QMutexLocker temp(&m_routingTableMutex);
     for(const EVENT_TYPE& etype : newsubs)

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
@@ -296,5 +296,12 @@ void EventManager::run()
 
 void EventManager::shutdown()
 {
-    stopEventHandling();
+    getEventManager().shutdownInt();
+}
+
+//=============================================================================================================
+
+void EventManager::shutdownInt()
+{
+    stopEventHandlingInt();
 }

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.cpp
@@ -171,6 +171,13 @@ void EventManager::removeCommunicatorInt(Communicator* commu)
 
 bool EventManager::startEventHandling(float frequency)
 {
+    return getEventManager().startEventHandlingInt(frequency);
+}
+
+//=============================================================================================================
+
+bool EventManager::startEventHandlingInt(float frequency)
+{
     if (m_running)
     {
         qDebug() << "[EventManager::startEventHandling] WARNING ! somebody tried to call startEventHandling when already running...";
@@ -189,6 +196,13 @@ bool EventManager::startEventHandling(float frequency)
 //=============================================================================================================
 
 bool EventManager::stopEventHandling()
+{
+    return getEventManager().stopEventHandlingInt();
+}
+
+//=============================================================================================================
+
+bool EventManager::stopEventHandlingInt()
 {
     if (m_running)
     {

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.h
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.h
@@ -110,6 +110,24 @@ public:
      */
     static void issueEvent(QSharedPointer<Event> e);
 
+    //=========================================================================================================
+    /**
+     * Expands a Communicator's subscriptions by the specified list
+     *
+     * @param[in] commu          The Communicator to add the events for
+     * @param[in] newsubs        List of new (additional) subscriptions
+     */
+    static void addSubscriptions(Communicator* commu, QVector<EVENT_TYPE> newsubs);
+
+    //=========================================================================================================
+    /**
+     * Replaces a Communicators subscriptions with the specified list.
+     *
+     * @param[in] commu          The respective Communicator
+     * @param[in] subs           New list of subscriptions
+     */
+    static void updateSubscriptions(Communicator* commu, const QVector<EVENT_TYPE> &subs);
+
 private:
     //=========================================================================================================
     /**
@@ -122,32 +140,35 @@ private:
 
     //=========================================================================================================
     /**
-     * Internal function to be called by issueEvent static function. Communicate an event to all entities that have registered for the respective event type.
-     * The Event will get buffered in a queue and processed during the next processing cycle.
+     * Internal function to be called by issueEvent static function. Communicate an event to all entities that
+     * have registered for the respective event type. The Event will get buffered in a queue and processed
+     * during the next processing cycle.
      *
      * @param[in] e              The event to publish.
      */
     void issueEventInt(QSharedPointer<Event> e);
 
-public:
     //=========================================================================================================
     /**
-     * Expands a Communicator's subscriptions by the specified list
+     * Internal function to be called by addSubscriptions. Expands a Communicator's subscriptions by the
+     * specified list
      *
      * @param[in] commu          The Communicator to add the events for.
      * @param[in] newsubs        List of new (additional) subscriptions.
      */
-    void addSubscriptions(Communicator* commu, QVector<EVENT_TYPE> newsubs);
+    void addSubscriptionsInt(Communicator* commu, QVector<EVENT_TYPE> newsubs);
 
     //=========================================================================================================
     /**
-     * Replaces a Communicators subscriptions with the specified list.
+     * Internal function to be called by updateSubscription. Replaces a Communicators subscriptions with the
+     * specified list.
      *
      * @param[in] commu          The respective Communicator.
      * @param[in] subs           New list of subscriptions.
      */
-    void updateSubscriptions(Communicator* commu, const QVector<EVENT_TYPE> &subs);
+    void updateSubscriptionsInt(Communicator* commu, const QVector<EVENT_TYPE> &subs);
 
+public:
     //=========================================================================================================
     /**
      * Removes (and thus disconnects) a Communicator and all its subscriptions from the routing table

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.h
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.h
@@ -128,6 +128,14 @@ public:
      */
     static void updateSubscriptions(Communicator* commu, const QVector<EVENT_TYPE> &subs);
 
+    //=========================================================================================================
+    /**
+     * Removes (and thus disconnects) a Communicator and all its subscriptions from the routing table
+     *
+     * @param[in] commu          The communicator to remove.
+     */
+    static void removeCommunicator(Communicator* commu);
+
 private:
     //=========================================================================================================
     /**
@@ -168,15 +176,15 @@ private:
      */
     void updateSubscriptionsInt(Communicator* commu, const QVector<EVENT_TYPE> &subs);
 
-public:
     //=========================================================================================================
     /**
-     * Removes (and thus disconnects) a Communicator and all its subscriptions from the routing table
+     * Internal function to be called by removeCommunicator. Removes (and thus disconnects) a Communicator and all its subscriptions from the routing table
      *
      * @param[in] commu          The communicator to remove.
      */
-    void removeCommunicator(Communicator* commu);
+    void removeCommunicatorInt(Communicator * commu);
 
+public:
     //=========================================================================================================
     /**
      * Starts the EventManagers thread that processes buffered events. The EventManager will try to maintain the

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.h
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.h
@@ -101,25 +101,35 @@ public:
      */
     static void addCommunicator(Communicator* commu);
 
-private:
-    //=========================================================================================================
-    /**
-     * Adds a Communicator, respectively its subscriptions to the routing table
-     *
-     * @param[in] commu          The Communicator to add
-     */
-    void addCommunicatorInt(Communicator* commu);
-
-public:
     //=========================================================================================================
     /**
      * Communicate an event to all entities that have registered for the respective event type.
      * The Event will get buffered in a queue and processed during the next processing cycle.
      *
+     * @param[in] e              The event to publish
+     */
+    static void issueEvent(QSharedPointer<Event> e);
+
+private:
+    //=========================================================================================================
+    /**
+     * Internal function to be called by addCommunicator. It adds a Communicator, respectively its subscriptions
+     * to the routing table
+     *
+     * @param[in] commu          The Communicator to add
+     */
+    void addCommunicatorInt(Communicator* commu);
+
+    //=========================================================================================================
+    /**
+     * Internal function to be called by issueEvent static function. Communicate an event to all entities that have registered for the respective event type.
+     * The Event will get buffered in a queue and processed during the next processing cycle.
+     *
      * @param[in] e              The event to publish.
      */
-    void issueEvent(QSharedPointer<Event> e);
+    void issueEventInt(QSharedPointer<Event> e);
 
+public:
     //=========================================================================================================
     /**
      * Expands a Communicator's subscriptions by the specified list

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.h
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.h
@@ -161,7 +161,13 @@ public:
      *
      * @return Whether or not the EventManager has unprocessed events.
      */
-    bool hasBufferedEvents();
+    static bool hasBufferedEvents();
+
+    //=========================================================================================================
+    /**
+     * This is called when the user presses the "close" button
+     */
+    static void shutdown();
 
 private:
     //=========================================================================================================
@@ -242,22 +248,19 @@ private:
      */
     bool hasBufferedEventsInt();
 
-public:
+    //=========================================================================================================
+    /**
+     * Internal fcn to be called by shutdown(). This is called when the user presses the "close" button
+     */
+    void shutdownInt();
+
     //=========================================================================================================
     /**
      * Static method for singleton implementation (returns reference to local static object)
      *
-     * @return A reference to the EventManager singleton.
+     * @return A reference to the EventManager singleton
      */
     static EventManager& getEventManager();
-
-    //=========================================================================================================
-    /**
-     * This is called when the user presses the "close" button
-     */
-    void shutdown();
-
-private:
 
     //=========================================================================================================
     /**

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.h
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.h
@@ -136,6 +136,25 @@ public:
      */
     static void removeCommunicator(Communicator* commu);
 
+    //=========================================================================================================
+    /**
+     * Starts the EventManagers thread that processes buffered events. The EventManager will try to maintain the
+     * specified frequency of dealing with buffered events (frequency in Hz)
+     *
+     * @param frequency          The frequency in Hz to start working through all buffered events.
+     * @return                   Whether starting was successfull
+     */
+    static bool startEventHandling(float frequency = 25.0f);
+
+    //=========================================================================================================
+    /**
+     * Stops the EventThread. Depending on the specified event-processing frequency, this might take some time
+     * (up to one waiting period, to be precise. Example: EventManager running on 20 Hz -> up to 50 ms shutdown).
+     *
+     * @return                   Whether stopping was successfull
+     */
+    static bool stopEventHandling();
+
 private:
     //=========================================================================================================
     /**
@@ -178,22 +197,23 @@ private:
 
     //=========================================================================================================
     /**
-     * Internal function to be called by removeCommunicator. Removes (and thus disconnects) a Communicator and all its subscriptions from the routing table
+     * Internal function to be called by removeCommunicator. Removes (and thus disconnects) a Communicator
+     * and all its subscriptions from the routing table.
      *
      * @param[in] commu          The communicator to remove.
      */
     void removeCommunicatorInt(Communicator * commu);
 
-public:
     //=========================================================================================================
     /**
-     * Starts the EventManagers thread that processes buffered events. The EventManager will try to maintain the
-     * specified frequency of dealing with buffered events (frequency in Hz)
+     * Internal function to be called by startEventHandling. Starts the EventManagers thread that processes
+     * buffered events. The EventManager will try to maintain the specified frequency of dealing with
+     * buffered events (frequency in Hz).
      *
      * @param[in] frequency          The frequency in Hz to start working through all buffered events.
      * @return                   Whether starting was successfull.
      */
-    bool startEventHandling(float frequency = 25.0f);
+    bool startEventHandlingInt(float frequency = 25.0f);
 
     //=========================================================================================================
     /**
@@ -202,7 +222,8 @@ public:
      *
      * @return                   Whether stopping was successfull.
      */
-    bool stopEventHandling();
+    bool stopEventHandlingInt();
+public:
 
     //=========================================================================================================
     /**

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.h
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.h
@@ -99,8 +99,18 @@ public:
      *
      * @param[in] commu          The Communicator to add.
      */
-    void addCommunicator(Communicator* commu);
+    static void addCommunicator(Communicator* commu);
 
+private:
+    //=========================================================================================================
+    /**
+     * Adds a Communicator, respectively its subscriptions to the routing table
+     *
+     * @param[in] commu          The Communicator to add
+     */
+    void addCommunicatorInt(Communicator* commu);
+
+public:
     //=========================================================================================================
     /**
      * Communicate an event to all entities that have registered for the respective event type.

--- a/applications/mne_analyze/libs/anShared/Management/eventmanager.h
+++ b/applications/mne_analyze/libs/anShared/Management/eventmanager.h
@@ -155,6 +155,14 @@ public:
      */
     static bool stopEventHandling();
 
+    //=========================================================================================================
+    /**
+     * Indicates whether or not the EventManager currently holds any unprocessed events.
+     *
+     * @return Whether or not the EventManager has unprocessed events.
+     */
+    bool hasBufferedEvents();
+
 private:
     //=========================================================================================================
     /**
@@ -217,22 +225,24 @@ private:
 
     //=========================================================================================================
     /**
-     * Stops the EventThread. Depending on the specified event-processing frequency, this might take some time
-     * (up to one waiting period, to be precise. Example: EventManager running on 20 Hz -> up to 50 ms shutdown).
+     * Internal fcn to be called by stopEventHandling. Stops the EventThread. Depending on the specified
+     * event-processing frequency, this might take some time (up to one waiting period, to be precise.
+     * Example: EventManager running on 20 Hz -> up to 50 ms shutdown).
      *
      * @return                   Whether stopping was successfull.
      */
     bool stopEventHandlingInt();
-public:
 
     //=========================================================================================================
     /**
-     * Indicates whether or not the EventManager currently holds any unprocessed events.
+     * Internal fcn to be called by hasBufferedEvents. Indicates whether or not the EventManager currently
+     * holds any unprocessed events.
      *
      * @return Whether or not the EventManager has unprocessed events.
      */
-    bool hasBufferedEvents();
+    bool hasBufferedEventsInt();
 
+public:
     //=========================================================================================================
     /**
      * Static method for singleton implementation (returns reference to local static object)

--- a/applications/mne_analyze/mne_analyze/analyzecore.cpp
+++ b/applications/mne_analyze/mne_analyze/analyzecore.cpp
@@ -211,7 +211,7 @@ void AnalyzeCore::registerMetaTypes()
 
 void AnalyzeCore::onMainWindowClosed()
 {
-    EventManager::getEventManager().shutdown();
+    EventManager::shutdown();
 
     // shutdown every plugin, empty analzye data etc.
     m_pPluginManager->shutdown();

--- a/applications/mne_analyze/mne_analyze/analyzecore.cpp
+++ b/applications/mne_analyze/mne_analyze/analyzecore.cpp
@@ -179,7 +179,7 @@ void AnalyzeCore::initGlobalData()
 
 void AnalyzeCore::initEventSystem()
 {
-    EventManager::getEventManager().startEventHandling();
+    EventManager::startEventHandling();
 }
 
 //=============================================================================================================


### PR DESCRIPTION
Hi, 
I wanted the functionality in the singleton EventManager to be accessible through static fcns. Right now it is set to the typical getInstance() method which then allows to retrieve public access to the class. Through this change (sugar) the api is directly accessible and it looks more natural to consume the class's API. 

+ bonus: In Communicator, there is a range for that was detaching from the Qt structure unnecessarily. Apparently, by making it const, c++ will iterate through references. Warnings-- (✊🏻)