### PR TITLE
[FIX] MNE Analyze 

### DIFF
--- a/applications/mne_analyze/mne_analyze/mne_analyze.pro
+++ b/applications/mne_analyze/mne_analyze/mne_analyze.pro
@@ -44,12 +44,11 @@ TEMPLATE = app
 QT += gui widgets network opengl svg concurrent charts
 qtHaveModule(printsupport): QT += printsupport
 
-CONFIG += console
-
 DESTDIR = $${MNE_BINARY_DIR}
 
 TARGET = mne_analyze
 CONFIG(debug, debug|release) {
+    CONFIG += console
     TARGET = $$join(TARGET,,,d)
 }
 

--- a/applications/mne_analyze/mne_analyze/mne_analyze.pro
+++ b/applications/mne_analyze/mne_analyze/mne_analyze.pro
@@ -37,6 +37,8 @@
 
 include(../../../mne-cpp.pri)
 
+QMAKE_TARGET_DESCRIPTION = A Framework for Electrophysiology.
+
 TEMPLATE = app
 
 QT += gui widgets network opengl svg concurrent charts

--- a/applications/mne_analyze/mne_analyze/mne_analyze.pro
+++ b/applications/mne_analyze/mne_analyze/mne_analyze.pro
@@ -37,7 +37,7 @@
 
 include(../../../mne-cpp.pri)
 
-QMAKE_TARGET_DESCRIPTION = A Framework for Electrophysiology.
+QMAKE_TARGET_DESCRIPTION = MNE Analyze
 
 TEMPLATE = app
 


### PR DESCRIPTION
QMAKE_TARGET_DESCRIPTION  is what Qt uses to populate whatever field window's task manager uses to name the applications listed there. It makes sense to populate it with the name of the applications. 

Regarding the console. It is not needed when working with analyze in release mode. 