### PR TITLE
[ENH] Avoid MNE_SCAN PluginItems' names in PluginScene to get chopped.

### DIFF
--- a/applications/mne_scan/mne_scan/pluginitem.cpp
+++ b/applications/mne_scan/mne_scan/pluginitem.cpp
@@ -58,7 +58,7 @@ using namespace MNESCAN;
 PluginItem::PluginItem(SCSHAREDLIB::AbstractPlugin::SPtr pPlugin, QMenu *contextMenu, QGraphicsItem *parent)
 : QGraphicsPolygonItem(parent)
 , m_pPlugin(pPlugin)
-, m_iWidth(90)
+, m_iWidth(12 * pPlugin->getName().length())
 , m_iHeight(40)
 , m_contextMenu(contextMenu)
 {
@@ -107,7 +107,7 @@ void PluginItem::paint(QPainter * painter, const QStyleOptionGraphicsItem * opti
 {
     QGraphicsPolygonItem::paint(painter, option, widget);
     painter->setPen(QPen(m_qColorContour, 1));
-    painter->drawText(-m_iWidth/2+6,6,m_pPlugin->getName().mid(0,10));
+    painter->drawText(-m_iWidth/2+6,6,m_pPlugin->getName());
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/pluginitem.cpp
+++ b/applications/mne_scan/mne_scan/pluginitem.cpp
@@ -107,7 +107,7 @@ void PluginItem::paint(QPainter * painter, const QStyleOptionGraphicsItem * opti
 {
     QGraphicsPolygonItem::paint(painter, option, widget);
     painter->setPen(QPen(m_qColorContour, 1));
-    painter->drawText(-m_iWidth/2+7,7,m_pPlugin->getName().mid(0,10));
+    painter->drawText(-m_iWidth/2+6,6,m_pPlugin->getName().mid(0,10));
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/pluginitem.cpp
+++ b/applications/mne_scan/mne_scan/pluginitem.cpp
@@ -105,27 +105,8 @@ PluginItem::~PluginItem()
 void PluginItem::paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget)
 {
     QGraphicsPolygonItem::paint(painter, option, widget);
-
     painter->setPen(QPen(m_qColorContour, 1));
-
-//    QString sKind("");
-//    switch (m_diagramType) {
-//        case StartEnd:
-//            break;
-//        case Algorithm:
-//            sKind = QString("Tool");
-//            break;
-//        case Sensor:
-//            sKind = QString("Sensor");
-//            break;
-//        default:
-//            sKind = QString("IO");
-//            break;
-//    }
-
     painter->drawText(-m_iWidth/2+7,7,m_pPlugin->getName().mid(0,10));
-
-//    painter->drawText(-m_iWidth/2+4,-m_iHeight/2+28,m_pPlugin->getName().mid(8,8));
 }
 
 //=============================================================================================================
@@ -194,18 +175,4 @@ QVariant PluginItem::itemChange(GraphicsItemChange change, const QVariant &value
     }
 
     return value;
-
-//    if (change == ItemPositionChange && scene()) {
-//        // value is the new position.
-//        QPointF newPos = value.toPointF();
-//        QRectF rect = scene()->sceneRect();
-//        if (!rect.contains(newPos)) {
-//            // Keep the item inside the scene rect.
-//            newPos.setX(qMin(rect.right(), qMax(newPos.x(), rect.left())));
-//            newPos.setY(qMin(rect.bottom(), qMax(newPos.y(), rect.top())));
-//            return newPos;
-//        }
-//    }
-
-//    return QGraphicsItem::itemChange(change, value);
 }

--- a/applications/mne_scan/mne_scan/pluginitem.cpp
+++ b/applications/mne_scan/mne_scan/pluginitem.cpp
@@ -57,7 +57,7 @@ using namespace MNESCAN;
 PluginItem::PluginItem(SCSHAREDLIB::AbstractPlugin::SPtr pPlugin, QMenu *contextMenu, QGraphicsItem *parent)
 : QGraphicsPolygonItem(parent)
 , m_pPlugin(pPlugin)
-, m_iWidth(60)
+, m_iWidth(90)
 , m_iHeight(40)
 , m_contextMenu(contextMenu)
 {
@@ -123,9 +123,9 @@ void PluginItem::paint(QPainter * painter, const QStyleOptionGraphicsItem * opti
 //            break;
 //    }
 
-    painter->drawText(-m_iWidth/2+4,-m_iHeight/2+14,m_pPlugin->getName().mid(0,8));
+    painter->drawText(-m_iWidth/2+7,7,m_pPlugin->getName().mid(0,10));
 
-    painter->drawText(-m_iWidth/2+4,-m_iHeight/2+28,m_pPlugin->getName().mid(8,8));
+//    painter->drawText(-m_iWidth/2+4,-m_iHeight/2+28,m_pPlugin->getName().mid(8,8));
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/pluginitem.cpp
+++ b/applications/mne_scan/mne_scan/pluginitem.cpp
@@ -58,7 +58,7 @@ using namespace MNESCAN;
 PluginItem::PluginItem(SCSHAREDLIB::AbstractPlugin::SPtr pPlugin, QMenu *contextMenu, QGraphicsItem *parent)
 : QGraphicsPolygonItem(parent)
 , m_pPlugin(pPlugin)
-, m_iWidth(12 * pPlugin->getName().length())
+, m_iWidth(90)
 , m_iHeight(40)
 , m_contextMenu(contextMenu)
 {
@@ -107,7 +107,7 @@ void PluginItem::paint(QPainter * painter, const QStyleOptionGraphicsItem * opti
 {
     QGraphicsPolygonItem::paint(painter, option, widget);
     painter->setPen(QPen(m_qColorContour, 1));
-    painter->drawText(-m_iWidth/2+6,6,m_pPlugin->getName());
+    painter->drawText(-m_iWidth/2+6,6,m_pPlugin->getName().mid(0,10));
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/pluginitem.cpp
+++ b/applications/mne_scan/mne_scan/pluginitem.cpp
@@ -1,13 +1,14 @@
 //=============================================================================================================
 /**
  * @file     pluginitem.cpp
- * @author   Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ * @author   Christoph Dinh <chdinh@nmr.mgh.harvard.edu>,
+ *           Juan GPC <jgarciaprieto@mgh.harvard.edu>
  * @since    0.1.0
- * @date     August, 2013
+ * @date     May, 2021
  *
  * @section  LICENSE
  *
- * Copyright (C) 2013, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2021, Christoph Dinh, Juan GPC. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:


### PR DESCRIPTION
Hi, 

The size of each PluginItem in the PluginScene (PluginGui) in MNE_SCAN is a bit wider now. This makes it better to print a significant amount of characters of the name in the little plugin box. Before this, it was 8 characters per line in two lines. Now 
it is only one line with the first 10 characters. I think it is easier to remember and cleaner. 

It solves a bug, generated by some text being printed outside the box, which, when the box was dragged around would generate a little path on the PluginScene.

The complete name of the plugin remains visible in the control view once each PluginItem box is clicked. 

This is how it looks now: 
![image](https://user-images.githubusercontent.com/8955424/117212612-8fa5bc00-adc8-11eb-8c39-5cca14262d5e.png)

This is how it looks with this pr
![image](https://user-images.githubusercontent.com/8955424/117212299-2aea6180-adc8-11eb-98f3-0f50533521b6.png)
