### PR TITLE
[FIX] MNE_Analyze store right-click context menu in fiffrawview plugin as member variables.

### DIFF
--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
@@ -375,6 +375,17 @@ void FiffRawView::onMakeScreenshot(const QString& imageType)
 
 //=============================================================================================================
 
+void FiffRawView::initRightClickContextMenu()
+{
+    m_pRightClickContextMenu = new QMenu(this);
+
+    m_pAddEventAction = m_pRightClickContextMenu->addAction(tr("Add Event"));
+    connect(m_pAddEventAction, &QAction::triggered,
+            this, &FiffRawView::addTimeMark, Qt::UniqueConnection);
+}
+
+//=============================================================================================================
+
 void FiffRawView::customContextMenuRequested(const QPoint &pos)
 {
     if(!m_pModel || m_pModel->isEmpty()) {
@@ -386,12 +397,6 @@ void FiffRawView::customContextMenuRequested(const QPoint &pos)
     int iMouseOffset = pos.x() / m_pModel->pixelDifference();
 
     m_iLastClickedSample = iFirstSampleOffset + iScrollBarOffset + iMouseOffset;
-
-    QMenu* menu = new QMenu(this);
-
-    QAction* markTime = menu->addAction(tr("Add Event"));
-    connect(markTime, &QAction::triggered,
-            this, &FiffRawView::addTimeMark, Qt::UniqueConnection);
 
     menu->popup(m_pTableView->viewport()->mapToGlobal(pos));
 }

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
@@ -97,6 +97,9 @@ FiffRawView::FiffRawView(QWidget *parent)
     //Create position labels
     createBottomLabels();
 
+    //Create Right-click Context menu
+    initRightClickContextMenu();
+
     m_pTableView->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
     //m_pTableView->horizontalScrollBar()->setRange(0, m_pTableView->horizontalScrollBar()->maximum() / 1000000);
     //m_pTableView->setShowGrid(true);
@@ -398,7 +401,7 @@ void FiffRawView::customContextMenuRequested(const QPoint &pos)
 
     m_iLastClickedSample = iFirstSampleOffset + iScrollBarOffset + iMouseOffset;
 
-    menu->popup(m_pTableView->viewport()->mapToGlobal(pos));
+    m_pRightClickContextMenu->popup(m_pTableView->viewport()->mapToGlobal(pos));
 }
 
 //=============================================================================================================

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.cpp
@@ -385,11 +385,6 @@ void FiffRawView::customContextMenuRequested(const QPoint &pos)
     int iScrollBarOffset = m_pTableView->horizontalScrollBar()->value() / m_pModel->pixelDifference();
     int iMouseOffset = pos.x() / m_pModel->pixelDifference();
 
-//    //double dScrollDiff = static_cast<double>(m_pTableView->horizontalScrollBar()->maximum()) / static_cast<double>(m_pModel->absoluteLastSample() - m_pModel->absoluteFirstSample());
-//    m_iLastClickedSample = floor((float)m_pModel->absoluteFirstSample() + //accounting for first sample offset
-//                             (m_pTableView->horizontalScrollBar()->value() / m_pModel->pixelDifference()) + //accounting for scroll offset
-//                             ((float)pos.x() / m_pModel->pixelDifference())); //accounting for mouse position offset
-
     m_iLastClickedSample = iFirstSampleOffset + iScrollBarOffset + iMouseOffset;
 
     QMenu* menu = new QMenu(this);

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
@@ -373,8 +373,15 @@ private:
     void updateVerticalScrollPosition(qint32 newScrollPosition);
 
     //=========================================================================================================
+    /**
+     * Reloads the view to show the new real-time data.
+     */
     void onNewRealtimeData();
 
+    //=========================================================================================================
+    /**
+     * Initialize the objects necessary for the righ-click add event menu to appear.
+     */
     void initRightClickContextMenu();
 
     QPointer<QTableView>                                m_pTableView;                   /**< Pointer to table view ui element. */

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
@@ -4,13 +4,14 @@
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
  *           Lars Debor <Lars.Debor@tu-ilmenau.de>;
  *           Simon Heinke <Simon.Heinke@tu-ilmenau.de>;
- *           Gabriel Motta <gbmotta@mgh.harvard.edu>
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>;
+ *           Juan GPC   <jgarciaprieto@mgh.harvard.edu>
  * @since    0.1.0
  * @date     July, 2018
  *
  * @section  LICENSE
  *
- * Copyright (C) 2018, Lorenz Esch, Lars Debor, Simon Heinke, Gabriel Motta. All rights reserved.
+ * Copyright (C) 2018, Lorenz Esch, Lars Debor, Simon Heinke, Gabriel Motta, Juan GPC. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
@@ -375,6 +375,7 @@ private:
     //=========================================================================================================
     void onNewRealtimeData();
 
+    void initRightClickMenu();
 
     QPointer<QTableView>                                m_pTableView;                   /**< Pointer to table view ui element. */
 
@@ -396,6 +397,8 @@ private:
     QLabel*                                             m_pEndTimeLabel;                /**< Right 'Sample | Seconds' display label. */
     QLabel*                                             m_pFileLabel;                   /**< File name and path, Fs and duration. */
     QLabel*                                             m_pFilterLabel;                 /**< Short filter description to be shown under the time-series. */
+    QMenu*                                              m_pRightClickContextMenu;       /**< Hold the menu that appears when a right-click event occurs. */
+    QAction*                                            m_pAddEventAction;              /**< Hold the action for directing callback for adding a new event. */
 signals:
     void tableViewDataWidthChanged(int iWidth);
 

--- a/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
+++ b/applications/mne_analyze/plugins/rawdataviewer/fiffrawview.h
@@ -375,7 +375,7 @@ private:
     //=========================================================================================================
     void onNewRealtimeData();
 
-    void initRightClickMenu();
+    void initRightClickContextMenu();
 
     QPointer<QTableView>                                m_pTableView;                   /**< Pointer to table view ui element. */
 


### PR DESCRIPTION
Instead of allocating a new menu and action each time the right-click mouse button is pressed, we store and reuse.