### PR TITLE
MAINT: Fix filter plugin crash in MNE Scan, add min buffer read size.

### DIFF
--- a/applications/mne_scan/plugins/ftbuffer/ftconnector.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftconnector.cpp
@@ -209,6 +209,7 @@ bool FtConnector::parseHeaderDef(QBuffer &readBuffer)
     m_iNumNewSamples = headerdef.nsamples;
     m_iDataType = headerdef.data_type;
     m_iExtendedHeaderSize = headerdef.bufsize;
+    m_iMinSampleRead = static_cast<int>(m_fSampleFreq/2);
 
     qInfo() << "[FtConnector::parseHeaderDef] Got header parameters.";
 

--- a/applications/mne_scan/plugins/ftbuffer/ftconnector.cpp
+++ b/applications/mne_scan/plugins/ftbuffer/ftconnector.cpp
@@ -60,7 +60,8 @@ using namespace FTBUFFERPLUGIN;
 //=============================================================================================================
 
 FtConnector::FtConnector()
-: m_iNumSamples(0)
+: m_iMinSampleRead(200)
+, m_iNumSamples(0)
 , m_iNumNewSamples(0)
 , m_iMsgSamples(0)
 , m_iNumChannels(0)
@@ -259,7 +260,7 @@ bool FtConnector::getData()
 {
     m_iNumNewSamples = totalBuffSamples();
 
-    if (m_iNumNewSamples == m_iNumSamples) {
+    if (m_iNumNewSamples <= (m_iNumSamples + m_iMinSampleRead)) {
         // no new unread data in buffer
         return false;
     }

--- a/applications/mne_scan/plugins/ftbuffer/ftconnector.h
+++ b/applications/mne_scan/plugins/ftbuffer/ftconnector.h
@@ -312,6 +312,7 @@ private:
      */
     FIFFLIB::FiffInfo infoFromSimpleHeader();
 
+    int                                     m_iMinSampleRead;                       /**< Number of samples that need to be added t obuffer before we try to read. */
     int                                     m_iNumSamples;                          /**< Number of samples we've read from the buffer. */
     int                                     m_iNumNewSamples;                       /**< Number of total samples (read and unread) in the buffer. */
     int                                     m_iMsgSamples;                          /**< Number of samples in the latest buffer transmission receied. */

--- a/libraries/rtprocessing/helpers/cosinefilter.cpp
+++ b/libraries/rtprocessing/helpers/cosinefilter.cpp
@@ -116,7 +116,7 @@ CosineFilter::CosineFilter(int fftLength,
             mult = 1.0/w;
             add  = 3.0;
 
-            for (k = 0; k < highpasss-w+1; k++)
+            for (k = 0; k < resp_size; k++)
                 filterFreqResp(k) = 0.0;
 
             for (k = -w+1, s = highpasss-w+1; k < w; k++, s++) {


### PR DESCRIPTION
- Prevent out of bounds access to Eigen structure that was sometimes causing a crash.
- Add min sample window to read from ftbuffer (quick fix for how filter plugin does max filter size).