### PR TITLE
[ENH] MNE_Scan splashscreen

### DIFF
--- a/applications/mne_scan/mne_scan/main.cpp
+++ b/applications/mne_scan/mne_scan/main.cpp
@@ -171,8 +171,6 @@ int main(int argc, char *argv[])
     fmt.setSamples(10);
     QSurfaceFormat::setDefaultFormat(fmt);
 
-    mainWin.hideSplashScreen();
-
     int returnValue(app.exec());
 
     return returnValue;

--- a/applications/mne_scan/mne_scan/main.cpp
+++ b/applications/mne_scan/mne_scan/main.cpp
@@ -166,7 +166,6 @@ int main(int argc, char *argv[])
     SCMEASLIB::MeasurementTypes::registerTypes();
 
     MainWindow mainWin;
-    mainWin.show();
 
     QSurfaceFormat fmt;
     fmt.setSamples(10);

--- a/applications/mne_scan/mne_scan/mainsplashscreen.cpp
+++ b/applications/mne_scan/mne_scan/mainsplashscreen.cpp
@@ -55,6 +55,20 @@ using namespace MNESCAN;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
+MainSplashScreen::MainSplashScreen ()
+: MainSplashScreen(QPixmap())
+{
+}
+
+//=============================================================================================================
+
+MainSplashScreen::MainSplashScreen (const QPixmap & pixmap)
+: MainSplashScreen(pixmap, 0)
+{
+}
+
+//=============================================================================================================
+
 MainSplashScreen::MainSplashScreen (const QPixmap & pixmap, Qt::WindowFlags f)
 : QSplashScreen(pixmap, f)
 {

--- a/applications/mne_scan/mne_scan/mainsplashscreen.h
+++ b/applications/mne_scan/mne_scan/mainsplashscreen.h
@@ -80,9 +80,25 @@ public:
      * Construct a splash screen that will display the pixmap.
      *
      * @param[in] pixmap is the background of the splash screen.
+     */
+    MainSplashScreen ();
+
+    //=========================================================================================================
+    /**
+     * Construct a splash screen that will display the pixmap.
+     *
+     * @param[in] pixmap is the background of the splash screen.
+     */
+    MainSplashScreen (const QPixmap & pixmap);
+
+    //=========================================================================================================
+    /**
+     * Construct a splash screen that will display the pixmap.
+     *
+     * @param[in] pixmap is the background of the splash screen.
      * @param[in] f There should be no need to set the widget flags, f, except perhaps Qt::WindowStaysOnTopHint.
      */
-    MainSplashScreen (const QPixmap & pixmap = QPixmap(), Qt::WindowFlags f = 0);
+    MainSplashScreen (const QPixmap & pixmap, Qt::WindowFlags f);
     //=========================================================================================================
     /**
      * Destroys the MainSplashScreen.

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.cpp
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.cpp
@@ -62,13 +62,13 @@ constexpr unsigned long defaultTimeToWait(3);
 
 //=============================================================================================================
 
-MainSplashScreenHider::MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen)
+MainSplashScreenHider::MainSplashScreenHider(MainSplashScreen& splashScreen)
 : MainSplashScreenHider(splashScreen, defaultTimeToWait)
 { }
 
 //=============================================================================================================
 
-MainSplashScreenHider::MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen, unsigned long sleepTime)
+MainSplashScreenHider::MainSplashScreenHider(MainSplashScreen& splashScreen, unsigned long sleepTime)
 : m_pSlashScreenToHide(splashScreen)
 , m_iSecondsToSleep(sleepTime)
 { }
@@ -78,7 +78,7 @@ MainSplashScreenHider::MainSplashScreenHider(QSharedPointer<MainSplashScreen> sp
 void MainSplashScreenHider::run()
 {
     sleep(m_iSecondsToSleep);
-    m_pSlashScreenToHide->hide();
+    m_pSlashScreenToHide.hide();
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.cpp
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.cpp
@@ -1,0 +1,71 @@
+//=============================================================================================================
+/**
+ * @file     mainsplashscreenhider.cpp
+ * @author   Juan GPC <jgarciaprieto@mgh.harvard.edu>
+ * @since    0.1.9
+ * @date     May, 2021
+ *
+ * @section  LICENSE
+ *
+ * Copyright (C) 2021, Juan Garcia-Prieto. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *     * Neither the name of MNE-CPP authors nor the names of its contributors may be used
+ *       to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * @brief    Class responsible of hiding the splash screen.
+ *
+ */
+
+//=============================================================================================================
+// INCLUDES
+//=============================================================================================================
+
+#include "mainsplashscreenhider.h"
+
+//=============================================================================================================
+// QT INCLUDES
+//=============================================================================================================
+
+//=============================================================================================================
+// USED NAMESPACES
+//=============================================================================================================
+
+using namespace MNESCAN;
+
+//=============================================================================================================
+// DEFINE MEMBER METHODS
+//=============================================================================================================
+
+MainSplashScreenHider::MainSplashScreenHider()
+{
+
+}
+
+//=============================================================================================================
+
+void MainSplashScreenHider::run()
+{
+
+}
+
+//=============================================================================================================
+
+
+
+

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.cpp
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.cpp
@@ -75,6 +75,17 @@ MainSplashScreenHider::MainSplashScreenHider(MainSplashScreen& splashScreen, uns
 
 //=============================================================================================================
 
+MainSplashScreenHider::~MainSplashScreenHider()
+{
+  quit();
+  #if QT_VERSION >= QT_VERSION_CHECK(5,2,0)
+  requestInterruption();
+  #endif
+  wait();
+}
+
+//=============================================================================================================
+
 void MainSplashScreenHider::run()
 {
     sleep(m_iSecondsToSleep);

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.cpp
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.cpp
@@ -43,6 +43,12 @@
 //=============================================================================================================
 
 //=============================================================================================================
+// INCLUDES
+//=============================================================================================================
+
+#include "mainsplashscreen.h"
+
+//=============================================================================================================
 // USED NAMESPACES
 //=============================================================================================================
 
@@ -52,16 +58,27 @@ using namespace MNESCAN;
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-MainSplashScreenHider::MainSplashScreenHider()
-{
+constexpr unsigned long defaultTimeToWait(3);
 
-}
+//=============================================================================================================
+
+MainSplashScreenHider::MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen)
+: MainSplashScreenHider(splashScreen, defaultTimeToWait)
+{ }
+
+//=============================================================================================================
+
+MainSplashScreenHider::MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen, unsigned long sleepTime)
+: m_pSlashScreenToHide(splashScreen)
+, m_iSecondsToSleep(sleepTime)
+{ }
 
 //=============================================================================================================
 
 void MainSplashScreenHider::run()
 {
-
+    sleep(m_iSecondsToSleep);
+    m_pSlashScreenToHide->hide();
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.h
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.h
@@ -76,10 +76,17 @@ class MainSplashScreenHider : public QThread
 {
     Q_OBJECT
 public:
+    //=========================================================================================================
     MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen);
+
+    //=========================================================================================================
     MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen, unsigned long sleepTime);
 
 protected:
+    //=========================================================================================================
+    /**
+     * Method to be run from another thread.
+     */
     void run();
 
     QSharedPointer<MNESCAN::MainSplashScreen> m_pSlashScreenToHide;     /**< Pointer to the slpash screen to hide.*/

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.h
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.h
@@ -77,6 +77,8 @@ class MainSplashScreenHider : public QThread
 {
     Q_OBJECT
 public:
+    typedef QSharedPointer<MainSplashScreenHider> SPtr;               /**< Shared pointer type for MainSplashScreenHider. */
+    typedef QSharedPointer<const MainSplashScreenHider> ConstSPtr;    /**< Const shared pointer type for MainSplashScreenHider. */
     //=========================================================================================================
     MainSplashScreenHider(MainSplashScreen& splashScreen);
 

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.h
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.h
@@ -44,6 +44,7 @@
 //=============================================================================================================
 
 #include <QThread>
+#include <QWeakPointer>
 
 //=============================================================================================================
 // QT INCLUDES
@@ -77,10 +78,10 @@ class MainSplashScreenHider : public QThread
     Q_OBJECT
 public:
     //=========================================================================================================
-    MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen);
+    MainSplashScreenHider(MainSplashScreen& splashScreen);
 
     //=========================================================================================================
-    MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen, unsigned long sleepTime);
+    MainSplashScreenHider(MainSplashScreen& splashScreen, unsigned long sleepTime);
 
 protected:
     //=========================================================================================================
@@ -89,7 +90,7 @@ protected:
      */
     void run();
 
-    QSharedPointer<MNESCAN::MainSplashScreen> m_pSlashScreenToHide;     /**< Pointer to the slpash screen to hide.*/
+    MainSplashScreen& m_pSlashScreenToHide;       /**< Pointer to the slpash screen to hide.*/
     unsigned long   m_iSecondsToSleep;                                  /**< Time to wait before hiding the splash window.*/
 };
 

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.h
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.h
@@ -1,0 +1,82 @@
+//=============================================================================================================
+/**
+ * @file     mainsplashscreenhider.cpp
+ * @author   Juan GPC <jgarciaprieto@mgh.harvard.edu>
+ * @since    0.1.9
+ * @date     May, 2021
+ *
+ * @section  LICENSE
+ *
+ * Copyright (C) 2021, Juan Garcia-Prieto. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *     * Neither the name of MNE-CPP authors nor the names of its contributors may be used
+ *       to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * @brief    Class responsible of hiding the splash screen.
+ *
+ */
+
+#ifndef MAINSPLASHSCREENHIDER_H
+#define MAINSPLASHSCREENHIDER_H
+
+//=============================================================================================================
+// INCLUDES
+//=============================================================================================================
+
+//=============================================================================================================
+// QT INCLUDES
+//=============================================================================================================
+
+#include <QThread>
+
+//=============================================================================================================
+// FORWARD DECLARATIONS
+//=============================================================================================================
+
+
+//=============================================================================================================
+// DEFINE NAMESPACE MNESCAN
+//=============================================================================================================
+
+namespace MNESCAN
+{
+
+//=============================================================================================================
+// MNESCAN FORWARD DECLARATIONS
+//=============================================================================================================
+
+//=============================================================================================================
+/**
+ * Provides a class for QThread to work on a separate thread, just to hide the splash screen window whenever
+ * found convenient.
+ */
+class MainSplashScreenHider : public QThread
+{
+    Q_OBJECT
+public:
+    MainSplashScreenHider();
+
+protected:
+    void run();
+
+
+};
+
+} // namespace MNESCAN
+#endif // MAINSPLASHSCREENHIDER_H

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.h
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.h
@@ -85,6 +85,8 @@ public:
     //=========================================================================================================
     MainSplashScreenHider(MainSplashScreen& splashScreen, unsigned long sleepTime);
 
+    ~MainSplashScreenHider();
+
 protected:
     //=========================================================================================================
     /**

--- a/applications/mne_scan/mne_scan/mainsplashscreenhider.h
+++ b/applications/mne_scan/mne_scan/mainsplashscreenhider.h
@@ -46,6 +46,12 @@
 #include <QThread>
 
 //=============================================================================================================
+// QT INCLUDES
+//=============================================================================================================
+
+#include "mainsplashscreen.h"
+
+//=============================================================================================================
 // FORWARD DECLARATIONS
 //=============================================================================================================
 
@@ -61,7 +67,7 @@ namespace MNESCAN
 // MNESCAN FORWARD DECLARATIONS
 //=============================================================================================================
 
-//=============================================================================================================
+
 /**
  * Provides a class for QThread to work on a separate thread, just to hide the splash screen window whenever
  * found convenient.
@@ -70,12 +76,14 @@ class MainSplashScreenHider : public QThread
 {
     Q_OBJECT
 public:
-    MainSplashScreenHider();
+    MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen);
+    MainSplashScreenHider(QSharedPointer<MainSplashScreen> splashScreen, unsigned long sleepTime);
 
 protected:
     void run();
 
-
+    QSharedPointer<MNESCAN::MainSplashScreen> m_pSlashScreenToHide;     /**< Pointer to the slpash screen to hide.*/
+    unsigned long   m_iSecondsToSleep;                                  /**< Time to wait before hiding the splash window.*/
 };
 
 } // namespace MNESCAN

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -282,10 +282,10 @@ void MainWindow::initSplashScreen(bool bShowSplashScreen)
 
 void MainWindow::hideSplashScreen()
 {
-    auto splashScreenHider = new MainSplashScreenHider(*m_pSplashScreen.get(),
+    m_pSplashScreenHider = MainSplashScreenHider::SPtr::create(*m_pSplashScreen.get(),
                                                        waitUntilHidingSplashScreen);
     m_pSplashScreen->clearMessage();
-    splashScreenHider->start();
+    m_pSplashScreenHider->start();
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -37,6 +37,8 @@
 // INCLUDES
 //=============================================================================================================
 
+#include <iostream>
+
 #include <scShared/Management/pluginmanager.h>
 #include <scShared/Management/pluginscenemanager.h>
 #include <scShared/Management/displaymanager.h>
@@ -56,6 +58,7 @@
 #include "startupwidget.h"
 #include "plugingui.h"
 #include "info.h"
+#include "mainsplashscreenhider.h"
 
 //=============================================================================================================
 // QT INCLUDES
@@ -70,8 +73,6 @@
 #include <QFileInfo>
 #include <QStandardPaths>
 
-#include <iostream>
-
 //=============================================================================================================
 // USED NAMESPACES
 //=============================================================================================================
@@ -85,7 +86,8 @@ using namespace DISPLIB;
 // CONST
 //=============================================================================================================
 
-const QString pluginDir = "/mne_scan_plugins";        /**< holds path to plugins.*/
+const QString pluginDir = "/mne_scan_plugins";          /**< holds path to plugins.*/
+constexpr unsigned long waitUntilHidingSplashScreen(2);     /**< Seconds to wait after the application setup has finished, before hiding the splash screen.*/
 
 //=============================================================================================================
 // DEFINE MEMBER METHODS
@@ -253,7 +255,8 @@ void MainWindow::onGuiModeChanged()
 
 void MainWindow::hideSplashScreen()
 {
-    m_pSplashScreen->hide();
+    MainSplashScreenHider splashScreenHider(m_pSplashScreen,
+                                            waitUntilHidingSplashScreen);
 }
 
 void MainWindow::setSplashScreen(bool bShowSplashScreen)

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -129,6 +129,7 @@ MainWindow::MainWindow(QWidget *parent)
     QMainWindow::setWindowIcon(QIcon(":/images/images/appIcons/icon_mne_scan_256x256.png"));
 #endif
 
+    hideSplashScreen();
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -128,6 +128,7 @@ MainWindow::MainWindow(QWidget *parent)
     qInfo() << "Loading icon...";
     QMainWindow::setWindowIcon(QIcon(":/images/images/appIcons/icon_mne_scan_256x256.png"));
 #endif
+
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -282,7 +282,7 @@ void MainWindow::initSplashScreen(bool bShowSplashScreen)
 
 void MainWindow::hideSplashScreen()
 {
-    m_pSplashScreenHider = MainSplashScreenHider::SPtr::create(*m_pSplashScreen.get(),
+    m_pSplashScreenHider = MainSplashScreenHider::SPtr::create(*m_pSplashScreen.data(),
                                                        waitUntilHidingSplashScreen);
     m_pSplashScreen->clearMessage();
     m_pSplashScreenHider->start();

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -87,7 +87,7 @@ using namespace DISPLIB;
 //=============================================================================================================
 
 const QString pluginDir = "/mne_scan_plugins";          /**< holds path to plugins.*/
-constexpr unsigned long waitUntilHidingSplashScreen(2);     /**< Seconds to wait after the application setup has finished, before hiding the splash screen.*/
+constexpr unsigned long waitUntilHidingSplashScreen(1);     /**< Seconds to wait after the application setup has finished, before hiding the splash screen.*/
 
 //=============================================================================================================
 // DEFINE MEMBER METHODS
@@ -118,7 +118,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     setUnifiedTitleAndToolBarOnMac(false);
 
-    setSplashScreen();
+    initSplashScreen(true);
 
     setupPlugins();
     setupUI();
@@ -253,17 +253,11 @@ void MainWindow::onGuiModeChanged()
 
 //=============================================================================================================
 
-void MainWindow::hideSplashScreen()
-{
-    MainSplashScreenHider splashScreenHider(m_pSplashScreen,
-                                            waitUntilHidingSplashScreen);
-}
-
-void MainWindow::setSplashScreen(bool bShowSplashScreen)
+void MainWindow::initSplashScreen(bool bShowSplashScreen)
 {
     QPixmap splashPixMap(":/images/splashscreen.png");
-    m_pSplashScreen = MainSplashScreen::SPtr::create(splashPixMap);
-
+    m_pSplashScreen = MainSplashScreen::SPtr::create(splashPixMap,
+                                                    Qt::WindowFlags() | Qt::WindowStaysOnTopHint );
     if(m_pSplashScreen && m_pPluginManager) {
         QObject::connect(m_pPluginManager.data(), &PluginManager::pluginLoaded,
                          m_pSplashScreen.data(), &MainSplashScreen::showMessage);
@@ -273,6 +267,15 @@ void MainWindow::setSplashScreen(bool bShowSplashScreen)
         m_pSplashScreen->finish(this);
         m_pSplashScreen->show();
     }
+}
+
+//=============================================================================================================
+
+void MainWindow::hideSplashScreen()
+{
+    MainSplashScreenHider splashScreenHider(m_pSplashScreen,
+                                            waitUntilHidingSplashScreen);
+//    splashScreenHider.start();
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -118,7 +118,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     setUnifiedTitleAndToolBarOnMac(false);
 
-    initSplashScreen(true);
+    initSplashScreen();
 
     setupPlugins();
     setupUI();
@@ -132,6 +132,7 @@ MainWindow::MainWindow(QWidget *parent)
 #endif
 
     hideSplashScreen();
+    show();
 }
 
 //=============================================================================================================
@@ -253,6 +254,14 @@ void MainWindow::onGuiModeChanged()
 
 //=============================================================================================================
 
+void MainWindow::initSplashScreen()
+{
+    bool showSplashScreen(true);
+    initSplashScreen(showSplashScreen);
+}
+
+//=============================================================================================================
+
 void MainWindow::initSplashScreen(bool bShowSplashScreen)
 {
     QPixmap splashPixMap(":/images/splashscreen.png");
@@ -273,9 +282,10 @@ void MainWindow::initSplashScreen(bool bShowSplashScreen)
 
 void MainWindow::hideSplashScreen()
 {
-    MainSplashScreenHider splashScreenHider(m_pSplashScreen,
-                                            waitUntilHidingSplashScreen);
-//    splashScreenHider.start();
+    auto splashScreenHider = new MainSplashScreenHider(*m_pSplashScreen.get(),
+                                                       waitUntilHidingSplashScreen);
+    m_pSplashScreen->clearMessage();
+    splashScreenHider->start();
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/mainwindow.h
+++ b/applications/mne_scan/mne_scan/mainwindow.h
@@ -392,7 +392,7 @@ private:
     QPointer<QAction>                   m_pActionRun;                   /**< run application. */
     QPointer<QAction>                   m_pActionStop;                  /**< stop application. */
     QPointer<QAction>                   m_pActionDefaultMode;           /**< stop application. */
-    QPointer<QAction>                   m_pActionResearchMode;        /**< activate research gui mode. */
+    QPointer<QAction>                   m_pActionResearchMode;          /**< activate research gui mode. */
     QPointer<QAction>                   m_pActionClinicalMode;          /**< activate clinical gui mode. */
 
     QList<QAction*>                     m_qListDynamicPluginActions;    /**< dynamic plugin actions. */

--- a/applications/mne_scan/mne_scan/mainwindow.h
+++ b/applications/mne_scan/mne_scan/mainwindow.h
@@ -173,7 +173,7 @@ public:
      *
      * @param[in] bShowSplashScreen    Whether to show the splash screen until this widget is shown. Default is true.
      */
-    void setSplashScreen(bool bShowSplashScreen = true);
+    void initSplashScreen(bool bShowSplashScreen = true);
 
     //=========================================================================================================
     /**

--- a/applications/mne_scan/mne_scan/mainwindow.h
+++ b/applications/mne_scan/mne_scan/mainwindow.h
@@ -169,11 +169,18 @@ public:
 
     //=========================================================================================================
     /**
-     * Set the splash screen.
+     * Initialize the splash screen. By default, the slpash screen will be shown to the user.
+     *
+     */
+    void initSplashScreen();
+
+    //=========================================================================================================
+    /**
+     * Initialize the splash screen.
      *
      * @param[in] bShowSplashScreen    Whether to show the splash screen until this widget is shown. Default is true.
      */
-    void initSplashScreen(bool bShowSplashScreen = true);
+    void initSplashScreen(bool bShowSplashScreen);
 
     //=========================================================================================================
     /**

--- a/applications/mne_scan/mne_scan/mainwindow.h
+++ b/applications/mne_scan/mne_scan/mainwindow.h
@@ -42,6 +42,7 @@
 
 #include "info.h"
 #include "mainsplashscreen.h"
+#include "mainsplashscreenhider.h"
 
 #include <disp/viewers/abstractview.h>
 
@@ -432,7 +433,8 @@ private:
 
     QPointer<DISPLIB::QuickControlView> m_pQuickControlView;            /**< quick control widget. */
 
-    MainSplashScreen::SPtr              m_pSplashScreen;                /**< Holds the splash scren. */
+    MainSplashScreenHider::SPtr         m_pSplashScreenHider;           /**< Holds the object responsible of hiding the splashscreen. */
+    MainSplashScreen::SPtr              m_pSplashScreen;                /**< Holds the splash screen. */
 
     QSharedPointer<QTimer>                              m_pTimer;               /**< timer of the main application*/
     QSharedPointer<QTime>                               m_pTime;                /**< Holds current time output, updated with timeout of timer.*/

--- a/applications/mne_scan/mne_scan/mne_scan.pro
+++ b/applications/mne_scan/mne_scan/mne_scan.pro
@@ -142,6 +142,7 @@ CONFIG(debug, debug|release) {
 
 SOURCES += \
     main.cpp \
+    mainsplashscreenhider.cpp \
     startupwidget.cpp \
     mainsplashscreen.cpp \
     pluginscene.cpp \
@@ -152,6 +153,7 @@ SOURCES += \
 
 HEADERS += \
     info.h \
+    mainsplashscreenhider.h \
     startupwidget.h \
     mainsplashscreen.h \
     pluginscene.h \


### PR DESCRIPTION
I make MNE Scan's splash screen hide 1 second after the main application's gui has finished its setup. During that second the splash screen can be hidden just by clicking on it, and since the splashscreen's management is offloaded to a new thread, even with the splash screen on top, the main GUI is still responsive. 

I think it gives a much sense of well tuned application. Since it is pretty much the first interaction with the user, i think it has some importance. 

More info... Some prs back, MNE Scan splash screen used to not be taken off by the application after it started. It would simply remain underneath the main gui window. I fixed that by making mne_scan's splash screen to hide the moment the initialization of the main screen had finished. Right before the main application loop started. This was not good enouth, and since then, I planned on finding time to implement the behavior shown in this pr.

thanks.