### PR TITLE
WIP [FIX] BabyMeg HPI Fitting

### DIFF
--- a/applications/mne_scan/plugins/hpi/hpi.h
+++ b/applications/mne_scan/plugins/hpi/hpi.h
@@ -268,6 +268,7 @@ private:
 
     Eigen::MatrixXd             m_matData;                  /**< The last data block.*/
     Eigen::MatrixXd             m_matCompProjectors;        /**< Holds the matrix with the SSP and compensator projectors.*/
+    Eigen::MatrixXd             m_matProjectors;            /**< Holds the matrix with the SSP.*/
 
     QSharedPointer<FIFFLIB::FiffInfo>                                           m_pFiffInfo;            /**< Fiff measurement info.*/
     QSharedPointer<UTILSLIB::CircularBuffer_Matrix_double>                      m_pCircularBuffer;      /**< Holds incoming raw data. */

--- a/libraries/inverse/hpiFit/hpifit.cpp
+++ b/libraries/inverse/hpiFit/hpifit.cpp
@@ -256,7 +256,7 @@ void HPIFit::fitHPI(const MatrixXd& t_mat,
     for (int j = 0; j < iNumCoils; j++) {
         int iChIdx = 0;
         VectorXd::Index indMax;
-        matAmp.col(j).maxCoeff(&indMax);
+        matAmp.col(j).cwiseAbs().maxCoeff(&indMax);
         if(indMax < m_vecInnerind.size()) {
             iChIdx = m_vecInnerind.at(indMax);
         }


### PR DESCRIPTION
PR #773 resubmitted.

This PR tries to fix the ongoing problems with the BabyMeg HPI fitting. After quite a lot of debugging and desperate nights, I was able to fix some stuff and get at least stable fits, also with a 'high' error. The fits are quite stable around 10 mm displacement error. 

Nevertheless, this is still more than with the old 42ce89b version before any changes were introduced. Besides a lot of other things, I also ended up copying the entire old HPI class and embed it into the current version. The results were as bad as with the most recent version. From that, I conclude that the problem was introduced with the new HPI plugin and I would suggest checking what is the difference between the way the HPI plugin and former `rthpis` and `HPIView`.

This brings us to what is yet in this PR:

HPI Fitting Class:

- use absolute value to determine channel with maximum amplitude


HPI Plugin:

- projectors and compensators were never updated and applied not entirely correct. The way now is more similar to how it was done before. 

That's it so far. I'm still not sure what will fix it entirely. It must be something that only affects the BabyMeg, since the VectorView fits are running like a charm. Also, the good results with the current versions are only obtained using the advanced model, and not the fast version.  