### PR TITLE
[UPDATE] Make Coverity depend on Main branch and use googlegroups email address

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Coverity scripts
         run: |
           COVERITY_SCAN_PROJECT_NAME="mne-tools/mne-cpp"
-          COVERITY_SCAN_NOTIFICATION_EMAIL1="lorenzesch@hotmail.com"
-          COVERITY_SCAN_NOTIFICATION_EMAIL2="gbmotta@mgh.harvard.edu"
+          COVERITY_SCAN_NOTIFICATION_EMAIL="mne_cpp@googlegroups.com"
           COVERITY_SCAN_BRANCH_PATTERN="main"
           COVERITY_SCAN_BUILD_COMMAND_PREPEND="qmake -r MNECPP_CONFIG+=noTests"
           COVERITY_SCAN_BUILD_COMMAND="make -j4"


### PR DESCRIPTION
H, 

coverity.yml now makes Coverity depend on **master** branch instead of main. This pr address this. 

It also starts using a googlegroups email distribution list instead of using individual emails of developers. 