### PR TITLE
[ENH] MNECPP - Comment installs keyword in pro files

### DIFF
--- a/applications/mne_analyze/libs/anShared/anShared.pro
+++ b/applications/mne_analyze/libs/anShared/anShared.pro
@@ -124,12 +124,6 @@ INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_ANALYZE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/anShared
-
-#INSTALLS += header_files
-
 win32:!contains(MNECPP_CONFIG, static) {
     QMAKE_POST_LINK += $$QMAKE_COPY $$shell_path($${MNE_LIBRARY_DIR}/$${TARGET}.dll) $${MNE_BINARY_DIR}
 }

--- a/applications/mne_analyze/libs/anShared/anShared.pro
+++ b/applications/mne_analyze/libs/anShared/anShared.pro
@@ -128,7 +128,7 @@ INCLUDEPATH += $${MNE_ANALYZE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/anShared
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 win32:!contains(MNECPP_CONFIG, static) {
     QMAKE_POST_LINK += $$QMAKE_COPY $$shell_path($${MNE_LIBRARY_DIR}/$${TARGET}.dll) $${MNE_BINARY_DIR}

--- a/applications/mne_scan/libs/scDisp/scDisp.pro
+++ b/applications/mne_scan/libs/scDisp/scDisp.pro
@@ -118,7 +118,7 @@ INCLUDEPATH += $${MNE_SCAN_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/scDisp
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 win32:!contains(MNECPP_CONFIG, static) {
     QMAKE_POST_LINK += $$QMAKE_COPY $$shell_path($${MNE_LIBRARY_DIR}/$${TARGET}.dll) $${MNE_BINARY_DIR}

--- a/applications/mne_scan/libs/scDisp/scDisp.pro
+++ b/applications/mne_scan/libs/scDisp/scDisp.pro
@@ -114,12 +114,6 @@ INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_SCAN_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/scDisp
-
-#INSTALLS += header_files
-
 win32:!contains(MNECPP_CONFIG, static) {
     QMAKE_POST_LINK += $$QMAKE_COPY $$shell_path($${MNE_LIBRARY_DIR}/$${TARGET}.dll) $${MNE_BINARY_DIR}
 }

--- a/applications/mne_scan/libs/scMeas/scMeas.pro
+++ b/applications/mne_scan/libs/scMeas/scMeas.pro
@@ -107,7 +107,7 @@ INCLUDEPATH += $${MNE_SCAN_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/scMeas
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 win32:!contains(MNECPP_CONFIG, static) {
     QMAKE_POST_LINK += $$QMAKE_COPY $$shell_path($${MNE_LIBRARY_DIR}/$${TARGET}.dll) $${MNE_BINARY_DIR}

--- a/applications/mne_scan/libs/scMeas/scMeas.pro
+++ b/applications/mne_scan/libs/scMeas/scMeas.pro
@@ -103,12 +103,6 @@ INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_SCAN_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/scMeas
-
-#INSTALLS += header_files
-
 win32:!contains(MNECPP_CONFIG, static) {
     QMAKE_POST_LINK += $$QMAKE_COPY $$shell_path($${MNE_LIBRARY_DIR}/$${TARGET}.dll) $${MNE_BINARY_DIR}
 }

--- a/applications/mne_scan/libs/scShared/scShared.pro
+++ b/applications/mne_scan/libs/scShared/scShared.pro
@@ -126,7 +126,7 @@ INCLUDEPATH += $${MNE_SCAN_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/scShared
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 win32:!contains(MNECPP_CONFIG, static) {
     QMAKE_POST_LINK += $$QMAKE_COPY $$shell_path($${MNE_LIBRARY_DIR}/$${TARGET}.dll) $${MNE_BINARY_DIR}

--- a/applications/mne_scan/libs/scShared/scShared.pro
+++ b/applications/mne_scan/libs/scShared/scShared.pro
@@ -122,12 +122,6 @@ INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_SCAN_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/scShared
-
-#INSTALLS += header_files
-
 win32:!contains(MNECPP_CONFIG, static) {
     QMAKE_POST_LINK += $$QMAKE_COPY $$shell_path($${MNE_LIBRARY_DIR}/$${TARGET}.dll) $${MNE_BINARY_DIR}
 }

--- a/libraries/communication/communication.pro
+++ b/libraries/communication/communication.pro
@@ -91,12 +91,6 @@ HEADERS +=  \
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/communication
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/communication/communication.pro
+++ b/libraries/communication/communication.pro
@@ -95,7 +95,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/communication
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/connectivity/connectivity.pro
+++ b/libraries/connectivity/connectivity.pro
@@ -116,7 +116,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/connectivity
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/connectivity/connectivity.pro
+++ b/libraries/connectivity/connectivity.pro
@@ -112,12 +112,6 @@ HEADERS += \
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/connectivity
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/disp/disp.pro
+++ b/libraries/disp/disp.pro
@@ -252,7 +252,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/disp
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/disp/disp.pro
+++ b/libraries/disp/disp.pro
@@ -248,12 +248,6 @@ FORMS += \
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/disp
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/disp3D/disp3D.pro
+++ b/libraries/disp3D/disp3D.pro
@@ -202,7 +202,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/disp3D
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/disp3D/disp3D.pro
+++ b/libraries/disp3D/disp3D.pro
@@ -198,12 +198,6 @@ RESOURCES += $$PWD/disp3d.qrc \
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/disp3D
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/events/events.pro
+++ b/libraries/events/events.pro
@@ -47,11 +47,6 @@ HEADERS += \
 
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/events
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/events/events.pro
+++ b/libraries/events/events.pro
@@ -50,7 +50,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/events
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/fiff/fiff.pro
+++ b/libraries/fiff/fiff.pro
@@ -140,7 +140,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/fiff
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/fiff/fiff.pro
+++ b/libraries/fiff/fiff.pro
@@ -136,12 +136,6 @@ HEADERS += fiff.h \
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/fiff
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/fs/fs.pro
+++ b/libraries/fs/fs.pro
@@ -86,12 +86,6 @@ HEADERS += \
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/fs
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/fs/fs.pro
+++ b/libraries/fs/fs.pro
@@ -90,7 +90,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/fs
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/fwd/fwd.pro
+++ b/libraries/fwd/fwd.pro
@@ -104,12 +104,6 @@ HEADERS +=\
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/fwd
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/fwd/fwd.pro
+++ b/libraries/fwd/fwd.pro
@@ -108,7 +108,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/fwd
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/inverse/inverse.pro
+++ b/libraries/inverse/inverse.pro
@@ -121,7 +121,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/inverse
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/inverse/inverse.pro
+++ b/libraries/inverse/inverse.pro
@@ -117,12 +117,6 @@ HEADERS +=\
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/inverse
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/mne/mne.pro
+++ b/libraries/mne/mne.pro
@@ -179,7 +179,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/mne
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/mne/mne.pro
+++ b/libraries/mne/mne.pro
@@ -175,12 +175,6 @@ HEADERS += \
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/mne
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/rtprocessing/rtprocessing.pro
+++ b/libraries/rtprocessing/rtprocessing.pro
@@ -120,7 +120,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/rtprocessing
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/rtprocessing/rtprocessing.pro
+++ b/libraries/rtprocessing/rtprocessing.pro
@@ -116,12 +116,6 @@ HEADERS +=  \
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/rtprocessing
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage

--- a/libraries/utils/utils.pro
+++ b/libraries/utils/utils.pro
@@ -103,7 +103,7 @@ INCLUDEPATH += $${MNE_INCLUDE_DIR}
 header_files.files = $${HEADERS}
 header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/utils
 
-INSTALLS += header_files
+#INSTALLS += header_files
 
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage

--- a/libraries/utils/utils.pro
+++ b/libraries/utils/utils.pro
@@ -99,12 +99,6 @@ HEADERS += \
 INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
 INCLUDEPATH += $${MNE_INCLUDE_DIR}
 
-# Install headers to include directory
-header_files.files = $${HEADERS}
-header_files.path = $${MNE_INSTALL_INCLUDE_DIR}/utils
-
-#INSTALLS += header_files
-
 contains(MNECPP_CONFIG, withCodeCov) {
     QMAKE_CXXFLAGS += --coverage
     QMAKE_LFLAGS += --coverage


### PR DESCRIPTION
The usage of ```INSTALLS``` keyword in some of the projects ```.pro``` files makes the project to show twice all the header files. 
That is the case in the library layer, for instance. 

Is there a reason why we're using ```INSTALLS``` keyword?