### PR TITLE
[WIP] MAINT, FIX: Change FtBuffer stop to fix crash and add thread interupt request before stopping plugins

### DIFF
--- a/applications/mne_scan/libs/scShared/Management/pluginscenemanager.cpp
+++ b/applications/mne_scan/libs/scShared/Management/pluginscenemanager.cpp
@@ -183,16 +183,22 @@ void PluginSceneManager::stopPlugins()
     // Stop AbstractSensor plugins first!
     QList<AbstractPlugin::SPtr>::iterator it = m_pluginList.begin();
     for( ; it != m_pluginList.end(); ++it)
-        if((*it)->getType() == AbstractPlugin::_ISensor)
+        if((*it)->getType() == AbstractPlugin::_ISensor){
+            (*it)->requestInterruption();
+            (*it)->wait();
             if(!(*it)->stop())
                 qWarning() << "Could not stop AbstractPlugin: " << (*it)->getName();
+        }
 
     // Stop all other plugins!
     it = m_pluginList.begin();
     for( ; it != m_pluginList.end(); ++it)
-        if((*it)->getType() != AbstractPlugin::_ISensor)
+        if((*it)->getType() != AbstractPlugin::_ISensor){
+            (*it)->requestInterruption();
+            (*it)->wait();
             if(!(*it)->stop())
                 qWarning() << "Could not stop AbstractPlugin: " << (*it)->getName();
+        }
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
@@ -152,9 +152,6 @@ bool FtBuffer::stop()
         msleep(10);
     }
 
-    requestInterruption();
-    wait();
-
     //Reset ftproducer and sample received list
     m_pFtBuffProducer.clear();
     m_pFtBuffProducer = QSharedPointer<FtBuffProducer>::create(this);


### PR DESCRIPTION
- Remove internal requestInterruption/wait in ftbuffer stop function
- Add requestInterruption to all plugins before calling stop.