### PR TITLE
[ENH] Create default FiffInfo for FtBuffer with minimal metadata

### DIFF
--- a/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
@@ -259,7 +259,11 @@ bool FtBuffer::setupRTMSA(FIFFLIB::FiffInfo FiffInfo)
         return false;
     }
 
+    std::cout << "attempting to init info\n";
+
     m_pFiffInfo = QSharedPointer<FIFFLIB::FiffInfo>(new FIFFLIB::FiffInfo (FiffInfo));
+
+    std::cout << "init info\n";
 
     //Set the RMTSA parameters
     m_pRTMSA_BufferOutput->measurementData()->initFromFiffInfo(m_pFiffInfo);

--- a/applications/mne_scan/plugins/ftbuffer/ftbuffproducer.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftbuffproducer.cpp
@@ -141,7 +141,7 @@ void FtBuffProducer::connectToBuffer(QString addr,
 
     //Try to get info from buffer first, then resort to file
     if(m_pFtConnector->connect()) {
-        if (m_pFtBuffer->setupRTMSA(m_pFtConnector->parseNeuromagHeader())) {
+        if (m_pFtBuffer->setupRTMSA(m_pFtConnector->parseExtenedHeaders())) {
             qInfo() << "[FtBuffProducer::connectToBuffer] Failed to read neuromag header from buffer.";
             emit connecStatus(true);
             return;

--- a/applications/mne_scan/plugins/ftbuffer/ftconnector.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftconnector.cpp
@@ -678,6 +678,8 @@ FIFFLIB::FiffInfo FtConnector::infoFromSimpleHeader()
         channel.chpos.coil_type = FIFFV_COIL_NONE;
 
         defaultInfo.chs.append(channel);
+
+        defaultInfo.ch_names.append("Ch. " + QString::number(i));
     }
 
     return defaultInfo;

--- a/applications/mne_scan/plugins/ftbuffer/ftconnector.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftconnector.cpp
@@ -63,6 +63,7 @@ FtConnector::FtConnector()
 :m_iNumSamples(0)
 ,m_iNumNewSamples(0)
 ,m_iNumChannels(0)
+,m_iExtendedHeaderSize(0)
 ,m_iPort(1972)
 ,m_bNewData(false)
 ,m_fSampleFreq(0)
@@ -550,12 +551,15 @@ FIFFLIB::FiffInfo FtConnector::parseExtenedHeaders()
 
     int iRead = 0;
 
+    std::cout << "Parsing extended header\n";
+
     while(iRead < m_iExtendedHeaderSize) {
         qint32 iType;
         char cType[sizeof(qint32)];
         chunkBuffer.read(cType, sizeof(qint32));
         std::memcpy(&iType, cType, sizeof(qint32));
         iRead += sizeof(qint32);
+        std::cout << "Read header of type" << iType << "\n";
 
         if(iType == 8) { // Header we care about, FT_CHUNK_NEUROMAG_HEADER = 8
             qint32 iSize;
@@ -627,6 +631,8 @@ FIFFLIB::FiffInfo FtConnector::parseExtenedHeaders()
         }
     }
 
+    std::cout << "No extended header\n";
+
     return infoFromSimpleHeader();
 }
 
@@ -673,4 +679,6 @@ FIFFLIB::FiffInfo FtConnector::infoFromSimpleHeader()
 
         defaultInfo.chs.append(channel);
     }
+
+    return defaultInfo;
 }

--- a/applications/mne_scan/plugins/ftbuffer/ftconnector.h
+++ b/applications/mne_scan/plugins/ftbuffer/ftconnector.h
@@ -139,6 +139,14 @@ typedef struct {
     qint32 nevents;
 } samples_events_t;
 
+struct BufferInfo{
+    int     iNumSamples;                          /**< Number of samples we've read from the buffer. */
+    int     iNumNewSamples;                       /**< Number of total samples (read and unread) in the buffer. */
+    int     iMsgSamples;                          /**< Number of samples in the latest buffer transmission receied. */
+    int     iNumChannels;                         /**< Number of channels in the buffer data. */
+    int     iDataType;                            /**< Type of data in the buffer. */
+};
+
 //=============================================================================================================
 
 class FtConnector : public QObject
@@ -264,13 +272,15 @@ public:
      *
      * @return returns the FiffInfo from the parsed fif file from the neuromag header chunk.
      */
-    FIFFLIB::FiffInfo parseNeuromagHeader();
+    FIFFLIB::FiffInfo parseExtenedHeaders();
 
     //=========================================================================================================
     /**
      * Gets the current number of samples in the buffer and stores it in m_iNumSamples
      */
     void catchUpToBuffer();
+
+    BufferInfo getBufferInfo();
 
 private:
     //=========================================================================================================
@@ -357,12 +367,14 @@ private:
      */
     int totalBuffSamples();
 
+    FIFFLIB::FiffInfo infoFromSimpleHeader();
+
     int                                     m_iNumSamples;                          /**< Number of samples we've read from the buffer. */
     int                                     m_iNumNewSamples;                       /**< Number of total samples (read and unread) in the buffer. */
     int                                     m_iMsgSamples;                          /**< Number of samples in the latest buffer transmission receied. */
     int                                     m_iNumChannels;                         /**< Number of channels in the buffer data. */
     int                                     m_iDataType;                            /**< Type of data in the buffer. */
-    int                                     m_iNeuromagHeader;                      /**< Size of neuromag header chunk. */
+    int                                     m_iExtendedHeaderSize;                          /**< Size of extended header chunks. */
     quint16                                 m_iPort;                                /**< Port where the ft bufferis found. */
 
     bool                                    m_bNewData;                             /**< Indicate whether we've received new data. */


### PR DESCRIPTION
- Change logic to no longer expect (or need) neuromag extended header. Instead, default to minimal FiffInfo with made with data from simple ftbuffer header.