### PR TITLE
[FIX] MNE Anonymize 

### DIFF
--- a/applications/mne_anonymize/main.cpp
+++ b/applications/mne_anonymize/main.cpp
@@ -89,8 +89,6 @@ int main(int argc, char* argv[])
     qtApp->setOrganizationName("MNE-CPP Project");
     qtApp->setApplicationName("MNE Anonymize");
 
-    qDebug() << "date: " << __DATE__;
-
     QScopedPointer<MNEANONYMIZE::SettingsControllerCl> controller(h->createController(qtApp->arguments()));
 
     return qtApp->exec();

--- a/applications/mne_anonymize/mne_anonymize.pro
+++ b/applications/mne_anonymize/mne_anonymize.pro
@@ -54,8 +54,6 @@ TEMPLATE = app
 
 QT += widgets network
 
-CONFIG += console
-
 !contains(MNECPP_CONFIG, withAppBundles) {
     CONFIG -= app_bundle
 }
@@ -64,6 +62,7 @@ DESTDIR = $${MNE_BINARY_DIR}
 
 TARGET = mne_anonymize
 CONFIG(debug, debug|release) {
+    CONFIG += console
     TARGET = $$join(TARGET,,,d)
 }
 

--- a/applications/mne_anonymize/mne_anonymize.pro
+++ b/applications/mne_anonymize/mne_anonymize.pro
@@ -38,6 +38,8 @@
 
 include(../../mne-cpp.pri)
 
+QMAKE_TARGET_DESCRIPTION = MNE Anonymize
+
 #Application version
 VERSION_MAJOR = 0
 VERSION_MINOR = 99

--- a/applications/mne_anonymize/settingscontrollercl.cpp
+++ b/applications/mne_anonymize/settingscontrollercl.cpp
@@ -111,7 +111,6 @@ SettingsControllerCl::SettingsControllerCl(const QStringList& arguments)
     if(parseInputs(arguments))
     {
         qCritical() << "Something went wrong during the parsing of input options.";
-        emit finished(1);
         return;
     }
 
@@ -121,11 +120,9 @@ SettingsControllerCl::SettingsControllerCl(const QStringList& arguments)
     if(execute())
     {
         qCritical() << "Error during the anonymization of the input file";
-        emit finished(1);
         return;
     }
 
-    emit finished(0);
 }
 
 //=============================================================================================================
@@ -165,7 +162,7 @@ void SettingsControllerCl::initParser()
            "\n - MNE Toolbox info: Working Directory"
            "\n - MNE Toolbox info: Command line used"
            "\n "
-           "\n - *** Additionally if there is MRI data present in the file a warning message will appear.\n"));
+           "\n - Additionally if there is MRI data present in the file a warning message will appear.\n"));
     m_parser.addHelpOption();
 
     //this breaks encapsulation. damn it. it has to be here in order to show in the help text.
@@ -181,7 +178,7 @@ void SettingsControllerCl::initParser()
     m_parser.addOption(inFileOpt);
 
     QCommandLineOption outFileOpt(QStringList() << "o" << "out",
-                                  QCoreApplication::translate("main","Output file <outfile>. Default ‘_anonymized.fif’ will be attached to the input file name."),
+                                  QCoreApplication::translate("main","Output file <outfile>. Default \"_anonymized.fif\" will be attached to the input file name."),
                                   QCoreApplication::translate("main","outfile"));
     m_parser.addOption(outFileOpt);
 
@@ -203,7 +200,7 @@ void SettingsControllerCl::initParser()
     m_parser.addOption(deleteInFileConfirmOpt);
 
     QCommandLineOption bruteOpt(QStringList() << "b" << "brute",
-                                QCoreApplication::translate("main","Anonymize additional subject’s information like weight, height, sex and handedness, and project’s data,"
+                                QCoreApplication::translate("main","Anonymize additional subject information like weight, height, sex and handedness, and project data,"
                                                             " subject's data. See help above. Default: false"));
     m_parser.addOption(bruteOpt);
 
@@ -218,7 +215,7 @@ void SettingsControllerCl::initParser()
     m_parser.addOption(measDateOffsetOpt);
 
     QCommandLineOption birthdayOpt(QStringList() << "sb" << "subject_birthday",
-                                   QCoreApplication::translate("main","Specify the subject’s birthday. Format: DDMMYYYY. Default: 01012000"),
+                                   QCoreApplication::translate("main","Specify the subject birthday date. Format: DDMMYYYY. Default: 01012000"),
                                    QCoreApplication::translate("main","date"));
     m_parser.addOption(birthdayOpt);
 
@@ -227,7 +224,7 @@ void SettingsControllerCl::initParser()
                                          QCoreApplication::translate("main","days"));
     m_parser.addOption(birthdayOffsetOpt);
 
-    QCommandLineOption subjectIdOpt("his",QCoreApplication::translate("main","Specify the subject’s ID within the Hospital information system. Default: ‘mne_anonymize’"),
+    QCommandLineOption subjectIdOpt("his",QCoreApplication::translate("main","Specify the subject ID within the Hospital information system. Default: \"mne_anonymize\""),
                                           QCoreApplication::translate("main","id#"));
     m_parser.addOption(subjectIdOpt);
 

--- a/applications/mne_anonymize/settingscontrollercl.h
+++ b/applications/mne_anonymize/settingscontrollercl.h
@@ -233,7 +233,7 @@ signals:
     /**
      * Signal the main qt core application to stop running and exit.
      */
-    void finished(const int) const;
+    void finished(const int);
 
 protected:
     FiffAnonymizer::SPtr m_pAnonymizer;     /**< Local pointer to a Fiffanonyzer object to configure and use.*/


### PR DESCRIPTION
Couple of things in the app needed to get fixed. 

 - Use of console only in debug mode. 
 - delete a qdebug printing the date that got leaked into production version. 
 - rewrite QMAKE_TARGET_DESCRIPTION variable so that windows task manager correctly prints the application name.
 - fix a warning regarding a const qualifier in a signal.
 - dont emit in constructors