### PR TITLE
[MAINT] Connect to ftbuffer on start

### DIFF
--- a/applications/mne_scan/plugins/ftbuffer/FormFiles/ftbuffersetupwidget.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/FormFiles/ftbuffersetupwidget.cpp
@@ -77,6 +77,13 @@ FtBufferSetupWidget::FtBufferSetupWidget(FtBuffer* toolbox,
             m_pFtBuffer->m_pFtBuffProducer.data(), &FtBuffProducer::connectToBuffer);
     connect(m_pFtBuffer->m_pFtBuffProducer.data(), &FtBuffProducer::connecStatus,
             this, &FtBufferSetupWidget::isConnected);
+
+    connect(m_pUi->m_lineEditIP, &QLineEdit::textChanged,
+            toolbox, &FtBuffer::setBufferAddress);
+    connect(m_pUi->m_spinBoxPort, qOverload<int>(&QSpinBox::valueChanged),
+            toolbox, &FtBuffer::setBufferPort);
+    toolbox->setBufferAddress(m_pUi->m_lineEditIP->text());
+    toolbox->setBufferPort(m_pUi->m_spinBoxPort->value());
 }
 
 //=============================================================================================================
@@ -132,7 +139,7 @@ void FtBufferSetupWidget::isConnected(bool stat)
         qWarning() << "[FtBufferSetupWidget::isConnected] Unable to find relevant fiff info.";
 
         QMessageBox msgBox;
-        msgBox.setText("Unable to find relevant fiff info. Is there header data in the buffer or a fiff file in your bin folder?");
+        msgBox.setText("Unable to find relevant fiff info. Is there header data in the buffer?");
         msgBox.exec();
     }
 }

--- a/applications/mne_scan/plugins/ftbuffer/FormFiles/ftbuffersetupwidget.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/FormFiles/ftbuffersetupwidget.cpp
@@ -80,7 +80,7 @@ FtBufferSetupWidget::FtBufferSetupWidget(FtBuffer* toolbox,
 
     connect(m_pUi->m_lineEditIP, &QLineEdit::textChanged,
             toolbox, &FtBuffer::setBufferAddress);
-    connect(m_pUi->m_spinBoxPort, qOverload<int>(&QSpinBox::valueChanged),
+    connect(m_pUi->m_spinBoxPort, QOverload<int>::of(&QSpinBox::valueChanged),
             toolbox, &FtBuffer::setBufferPort);
     toolbox->setBufferAddress(m_pUi->m_lineEditIP->text());
     toolbox->setBufferPort(m_pUi->m_spinBoxPort->value());

--- a/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
@@ -68,6 +68,8 @@ FtBuffer::FtBuffer()
 , m_pFtBuffProducer(QSharedPointer<FtBuffProducer>::create(this))
 , m_pFiffInfo(QSharedPointer<FiffInfo>::create())
 , m_pCircularBuffer(QSharedPointer<CircularBuffer_Matrix_double>(new CircularBuffer_Matrix_double(10)))
+, m_sBufferAddress("127.0.0.1")
+, m_iBufferPort(1972)
 {
 }
 
@@ -109,7 +111,11 @@ void FtBuffer::unload()
 bool FtBuffer::start()
 {
     if (!m_bIsConfigured) {
-        return false;
+        m_pFtBuffProducer->connectToBuffer(m_sBufferAddress,
+                                           m_iBufferPort);
+        if (!m_bIsConfigured) {
+            return false;
+        }
     }
 
     qInfo() << "[FtBuffer::start] Starting FtBuffer...";
@@ -262,4 +268,18 @@ bool FtBuffer::setupRTMSA(FIFFLIB::FiffInfo FiffInfo)
 
     qInfo() << "[FtBuffer::setupRTMSA] Successfully acquired fif info from buffer.";
     return m_bIsConfigured = true;
+}
+
+//=============================================================================================================
+
+void FtBuffer::setBufferAddress(const QString &sAddress)
+{
+    m_sBufferAddress = sAddress;
+}
+
+//=============================================================================================================
+
+void FtBuffer::setBufferPort(int iPort)
+{
+    m_iBufferPort = iPort;
 }

--- a/applications/mne_scan/plugins/ftbuffer/ftbuffer.h
+++ b/applications/mne_scan/plugins/ftbuffer/ftbuffer.h
@@ -177,6 +177,22 @@ public:
      */
     virtual QWidget* setupWidget();
 
+    //=========================================================================================================
+    /**
+     * Sets address used to connect to buffer (if starting plugin without an established connection).
+     *
+     * @param[in] sAddress      IP address of the FieldTrip buffer
+     */
+    void setBufferAddress(const QString& sAddress);
+
+    //=========================================================================================================
+    /**
+     * Sets port used to connect to buffer (if starting plugin without an established connection).
+     *
+     * @param[in] iPort         Port of the FieldTrip buffer
+     */
+    void setBufferPort(int iPort);
+
 signals:
     //=========================================================================================================
     /**
@@ -224,6 +240,9 @@ private:
     QSharedPointer<FIFFLIB::FiffRawData>                                                m_pNeuromagHeadChunkData;       /**< Fiff into parser for header data collected from Neuromag extended header. */
     QSharedPointer<SCSHAREDLIB::PluginOutputData<SCMEASLIB::RealTimeMultiSampleArray> > m_pRTMSA_BufferOutput;          /**< The RealTimeSampleArray to provide the plugin output data.*/
     QSharedPointer<UTILSLIB::CircularBuffer_Matrix_double>                              m_pCircularBuffer;              /**< Holds incoming raw data. */
+
+    QString                                                                             m_sBufferAddress;               /**< The address used to connect to the buffer if starting without being connected */
+    int                                                                                 m_iBufferPort;                  /**< The port used to connect to the buffer if starting without being connected */
 };
 }//namespace end brace
 

--- a/applications/mne_scan/plugins/ftbuffer/ftbuffproducer.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftbuffproducer.cpp
@@ -140,15 +140,14 @@ void FtBuffProducer::connectToBuffer(QString addr,
 //    }
 
     //Try to get info from buffer first, then resort to file
-    if(!m_pFtConnector->connect()) {
-        if(!m_pFtBuffer->setupRTMSA()) {
-            emit connecStatus(false);
+    if(m_pFtConnector->connect()) {
+        if (m_pFtBuffer->setupRTMSA(m_pFtConnector->parseNeuromagHeader())) {
+            qInfo() << "[FtBuffProducer::connectToBuffer] Failed to read neuromag header from buffer.";
+            emit connecStatus(true);
+            return;
         }
-    } else if (!m_pFtBuffer->setupRTMSA(m_pFtConnector->parseNeuromagHeader())) {
-        qInfo() << "[FtBuffProducer::connectToBuffer] Failed to read neuromag header from buffer.";
-        emit connecStatus(false);
     }
-    emit connecStatus(true); //this happens if all goes well
+    emit connecStatus(false); //this happens if all goes well
 }
 
 //=============================================================================================================


### PR DESCRIPTION
- Attempt to connect to FieldTrip buffer on pressing start in MNE Scan.

This is part of the functionality that was present in the 'ssadhd' branch, but just the ftbuffer stuff decoupled from the hpi debugging.