### PR TITLE
Do not merge. Make tests fail to test ci

### DIFF
--- a/testframes/test_coregistration/test_coregistration.cpp
+++ b/testframes/test_coregistration/test_coregistration.cpp
@@ -214,6 +214,7 @@ void TestCoregistration::initTestCase()
 
 void TestCoregistration::compareFitMatchedPoints()
 {
+    QVERIFY(false);
     QVERIFY(transFitMatchedRef == transFitMatched);
 }
 

--- a/testframes/test_edf2fiff_rwr/test_edf2fiff_rwr.cpp
+++ b/testframes/test_edf2fiff_rwr/test_edf2fiff_rwr.cpp
@@ -169,6 +169,7 @@ void TestEDF2FIFFRWR::testEDFReadAndFiffWrite()
     outfid->finish_writing_raw();
 
     QVERIFY(iSamplesRead == m_pEDFRaw->getInfo().getSampleCount());
+    QVERIFY(false);
 }
 
 


### PR DESCRIPTION
I've modify a couple of tests so that they always fail. I want to test the ci.