### PR TITLE
[ENH] Quick tool for spitting out fiff metadata

### DIFF
--- a/examples/ex_fiff_sniffer/ex_fiff_sniffer.pro
+++ b/examples/ex_fiff_sniffer/ex_fiff_sniffer.pro
@@ -1,0 +1,105 @@
+#==============================================================================================================
+#
+# @file     ex_fiff_sniff.pro
+# @author
+# @since    0.1.9
+# @date     June, 2021
+#
+# @section  LICENSE
+#d
+# Copyright (C) 2021, . All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+# the following conditions are met:
+#     * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+#       following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+#       the following disclaimer in the documentation and/or other materials provided with the distribution.
+#     * Neither the name of MNE-CPP authors nor the names of its contributors may be used
+#       to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# @brief    Example of the FiffIO interface class
+#
+#==============================================================================================================
+
+include(../../mne-cpp.pri)
+
+TEMPLATE = app
+
+QT += network
+QT -= gui
+
+CONFIG   += console
+!contains(MNECPP_CONFIG, withAppBundles) {
+    CONFIG -= app_bundle
+}
+
+DESTDIR =  $${MNE_BINARY_DIR}
+
+TARGET = fiffsniff
+CONFIG(debug, debug|release) {
+    TARGET = $$join(TARGET,,,d)
+}
+
+contains(MNECPP_CONFIG, static) {
+    CONFIG += static
+    DEFINES += STATICBUILD
+}
+
+LIBS += -L$${MNE_LIBRARY_DIR}
+CONFIG(debug, debug|release) {
+    LIBS += -lmnecppMned \
+            -lmnecppFiffd \
+            -lmnecppFsd \
+            -lmnecppUtilsd \
+} else {
+    LIBS += -lmnecppMne \
+            -lmnecppFiff \
+            -lmnecppFs \
+            -lmnecppUtils \
+}
+
+SOURCES += \
+        main.cpp \
+
+INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
+INCLUDEPATH += $${MNE_INCLUDE_DIR}
+
+unix:!macx {
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
+macx {
+    QMAKE_LFLAGS += -Wl,-rpath,@executable_path/../lib
+}
+
+# Activate FFTW backend in Eigen for non-static builds only
+contains(MNECPP_CONFIG, useFFTW):!contains(MNECPP_CONFIG, static) {
+    DEFINES += EIGEN_FFTW_DEFAULT
+    INCLUDEPATH += $$shell_path($${FFTW_DIR_INCLUDE})
+    LIBS += -L$$shell_path($${FFTW_DIR_LIBS})
+
+    win32 {
+        # On Windows
+        LIBS += -llibfftw3-3 \
+                -llibfftw3f-3 \
+                -llibfftw3l-3 \
+    }
+
+    unix:!macx {
+        # On Linux
+        LIBS += -lfftw3 \
+                -lfftw3_threads \
+    }
+}
+

--- a/examples/ex_fiff_sniffer/main.cpp
+++ b/examples/ex_fiff_sniffer/main.cpp
@@ -36,10 +36,10 @@ int main(int argc, char *argv[])
     QFile t_fileRaw(parser.value(inputOption));
 
     std::cout << "\n------------ Fiff Sniffer ------------\n";
-    std::cout << "Input file : " << t_fileRaw.fileName().toStdString() << "\n";
 
     if(!t_fileRaw.exists())
     {
+        std::cout << "Input file : " << t_fileRaw.fileName().toStdString() << "\n";
         std::cout << "File cannot be found.\n";
         std::cout << "\nBye!\n";
 

--- a/examples/ex_fiff_sniffer/main.cpp
+++ b/examples/ex_fiff_sniffer/main.cpp
@@ -35,37 +35,47 @@ int main(int argc, char *argv[])
 
     QFile t_fileRaw(parser.value(inputOption));
 
-    FIFFLIB::FiffIO p_fiffIO(t_fileRaw);
-
     std::cout << "\n------------ Fiff Sniffer ------------\n";
-    std::cout << "Num. raw dat sets: " << p_fiffIO.m_qlistRaw.size() << "\n";
-    std::cout << "Num. evoked sets: " << p_fiffIO.m_qlistEvoked.size() << "\n";
+    std::cout << "Input file : " << t_fileRaw.fileName().toStdString() << "\n";
 
-    int count = 0;
-    for (auto& data : p_fiffIO.m_qlistRaw){
-        std::cout << "--- \n";
-        std::cout << "Raw Set " << count << "\n";
-        std::cout << "Sample frequency: " << data->info.sfreq << "\n";
-        std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
-        std::cout << "First sample: " << data->first_samp << " | Last sample: " << data->last_samp << "\n";
-        std::cout << "Number of samples: " << data->last_samp - data->first_samp << " | Time: " << (data->last_samp - data->first_samp) / data->info.sfreq << " sec. \n";
-        std::cout << "Nubmer of digitizer points: " << data->info.dig.size() << "\n";
-        for (auto& point : data->info.dig){
-            if (point.kind == FIFFV_POINT_HPI){
-                std::cout << "HPI Point " << point.ident << " - " << point.r[0] << ", " << point.r[1] << ", " << point.r[2] << "\n";
+    if(!t_fileRaw.exists())
+    {
+        std::cout << "File cannot be found.\n";
+        std::cout << "\nBye!\n";
+
+    } else { //file found
+
+        FIFFLIB::FiffIO p_fiffIO(t_fileRaw);
+
+        std::cout << "Num. raw dat sets: " << p_fiffIO.m_qlistRaw.size() << "\n";
+        std::cout << "Num. evoked sets: " << p_fiffIO.m_qlistEvoked.size() << "\n";
+
+        int count = 0;
+        for (auto& data : p_fiffIO.m_qlistRaw){
+            std::cout << "--- \n";
+            std::cout << "Raw Set " << count << "\n";
+            std::cout << "Sample frequency: " << data->info.sfreq << "\n";
+            std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
+            std::cout << "First sample: " << data->first_samp << " | Last sample: " << data->last_samp << "\n";
+            std::cout << "Number of samples: " << data->last_samp - data->first_samp << " | Time: " << (data->last_samp - data->first_samp) / data->info.sfreq << " sec. \n";
+            std::cout << "Nubmer of digitizer points: " << data->info.dig.size() << "\n";
+            for (auto& point : data->info.dig){
+                if (point.kind == FIFFV_POINT_HPI){
+                    std::cout << "HPI Point " << point.ident << " - " << point.r[0] << ", " << point.r[1] << ", " << point.r[2] << "\n";
+                }
             }
         }
-    }
-    count = 0;
-    for (auto& data : p_fiffIO.m_qlistEvoked){
+        count = 0;
+        for (auto& data : p_fiffIO.m_qlistEvoked){
+            std::cout << "--- \n";
+            std::cout << "Evoked Set " << count << "\n";
+            std::cout << "Sample frequency: " << data->info.sfreq << "\n";
+            std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
+            std::cout << "Num. averaged epochs: " << data->nave << "\n";
+        }
         std::cout << "--- \n";
-        std::cout << "Evoked Set " << count << "\n";
-        std::cout << "Sample frequency: " << data->info.sfreq << "\n";
-        std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
-        std::cout << "Num. averaged epochs: " << data->nave << "\n";
+        std::cout << "--------------------------------------\n";
     }
-    std::cout << "--- \n";
-    std::cout << "--------------------------------------\n";
 
     return 0;
 }

--- a/examples/ex_fiff_sniffer/main.cpp
+++ b/examples/ex_fiff_sniffer/main.cpp
@@ -1,0 +1,71 @@
+
+//=============================================================================================================
+// INCLUDES
+//=============================================================================================================
+
+#include <QCoreApplication>
+
+#include <fiff/fiff.h>
+#include <mne/mne.h>
+
+#include <fiff/fiff_io.h>
+
+//=============================================================================================================
+// QT INCLUDES
+//=============================================================================================================
+
+#include <QCommandLineParser>
+
+//=============================================================================================================
+// MAIN
+//=============================================================================================================
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Disp Example");
+    parser.addHelpOption();
+
+    QCommandLineOption inputOption("file", "The input file <in>.", "in", QCoreApplication::applicationDirPath() + "/MNE-sample-data/MEG/sample/sample_audvis_raw.fif");
+    parser.addOption(inputOption);
+
+    parser.process(a);
+
+    QFile t_fileRaw(parser.value(inputOption));
+
+    FIFFLIB::FiffIO p_fiffIO(t_fileRaw);
+
+    std::cout << "\n------------ Fiff Sniffer ------------\n";
+    std::cout << "Num. raw dat sets: " << p_fiffIO.m_qlistRaw.size() << "\n";
+    std::cout << "Num. evoked sets: " << p_fiffIO.m_qlistEvoked.size() << "\n";
+
+    int count = 0;
+    for (auto& data : p_fiffIO.m_qlistRaw){
+        std::cout << "--- \n";
+        std::cout << "Raw Set " << count << "\n";
+        std::cout << "Sample frequency: " << data->info.sfreq << "\n";
+        std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
+        std::cout << "First sample: " << data->first_samp << " | Last sample: " << data->last_samp << "\n";
+        std::cout << "Number of samples: " << data->last_samp - data->first_samp << " | Time: " << (data->last_samp - data->first_samp) / data->info.sfreq << " sec. \n";
+        std::cout << "Nubmer of digitizer points: " << data->info.dig.size() << "\n";
+        for (auto& point : data->info.dig){
+            if (point.kind == FIFFV_POINT_HPI){
+                std::cout << "HPI Point " << point.ident << " - " << point.r[0] << ", " << point.r[1] << ", " << point.r[2] << "\n";
+            }
+        }
+    }
+    count = 0;
+    for (auto& data : p_fiffIO.m_qlistEvoked){
+        std::cout << "--- \n";
+        std::cout << "Evoked Set " << count << "\n";
+        std::cout << "Sample frequency: " << data->info.sfreq << "\n";
+        std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
+        std::cout << "Num. averaged epochs: " << data->nave << "\n";
+    }
+    std::cout << "--- \n";
+    std::cout << "--------------------------------------\n";
+
+    return 0;
+}

--- a/examples/examples.pro
+++ b/examples/examples.pro
@@ -53,6 +53,7 @@ SUBDIRS += \
     ex_coreg \
     ex_evoked_grad_amp \
     ex_fiff_io \
+    ex_fiff_sniffer \
     ex_find_evoked \
     ex_inverse_mne \
     ex_make_inverse_operator \


### PR DESCRIPTION
It just prints a bunch of fiff metadata to console for the fiff file you point it at with --file . It is currently in examples, not sure what the best place for it would be (or if its even worth merging at all)