### PR TITLE
[MAINT] Add 'fits per second' control to hpi.

### DIFF
--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -131,8 +131,8 @@ MainWindow::MainWindow(QWidget *parent)
     QMainWindow::setWindowIcon(QIcon(":/images/images/appIcons/icon_mne_scan_256x256.png"));
 #endif
 
-    show();
     hideSplashScreen();
+    show();
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -131,8 +131,8 @@ MainWindow::MainWindow(QWidget *parent)
     QMainWindow::setWindowIcon(QIcon(":/images/images/appIcons/icon_mne_scan_256x256.png"));
 #endif
 
-    hideSplashScreen();
     show();
+    hideSplashScreen();
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -523,8 +523,6 @@ void Hpi::run()
 
         //pop matrix
         if(m_pCircularBuffer->pop(matData)) {
-            std::cout << matData;
-
             if(iDataIndexCounter + matData.cols() < matDataMerged.cols()) {
                 matDataMerged.block(0, iDataIndexCounter, matData.rows(), matData.cols()) = matData;
                 iDataIndexCounter += matData.cols();

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -258,6 +258,8 @@ void Hpi::initPluginControlWidgets()
                 this, &Hpi::onAllowedMovementChanged);
         connect(pHpiSettingsView, &HpiSettingsView::allowedRotationChanged,
                 this, &Hpi::onAllowedRotationChanged);
+        connect(pHpiSettingsView, &HpiSettingsView::fitsPerSecondChanged,
+                this, &Hpi::setNumberofFitsPerSecond);
         connect(this, &Hpi::errorsChanged,
                 pHpiSettingsView, &HpiSettingsView::setErrorLabels, Qt::BlockingQueuedConnection);
         connect(this, &Hpi::movementResultsChanged,
@@ -268,6 +270,7 @@ void Hpi::initPluginControlWidgets()
         onAllowedMeanErrorDistChanged(pHpiSettingsView->getAllowedMeanErrorDistChanged());
         onAllowedMovementChanged(pHpiSettingsView->getAllowedMovementChanged());
         onAllowedRotationChanged(pHpiSettingsView->getAllowedRotationChanged());
+        setNumberofFitsPerSecond(pHpiSettingsView->getNumFitsPerSecond());
 
         plControlWidgets.append(pHpiSettingsView);
 
@@ -440,6 +443,14 @@ void Hpi::onContHpiStatusChanged(bool bChecked)
     }
 
     m_bDoContinousHpi = bChecked;
+}
+
+//=============================================================================================================
+
+void Hpi::setNumberofFitsPerSecond(int iFitsPerSecond)
+{
+    QMutexLocker locker(&m_mutex);
+    m_iNumberOfFitsPerSecond = iFitsPerSecond;
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -73,7 +73,7 @@ using namespace INVERSELIB;
 // DEFINE LOCAL CONSTANTS
 //=============================================================================================================
 
-constexpr const int defaultFittingWindowSize(100);
+constexpr const int defaultFittingWindowSize(300);
 
 //=============================================================================================================
 // DEFINE MEMBER METHODS

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -508,6 +508,8 @@ void Hpi::run()
     while(!isInterruptionRequested()) {
         m_mutex.lock();
         if(iNumberOfFitsPerSecond != m_iNumberOfFitsPerSecond) {
+            iNumberOfFitsPerSecond = m_iNumberOfFitsPerSecond;
+            std::cout << "Number of Fits per second:" << iNumberOfFitsPerSecond << "\n";
             matDataMerged.resize(m_pFiffInfo->chs.size(), int(m_pFiffInfo->sfreq/iNumberOfFitsPerSecond));
             iDataIndexCounter = 0;
         }

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -70,11 +70,17 @@ using namespace Eigen;
 using namespace INVERSELIB;
 
 //=============================================================================================================
+// DEFINE LOCAL CONSTANTS
+//=============================================================================================================
+
+constexpr const int defaultFittingWindowSize(100);
+
+//=============================================================================================================
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
 Hpi::Hpi()
-: m_iNumberOfFitsPerSecond(3)
+: m_iNumberOfFitsPerSecond(defaultFittingWindowSize)
 , m_bDoFreqOrder(false)
 , m_bDoSingleHpi(false)
 , m_bDoContinousHpi(false)

--- a/applications/mne_scan/plugins/hpi/hpi.h
+++ b/applications/mne_scan/plugins/hpi/hpi.h
@@ -237,6 +237,14 @@ private:
 
     //=========================================================================================================
     /**
+     * Set nubmer of fits per second when doing continuous hpi.
+     *
+     * @param[in] iFitsPerSecond    number of fits per second
+     */
+    void setNumberofFitsPerSecond(int iFitsPerSecond);
+
+    //=========================================================================================================
+    /**
      * Read Polhemus data from fif file.
      */
     QList<FIFFLIB::FiffDigPoint> readPolhemusDig(const QString& fileName);

--- a/applications/mne_scan/plugins/hpi/hpi.h
+++ b/applications/mne_scan/plugins/hpi/hpi.h
@@ -237,11 +237,11 @@ private:
 
     //=========================================================================================================
     /**
-     * Set nubmer of fits per second when doing continuous hpi.
+     * Set fitting window size when doing continuous hpi.
      *
-     * @param[in] iFitsPerSecond    number of fits per second
+     * @param[in] winSize    window size in samples
      */
-    void setNumberofFitsPerSecond(int iFitsPerSecond);
+    void setFittingWindowSize(int winSize);
 
     //=========================================================================================================
     /**
@@ -262,7 +262,7 @@ private:
     QString                     m_sFilePathDigitzers;       /**< The file path to the current digitzers. */
 
     qint16                      m_iNumberBadChannels;       /**< The number of bad channels.*/
-    qint16                      m_iNumberOfFitsPerSecond;   /**< The number of allowed HPI fits per second. Default is 3.*/
+    qint16                      m_iFittingWindowSize;       /**< The number of samples in each fitting window.*/
 
     double                      m_dAllowedMeanErrorDist;    /**< The allowed error distance in order for the last fit to be counted as a good fit.*/
     double                      m_dAllowedMovement;         /**< The allowed head movement regarding reference head position.*/

--- a/libraries/disp/viewers/formfiles/hpisettingsview.ui
+++ b/libraries/disp/viewers/formfiles/hpisettingsview.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_loadDigitizers">
       <attribute name="title">
@@ -192,16 +192,44 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="m_pushButton_removeCoil">
-         <property name="text">
-          <string>-</string>
+        <widget class="QFrame" name="frame_AddRemove">
+         <property name="lineWidth">
+          <number>5</number>
          </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="m_pushButton_addCoil">
+            <property name="text">
+             <string>+</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="m_pushButton_removeCoil">
+            <property name="text">
+             <string>-</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="m_pushButton_addCoil">
-         <property name="text">
-          <string>+</string>
+        <widget class="QComboBox" name="comboBox_coilPreset">
+         <property name="placeholderText">
+          <string>Load preset</string>
          </property>
         </widget>
        </item>
@@ -643,8 +671,6 @@
   <tabstop>m_lineEdit_filePath</tabstop>
   <tabstop>m_pushButton_loadDigitizers</tabstop>
   <tabstop>m_tableWidget_Frequencies</tabstop>
-  <tabstop>m_pushButton_removeCoil</tabstop>
-  <tabstop>m_pushButton_addCoil</tabstop>
   <tabstop>m_pushButton_doFreqOrder</tabstop>
   <tabstop>m_checkBox_useSSP</tabstop>
   <tabstop>m_checkBox_useComp</tabstop>

--- a/libraries/disp/viewers/formfiles/hpisettingsview.ui
+++ b/libraries/disp/viewers/formfiles/hpisettingsview.ui
@@ -275,10 +275,51 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="m_checkBox_continousHPI">
-         <property name="text">
-          <string>Do continous HPI fitting</string>
-         </property>
+        <widget class="QWidget" name="widget" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="m_checkBox_continousHPI">
+            <property name="text">
+             <string>Do continous HPI fitting at</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="m_spinBox_fps">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>10</number>
+            </property>
+            <property name="value">
+             <number>3</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string> fits per second</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
@@ -578,7 +619,6 @@
   <tabstop>m_pushButton_doFreqOrder</tabstop>
   <tabstop>m_checkBox_useSSP</tabstop>
   <tabstop>m_checkBox_useComp</tabstop>
-  <tabstop>m_checkBox_continousHPI</tabstop>
   <tabstop>m_pushButton_doSingleFit</tabstop>
   <tabstop>m_tableWidget_errors</tabstop>
   <tabstop>m_doubleSpinBox_maxHPIContinousDist</tabstop>

--- a/libraries/disp/viewers/formfiles/hpisettingsview.ui
+++ b/libraries/disp/viewers/formfiles/hpisettingsview.ui
@@ -227,11 +227,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="comboBox_coilPreset">
-         <property name="placeholderText">
-          <string>Load preset</string>
-         </property>
-        </widget>
+        <widget class="QComboBox" name="comboBox_coilPreset"/>
        </item>
        <item>
         <widget class="QToolButton" name="m_pushButton_doFreqOrder">

--- a/libraries/disp/viewers/formfiles/hpisettingsview.ui
+++ b/libraries/disp/viewers/formfiles/hpisettingsview.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab_loadDigitizers">
       <attribute name="title">
@@ -299,23 +299,53 @@
             </property>
            </widget>
           </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="frame">
+         <property name="minimumSize">
+          <size>
+           <width>61</width>
+           <height>35</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="topMargin">
+           <number>4</number>
+          </property>
+          <property name="bottomMargin">
+           <number>4</number>
+          </property>
           <item>
-           <widget class="QSpinBox" name="m_spinBox_fps">
-            <property name="minimum">
-             <number>1</number>
+           <widget class="QSpinBox" name="m_spinBox_samplesToFit">
+            <property name="maximumSize">
+             <size>
+              <width>70</width>
+              <height>16777215</height>
+             </size>
             </property>
-            <property name="maximum">
+            <property name="minimum">
              <number>10</number>
             </property>
+            <property name="maximum">
+             <number>1000000</number>
+            </property>
             <property name="value">
-             <number>3</number>
+             <number>10</number>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string> fits per second</string>
+             <string>Win Size [Samples]</string>
             </property>
            </widget>
           </item>
@@ -610,7 +640,6 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>tabWidget</tabstop>
   <tabstop>m_lineEdit_filePath</tabstop>
   <tabstop>m_pushButton_loadDigitizers</tabstop>
   <tabstop>m_tableWidget_Frequencies</tabstop>

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -95,6 +95,8 @@ HpiSettingsView::HpiSettingsView(const QString& sSettingsPath,
             this, &HpiSettingsView::compStatusChanged);
     connect(m_pUi->m_checkBox_continousHPI, &QCheckBox::clicked,
             this, &HpiSettingsView::contHpiStatusChanged);
+    connect(m_pUi->m_spinBox_fps, qOverload<int>(&QSpinBox::valueChanged),
+            this, &HpiSettingsView::fitsPerSecondChanged);
     connect(m_pUi->m_doubleSpinBox_maxHPIContinousDist, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
             this, &HpiSettingsView::allowedMeanErrorDistChanged);
     connect(m_pUi->m_doubleSpinBox_moveThreshold, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -200,6 +200,13 @@ double HpiSettingsView::getAllowedRotationChanged()
 
 //=============================================================================================================
 
+int HpiSettingsView::getNumFitsPerSecond()
+{
+    return m_pUi->m_spinBox_fps->value();
+}
+
+//=============================================================================================================
+
 void HpiSettingsView::saveSettings()
 {
     if(m_sSettingsPath.isEmpty()) {

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -107,6 +107,8 @@ HpiSettingsView::HpiSettingsView(const QString& sSettingsPath,
             this, &HpiSettingsView::allowedRotationChanged);
     connect(m_pUi->comboBox_coilPreset, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, &HpiSettingsView::loadCoilPreset);
+
+    m_pUi->comboBox_coilPreset->hide();
     //Init coil freqs
     m_vCoilFreqs << 155 << 165 << 190 << 200;
     qRegisterMetaTypeStreamOperators<QVector<int> >("QVector<int>");

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -95,8 +95,8 @@ HpiSettingsView::HpiSettingsView(const QString& sSettingsPath,
             this, &HpiSettingsView::compStatusChanged);
     connect(m_pUi->m_checkBox_continousHPI, &QCheckBox::clicked,
             this, &HpiSettingsView::contHpiStatusChanged);
-    connect(m_pUi->m_spinBox_fps, QOverload<int>::of(&QSpinBox::valueChanged),
-            this, &HpiSettingsView::fitsPerSecondChanged);
+    connect(m_pUi->m_spinBox_samplesToFit, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &HpiSettingsView::fittingWindowSizeChanged);
     connect(m_pUi->m_doubleSpinBox_maxHPIContinousDist, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
             this, &HpiSettingsView::allowedMeanErrorDistChanged);
     connect(m_pUi->m_doubleSpinBox_moveThreshold, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
@@ -200,9 +200,9 @@ double HpiSettingsView::getAllowedRotationChanged()
 
 //=============================================================================================================
 
-int HpiSettingsView::getNumFitsPerSecond()
+int HpiSettingsView::getFittingWindowSize()
 {
-    return m_pUi->m_spinBox_fps->value();
+    return m_pUi->m_spinBox_samplesToFit->value();
 }
 
 //=============================================================================================================
@@ -230,8 +230,8 @@ void HpiSettingsView::saveSettings()
     settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/maxError"),
                       QVariant::fromValue(m_pUi->m_doubleSpinBox_maxHPIContinousDist->value()));
 
-    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/fitsPerSecond"),
-                      QVariant::fromValue(m_pUi->m_spinBox_fps->value()));
+    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/fittingWindowSize"),
+                      QVariant::fromValue(m_pUi->m_spinBox_samplesToFit->value()));
 }
 
 //=============================================================================================================
@@ -253,7 +253,7 @@ void HpiSettingsView::loadSettings()
     m_pUi->m_checkBox_useComp->setChecked(settings.value(m_sSettingsPath + QString("/HpiSettingsView/useCOMP"), false).toBool());
     m_pUi->m_checkBox_continousHPI->setChecked(settings.value(m_sSettingsPath + QString("/HpiSettingsView/continousHPI"), false).toBool());
     m_pUi->m_doubleSpinBox_maxHPIContinousDist->setValue(settings.value(m_sSettingsPath + QString("/HpiSettingsView/maxError"), 10.0).toDouble());
-    m_pUi->m_spinBox_fps->setValue(settings.value(m_sSettingsPath + QString("/HpiSettingsView/fitsPerSecond"), 3).toInt());
+    m_pUi->m_spinBox_samplesToFit->setValue(settings.value(m_sSettingsPath + QString("/HpiSettingsView/fittingWindowSize"), 1000).toInt());
 }
 
 //=============================================================================================================

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -207,22 +207,24 @@ void HpiSettingsView::saveSettings()
     }
 
     QSettings settings("MNECPP");
-    QVariant data;
 
-    data.setValue(m_vCoilFreqs);
-    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/coilFreqs"), data);
+    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/coilFreqs"),
+                      QVariant::fromValue(m_vCoilFreqs));
 
-    data.setValue(m_pUi->m_checkBox_useSSP->isChecked());
-    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/useSSP"), data);
+    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/useSSP"),
+                      QVariant::fromValue(m_pUi->m_checkBox_useSSP->isChecked()));
 
-    data.setValue(m_pUi->m_checkBox_useComp->isChecked());
-    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/useCOMP"), data);
+    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/useCOMP"),
+                      QVariant::fromValue(m_pUi->m_checkBox_useComp->isChecked()));
 
-    data.setValue(m_pUi->m_checkBox_continousHPI->isChecked());
-    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/continousHPI"), data);
+    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/continousHPI"),\
+                      QVariant::fromValue(m_pUi->m_checkBox_continousHPI->isChecked()));
 
-    data.setValue(m_pUi->m_doubleSpinBox_maxHPIContinousDist->value());
-    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/maxError"), data);
+    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/maxError"),
+                      QVariant::fromValue(m_pUi->m_doubleSpinBox_maxHPIContinousDist->value()));
+
+    settings.setValue(m_sSettingsPath + QString("/HpiSettingsView/fitsPerSecond"),
+                      QVariant::fromValue(m_pUi->m_spinBox_fps->value()));
 }
 
 //=============================================================================================================
@@ -244,6 +246,7 @@ void HpiSettingsView::loadSettings()
     m_pUi->m_checkBox_useComp->setChecked(settings.value(m_sSettingsPath + QString("/HpiSettingsView/useCOMP"), false).toBool());
     m_pUi->m_checkBox_continousHPI->setChecked(settings.value(m_sSettingsPath + QString("/HpiSettingsView/continousHPI"), false).toBool());
     m_pUi->m_doubleSpinBox_maxHPIContinousDist->setValue(settings.value(m_sSettingsPath + QString("/HpiSettingsView/maxError"), 10.0).toDouble());
+    m_pUi->m_spinBox_fps->setValue(settings.value(m_sSettingsPath + QString("/HpiSettingsView/fitsPerSecond"), 3).toInt());
 }
 
 //=============================================================================================================

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -253,7 +253,7 @@ void HpiSettingsView::loadSettings()
     m_pUi->m_checkBox_useComp->setChecked(settings.value(m_sSettingsPath + QString("/HpiSettingsView/useCOMP"), false).toBool());
     m_pUi->m_checkBox_continousHPI->setChecked(settings.value(m_sSettingsPath + QString("/HpiSettingsView/continousHPI"), false).toBool());
     m_pUi->m_doubleSpinBox_maxHPIContinousDist->setValue(settings.value(m_sSettingsPath + QString("/HpiSettingsView/maxError"), 10.0).toDouble());
-    m_pUi->m_spinBox_samplesToFit->setValue(settings.value(m_sSettingsPath + QString("/HpiSettingsView/fittingWindowSize"), 1000).toInt());
+    m_pUi->m_spinBox_samplesToFit->setValue(settings.value(m_sSettingsPath + QString("/HpiSettingsView/fittingWindowSize"), 300).toInt());
 }
 
 //=============================================================================================================

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -95,7 +95,7 @@ HpiSettingsView::HpiSettingsView(const QString& sSettingsPath,
             this, &HpiSettingsView::compStatusChanged);
     connect(m_pUi->m_checkBox_continousHPI, &QCheckBox::clicked,
             this, &HpiSettingsView::contHpiStatusChanged);
-    connect(m_pUi->m_spinBox_fps, qOverload<int>(&QSpinBox::valueChanged),
+    connect(m_pUi->m_spinBox_fps, QOverload<int>::of(&QSpinBox::valueChanged),
             this, &HpiSettingsView::fitsPerSecondChanged);
     connect(m_pUi->m_doubleSpinBox_maxHPIContinousDist, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
             this, &HpiSettingsView::allowedMeanErrorDistChanged);

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -77,6 +77,8 @@ HpiSettingsView::HpiSettingsView(const QString& sSettingsPath,
     m_sSettingsPath = sSettingsPath;
     m_pUi->setupUi(this);
 
+    setupCoilPresets();
+
     connect(m_pUi->m_pushButton_loadDigitizers, &QPushButton::released,
             this, &HpiSettingsView::onLoadDigitizers);
     connect(m_pUi->m_pushButton_doFreqOrder, &QPushButton::clicked,
@@ -103,6 +105,8 @@ HpiSettingsView::HpiSettingsView(const QString& sSettingsPath,
             this, &HpiSettingsView::allowedMovementChanged);
     connect(m_pUi->m_doubleSpinBox_rotThreshold, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
             this, &HpiSettingsView::allowedRotationChanged);
+    connect(m_pUi->comboBox_coilPreset, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this, &HpiSettingsView::loadCoilPreset);
     //Init coil freqs
     m_vCoilFreqs << 155 << 165 << 190 << 200;
     qRegisterMetaTypeStreamOperators<QVector<int> >("QVector<int>");
@@ -507,4 +511,27 @@ QList<FiffDigPoint> HpiSettingsView::readPolhemusDig(const QString& fileName)
 void HpiSettingsView::clearView()
 {
 
+}
+
+//=============================================================================================================
+
+void HpiSettingsView::setupCoilPresets()
+{
+    m_pUi->comboBox_coilPreset->addItem("Load preset");
+
+    m_pUi->comboBox_coilPreset->addItem("VV 4coils 1-500Hz", QVariant::fromValue(QVector<int>{154,158,161,166}));
+    m_pUi->comboBox_coilPreset->addItem("VV 4coils 501-2000Hz", QVariant::fromValue(QVector<int>{293,307,314,321}));
+    m_pUi->comboBox_coilPreset->addItem("VV 4coils 2001-3000Hz+", QVariant::fromValue(QVector<int>{586,614,628,642}));
+}
+
+//=============================================================================================================
+
+void HpiSettingsView::loadCoilPreset(int iCoilPresetIndex)
+{
+    if (iCoilPresetIndex < (m_pUi->comboBox_coilPreset->count() - 1)){
+        auto data = m_pUi->comboBox_coilPreset->itemData(iCoilPresetIndex);
+        if (!data.isNull()){
+            //set coil freqs
+        }
+    }
 }

--- a/libraries/disp/viewers/hpisettingsview.h
+++ b/libraries/disp/viewers/hpisettingsview.h
@@ -156,6 +156,14 @@ public:
 
     //=========================================================================================================
     /**
+     * Get number of fits per second to do when performing continuous hpi
+     *
+     * @return  Number of fits per second
+     */
+    int getNumFitsPerSecond();
+
+    //=========================================================================================================
+    /**
      * Saves all important settings of this view via QSettings.
      */
     void saveSettings();
@@ -240,14 +248,6 @@ signals:
 
     //=========================================================================================================
     /**
-     * Emit this signal whenever the user toggled the do HPI check box.
-     *
-     * @param[in] state    Whether to do continous HPI.
-     */
-    void continousHPIToggled(bool state);
-
-    //=========================================================================================================
-    /**
      * Emit this signal whenever new digitzers were loaded.
      *
      * @param[in] lDigitzers    The new digitzers.
@@ -291,6 +291,14 @@ signals:
      * @param[in] bChecked    Whether the continous HPI check box is checked.
      */
     void contHpiStatusChanged(bool bChecked);
+
+    //=========================================================================================================
+    /**
+     * Emit this signal when 'fits per second' control gets updated.
+     *
+     * @param[in] iFitsPerSecond    How many fits per second we should do.
+     */
+    void fitsPerSecondChanged(int iFitsPerSecond);
 
     //=========================================================================================================
     /**

--- a/libraries/disp/viewers/hpisettingsview.h
+++ b/libraries/disp/viewers/hpisettingsview.h
@@ -160,7 +160,7 @@ public:
      *
      * @return  Number of fits per second
      */
-    int getNumFitsPerSecond();
+    int getFittingWindowSize();
 
     //=========================================================================================================
     /**
@@ -298,7 +298,7 @@ signals:
      *
      * @param[in] iFitsPerSecond    How many fits per second we should do.
      */
-    void fitsPerSecondChanged(int iFitsPerSecond);
+    void fittingWindowSizeChanged(int iFitsPerSecond);
 
     //=========================================================================================================
     /**

--- a/libraries/disp/viewers/hpisettingsview.h
+++ b/libraries/disp/viewers/hpisettingsview.h
@@ -231,6 +231,10 @@ protected:
      */
     QList<FIFFLIB::FiffDigPoint> readPolhemusDig(const QString& fileName);
 
+    void setupCoilPresets();
+
+    void loadCoilPreset(int iCoilPresetIndex);
+
     Ui::HpiSettingsViewWidget*                  m_pUi;                  /**< The HPI dialog. */
 
     QVector<int>                                m_vCoilFreqs;           /**< Vector contains the HPI coil frequencies. */


### PR DESCRIPTION
Preamble:
This is not a permanent fix by any means, this is a quick fix to have the continuous hpi in its current state more easily debugable during runtime (with different setups). This is a control for making iNumberOfFitsPerSecond variable during runtime, which was found to be a temporary solution to getting the continuous hpi fitting working on different incoming frequencies and data chunk sizes. iNumberOfFitsPerSecond does not set the number of fits per second, it is used to set the sample window used to perform the continuous fit, but the fit still seems to occur at whatever rate the data comes in. Treat this as a tuning variable, find a setting that works and leave it there. With that being said:

- Add controls for setting fits per seocnd in HpiSettingsView
- Make iNumberOfFitsPerSecond changeable during runtime