### PR TITLE
MAINT: Fix some MNE Scan Coverity issues

### DIFF
--- a/applications/mne_scan/mne_scan/mainwindow.cpp
+++ b/applications/mne_scan/mne_scan/mainwindow.cpp
@@ -230,9 +230,10 @@ void MainWindow::onStyleChanged(const QString& sStyle)
             qInfo() << "MainWindow::onStyleChanged 2";
             m_sCurrentStyle = "dark";
             QFile file(":/dark.qss");
-            file.open(QFile::ReadOnly);
-            QTextStream stream(&file);
-            pApp->setStyleSheet(stream.readAll());
+            if(file.open(QFile::ReadOnly)){
+                QTextStream stream(&file);
+                pApp->setStyleSheet(stream.readAll());
+            }
         }
 
         // Set default font

--- a/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftbuffer.cpp
@@ -246,7 +246,7 @@ bool FtBuffer::setupRTMSA()
 
 //=============================================================================================================
 
-bool FtBuffer::setupRTMSA(FIFFLIB::FiffInfo FiffInfo)
+bool FtBuffer::setupRTMSA(const FIFFLIB::FiffInfo& FiffInfo)
 {
     //Check for FiffInfo that has not changed its default values and return early
     if (FiffInfo.sfreq < 0) {

--- a/applications/mne_scan/plugins/ftbuffer/ftbuffer.h
+++ b/applications/mne_scan/plugins/ftbuffer/ftbuffer.h
@@ -227,7 +227,7 @@ private:
      *
      * @param[in] FiffInfo  FiffInfo used to set up buffer output.
      */
-    bool setupRTMSA(FIFFLIB::FiffInfo FiffInfo);
+    bool setupRTMSA(const FIFFLIB::FiffInfo& FiffInfo);
 
     //=========================================================================================================
     /**

--- a/applications/mne_scan/plugins/ftbuffer/ftheaderparser.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftheaderparser.cpp
@@ -92,11 +92,12 @@ void FTBUFFERPLUGIN::parseIsotrakHeader(MetaData& data, QBuffer& isotrakBuffer)
     FIFFLIB::FiffStream stream(&isotrakBuffer);
     FIFFLIB::FiffDigitizerData digData;
 
-    stream.open();
-    stream.read_digitizer_data(stream.dirtree(), digData);
-    stream.close();
+    if(stream.open()){
+        stream.read_digitizer_data(stream.dirtree(), digData);
+        stream.close();
 
-    data.setFiffDigitizerData(digData);
+        data.setFiffDigitizerData(digData);
+    }
 }
 
 //=============================================================================================================

--- a/applications/mne_scan/plugins/ftbuffer/ftheaderparser.h
+++ b/applications/mne_scan/plugins/ftbuffer/ftheaderparser.h
@@ -80,11 +80,11 @@ struct FTBUFFER_EXPORT MetaData{
     bool bFiffDigitizerData = false;
     FIFFLIB::FiffDigitizerData dig;
 
-    void setFiffinfo(FIFFLIB::FiffInfo newinfo) {info = newinfo;
-                                                 bFiffInfo = true;};
+    void setFiffinfo(const FIFFLIB::FiffInfo& newinfo) {info = newinfo;
+                                                        bFiffInfo = true;};
 
-    void setFiffDigitizerData(FIFFLIB::FiffDigitizerData newdig) {dig = newdig;
-                                                                  bFiffDigitizerData = true;};
+    void setFiffDigitizerData(const FIFFLIB::FiffDigitizerData& newdig) {dig = newdig;
+                                                                         bFiffDigitizerData = true;};
 };
 
 //=============================================================================================================

--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -83,7 +83,11 @@ constexpr const int defaultFittingWindowSize(300);
 //=============================================================================================================
 
 Hpi::Hpi()
-: m_iFittingWindowSize(defaultFittingWindowSize)
+: m_iNumberBadChannels(0)
+, m_iFittingWindowSize(defaultFittingWindowSize)
+, m_dAllowedMeanErrorDist(10)
+, m_dAllowedMovement(3)
+, m_dAllowedRotation(5)
 , m_bDoFreqOrder(false)
 , m_bDoSingleHpi(false)
 , m_bDoContinousHpi(false)

--- a/examples/ex_fiff_sniffer/main.cpp
+++ b/examples/ex_fiff_sniffer/main.cpp
@@ -107,52 +107,52 @@ int main(int argc, char *argv[])
             stream.setByteOrder(QDataStream::BigEndian);
         }
 
-        stream.open();
+        if(stream.open()){
+            FIFFLIB::FiffInfo FifInfo;
+            FIFFLIB::FiffDirNode::SPtr DirNode;
 
-        FIFFLIB::FiffInfo FifInfo;
-        FIFFLIB::FiffDirNode::SPtr DirNode;
+            FIFFLIB::FiffDigitizerData digData;
 
-        FIFFLIB::FiffDigitizerData digData;
+            if(stream.read_meas_info(stream.dirtree(), FifInfo, DirNode)) {
 
-        if(stream.read_meas_info(stream.dirtree(), FifInfo, DirNode)) {
+                FIFFLIB::FiffIO p_fiffIO(t_fileRaw);
 
-            FIFFLIB::FiffIO p_fiffIO(t_fileRaw);
+                std::cout << "Num. raw dat sets: " << p_fiffIO.m_qlistRaw.size() << "\n";
+                std::cout << "Num. evoked sets: " << p_fiffIO.m_qlistEvoked.size() << "\n";
 
-            std::cout << "Num. raw dat sets: " << p_fiffIO.m_qlistRaw.size() << "\n";
-            std::cout << "Num. evoked sets: " << p_fiffIO.m_qlistEvoked.size() << "\n";
-
-            int count = 0;
-            for (auto& data : p_fiffIO.m_qlistRaw){
+                int count = 0;
+                for (auto& data : p_fiffIO.m_qlistRaw){
+                    std::cout << "--- \n";
+                    std::cout << "Raw Set " << count << "\n";
+                    std::cout << "Sample frequency: " << data->info.sfreq << "\n";
+                    std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
+                    std::cout << "First sample: " << data->first_samp << " | Last sample: " << data->last_samp << "\n";
+                    std::cout << "Number of samples: " << data->last_samp - data->first_samp << " | Time: " << (data->last_samp - data->first_samp) / data->info.sfreq << " sec. \n";
+                    std::cout << "Number of digitizer points: " << data->info.dig.size() << "\n";
+                    for (auto& point : data->info.dig){
+                        if (point.kind == FIFFV_POINT_HPI){
+                            std::cout << "HPI Point " << point.ident << " - " << point.r[0] << ", " << point.r[1] << ", " << point.r[2] << "\n";
+                        }
+                    }
+                }
+                count = 0;
+                for (auto& data : p_fiffIO.m_qlistEvoked){
+                    std::cout << "--- \n";
+                    std::cout << "Evoked Set " << count << "\n";
+                    std::cout << "Sample frequency: " << data->info.sfreq << "\n";
+                    std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
+                    std::cout << "Num. averaged epochs: " << data->nave << "\n";
+                }
                 std::cout << "--- \n";
-                std::cout << "Raw Set " << count << "\n";
-                std::cout << "Sample frequency: " << data->info.sfreq << "\n";
-                std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
-                std::cout << "First sample: " << data->first_samp << " | Last sample: " << data->last_samp << "\n";
-                std::cout << "Number of samples: " << data->last_samp - data->first_samp << " | Time: " << (data->last_samp - data->first_samp) / data->info.sfreq << " sec. \n";
-                std::cout << "Number of digitizer points: " << data->info.dig.size() << "\n";
-                for (auto& point : data->info.dig){
+                std::cout << "--------------------------------------\n";
+            }
+            if(stream.read_digitizer_data(stream.dirtree(), digData)) {
+                std::cout << "Digitizer data found.\n";
+                std::cout << "Number of digitizer points: " << digData.points.size() << "\n";
+                for (auto& point : digData.points){
                     if (point.kind == FIFFV_POINT_HPI){
                         std::cout << "HPI Point " << point.ident << " - " << point.r[0] << ", " << point.r[1] << ", " << point.r[2] << "\n";
                     }
-                }
-            }
-            count = 0;
-            for (auto& data : p_fiffIO.m_qlistEvoked){
-                std::cout << "--- \n";
-                std::cout << "Evoked Set " << count << "\n";
-                std::cout << "Sample frequency: " << data->info.sfreq << "\n";
-                std::cout << "LineFreq: " << data->info.linefreq << " | Highpass: " << data->info.highpass << " | Lowpass: " << data->info.lowpass << "\n";
-                std::cout << "Num. averaged epochs: " << data->nave << "\n";
-            }
-            std::cout << "--- \n";
-            std::cout << "--------------------------------------\n";
-        }
-        if(stream.read_digitizer_data(stream.dirtree(), digData)) {
-            std::cout << "Digitizer data found.\n";
-            std::cout << "Number of digitizer points: " << digData.points.size() << "\n";
-            for (auto& point : digData.points){
-                if (point.kind == FIFFV_POINT_HPI){
-                    std::cout << "HPI Point " << point.ident << " - " << point.r[0] << ", " << point.r[1] << ", " << point.r[2] << "\n";
                 }
             }
         }


### PR DESCRIPTION
- Add read guards before operating on data that was opened from streams/files
- Calls by const reference
- Init member variables in constructor

Part of Juan's new 10 issues a week initiative.