### PR TITLE
[Fix] Memory leak in MNE library in bem related functions

### DIFF
--- a/libraries/mne/c/mne_msh_display_surface_set.cpp
+++ b/libraries/mne/c/mne_msh_display_surface_set.cpp
@@ -427,7 +427,7 @@ int MneMshDisplaySurfaceSet::add_bem_surface(MneMshDisplaySurfaceSet* surfs,
         if (std::fabs(sum - 1.0) > 1e-4) {
             fprintf(stderr, "%s surface is not closed "
                                  "(sum of solid angles = %g * 4*PI).",name,sum);
-            return FAIL;
+            goto bad;
         }
     }
 
@@ -449,7 +449,14 @@ int MneMshDisplaySurfaceSet::add_bem_surface(MneMshDisplaySurfaceSet* surfs,
     return OK;
 
 bad : {
-        delete surf;
+        if(surf)
+        {
+            delete surf;
+        }
+        if(newSurf)
+        {
+            delete newSurf;
+        }
         return FAIL;
     }
 }
@@ -461,11 +468,10 @@ void MneMshDisplaySurfaceSet::add_replace_display_surface(MneMshDisplaySurfaceSe
                                                           int                  replace,
                                                           int                  drawable)
 {
-    int k;
     MneMshDisplaySurface* surf = new MneMshDisplaySurface();
 
     if (replace) {
-        for (k = 0; k < surfs->nsurf; k++) {
+        for (int k = 0; k < surfs->nsurf; k++) {
             surf = surfs->surfs[k];
             if (surf->s->id == newSurf->s->id) {
                 newSurf->transparent   = surf->transparent;
@@ -494,7 +500,6 @@ void MneMshDisplaySurfaceSet::add_replace_display_surface(MneMshDisplaySurfaceSe
         surfs->patch_rot[surfs->nsurf] = 0.0;
         surfs->nsurf++;
     }
-    return;
 }
 
 //=============================================================================================================

--- a/libraries/mne/c/mne_msh_display_surface_set.cpp
+++ b/libraries/mne/c/mne_msh_display_surface_set.cpp
@@ -427,7 +427,7 @@ int MneMshDisplaySurfaceSet::add_bem_surface(MneMshDisplaySurfaceSet* surfs,
         if (std::fabs(sum - 1.0) > 1e-4) {
             fprintf(stderr, "%s surface is not closed "
                                  "(sum of solid angles = %g * 4*PI).",name,sum);
-            goto bad;
+            return FAIL;
         }
     }
 
@@ -442,21 +442,14 @@ int MneMshDisplaySurfaceSet::add_bem_surface(MneMshDisplaySurfaceSet* surfs,
     newSurf->overlay_color_mode   = SHOW_OVERLAY_HEAT;
 
     decide_surface_extent(newSurf,name);
-    add_replace_display_surface(surfs,newSurf,TRUE,TRUE);
+    add_replace_display_surface(surfs, newSurf, true, true);
     apply_left_eyes(surfs);
     setup_current_surface_lights(surfs);
 
     return OK;
 
 bad : {
-        if(surf)
-        {
-            delete surf;
-        }
-        if(newSurf)
-        {
-            delete newSurf;
-        }
+        delete surf;
         return FAIL;
     }
 }
@@ -465,13 +458,14 @@ bad : {
 
 void MneMshDisplaySurfaceSet::add_replace_display_surface(MneMshDisplaySurfaceSet* surfs,
                                                           MneMshDisplaySurface*    newSurf,
-                                                          int                  replace,
-                                                          int                  drawable)
+                                                          bool                  replace,
+                                                          bool                  drawable)
 {
+    int k;
     MneMshDisplaySurface* surf = new MneMshDisplaySurface();
 
     if (replace) {
-        for (int k = 0; k < surfs->nsurf; k++) {
+        for (k = 0; k < surfs->nsurf; k++) {
             surf = surfs->surfs[k];
             if (surf->s->id == newSurf->s->id) {
                 newSurf->transparent   = surf->transparent;
@@ -500,6 +494,7 @@ void MneMshDisplaySurfaceSet::add_replace_display_surface(MneMshDisplaySurfaceSe
         surfs->patch_rot[surfs->nsurf] = 0.0;
         surfs->nsurf++;
     }
+    return;
 }
 
 //=============================================================================================================

--- a/libraries/mne/c/mne_msh_display_surface_set.cpp
+++ b/libraries/mne/c/mne_msh_display_surface_set.cpp
@@ -461,7 +461,7 @@ void MneMshDisplaySurfaceSet::add_replace_display_surface(MneMshDisplaySurfaceSe
                                                           bool                  replace,
                                                           bool                  drawable)
 {
-    MneMshDisplaySurface* surf = new MneMshDisplaySurface();
+    MneMshDisplaySurface* surf;
 
     if (replace) {
         for (int k = 0; k < surfs->nsurf; k++) {

--- a/libraries/mne/c/mne_msh_display_surface_set.cpp
+++ b/libraries/mne/c/mne_msh_display_surface_set.cpp
@@ -461,11 +461,10 @@ void MneMshDisplaySurfaceSet::add_replace_display_surface(MneMshDisplaySurfaceSe
                                                           bool                  replace,
                                                           bool                  drawable)
 {
-    int k;
     MneMshDisplaySurface* surf = new MneMshDisplaySurface();
 
     if (replace) {
-        for (k = 0; k < surfs->nsurf; k++) {
+        for (int k = 0; k < surfs->nsurf; k++) {
             surf = surfs->surfs[k];
             if (surf->s->id == newSurf->s->id) {
                 newSurf->transparent   = surf->transparent;

--- a/libraries/mne/c/mne_msh_display_surface_set.cpp
+++ b/libraries/mne/c/mne_msh_display_surface_set.cpp
@@ -427,7 +427,7 @@ int MneMshDisplaySurfaceSet::add_bem_surface(MneMshDisplaySurfaceSet* surfs,
         if (std::fabs(sum - 1.0) > 1e-4) {
             fprintf(stderr, "%s surface is not closed "
                                  "(sum of solid angles = %g * 4*PI).",name,sum);
-            return FAIL;
+            goto bad;
         }
     }
 
@@ -448,8 +448,16 @@ int MneMshDisplaySurfaceSet::add_bem_surface(MneMshDisplaySurfaceSet* surfs,
 
     return OK;
 
-bad : {
-        delete surf;
+bad :
+    {
+        if(surf)
+        {
+            delete surf;
+        }
+        if(newSurf)
+        {
+            delete newSurf;
+        }
         return FAIL;
     }
 }

--- a/libraries/mne/c/mne_msh_display_surface_set.h
+++ b/libraries/mne/c/mne_msh_display_surface_set.h
@@ -119,9 +119,9 @@ public:
                         int                  check);
 
     static void add_replace_display_surface(MneMshDisplaySurfaceSet* surfs,
-                                                MneMshDisplaySurface*    newSurf,
-                                                int                  replace,
-                                                int                  drawable);
+                                            MneMshDisplaySurface*    newSurf,
+                                            int                  replace,
+                                            int                  drawable);
 
     //============================= vertex_colors.c =============================
 

--- a/libraries/mne/c/mne_msh_display_surface_set.h
+++ b/libraries/mne/c/mne_msh_display_surface_set.h
@@ -120,8 +120,8 @@ public:
 
     static void add_replace_display_surface(MneMshDisplaySurfaceSet* surfs,
                                             MneMshDisplaySurface*    newSurf,
-                                            int                  replace,
-                                            int                  drawable);
+                                            bool                  replace,
+                                            bool                  drawable);
 
     //============================= vertex_colors.c =============================
 


### PR DESCRIPTION
In ```add_bem_surface``` there seems to be a leak of ```newSurf``` 

In ```add_replace_display_surface``` I'm not sure about ```surf``` variable. @LorenzE do you remember about this function?