### PR TITLE
[MAINT] Utils library Qt-less refactor (Part 1 of many)

### DIFF
--- a/examples/ex_hpiFit/main.cpp
+++ b/examples/ex_hpiFit/main.cpp
@@ -272,6 +272,6 @@ int main(int argc, char *argv[])
             << "Average Duration:" << matPosition.col(9).mean() << "ms";
 
     if(bSave) {
-        IOUtils::write_eigen_matrix(matPosition, QCoreApplication::applicationDirPath() + "/MNE-sample-data/" + sNameOut);
+        IOUtils::write_eigen_matrix(matPosition, QString(QCoreApplication::applicationDirPath() + "/MNE-sample-data/" + sNameOut));
     }
 }

--- a/examples/ex_read_fwd/main.cpp
+++ b/examples/ex_read_fwd/main.cpp
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
     qDebug() << "col_names:";
     qDebug() << t_clusteredFwd.sol->col_names;
     qDebug() << "write fwd data to ./test_fwd.txt ...";
-    IOUtils::write_eigen_matrix(t_clusteredFwd.sol->data,"./test_fwd.txt");
+    IOUtils::write_eigen_matrix(t_clusteredFwd.sol->data, QString("./test_fwd.txt"));
     qDebug() << "[done]";
 
     return app.exec();

--- a/examples/ex_spectral/main.cpp
+++ b/examples/ex_spectral/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
     }
 
     //Generate hanning window
-    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iNSamples, "hanning");
+    QPair<MatrixXd, VectorXd> tapers = Spectral::generateTapers(iNSamples, QString("hanning"));
     MatrixXd matTaps = tapers.first;
     VectorXd vecTapWeights = tapers.second;
 

--- a/libraries/utils/file.cpp
+++ b/libraries/utils/file.cpp
@@ -57,12 +57,8 @@ using namespace UTILSLIB;
 
 bool File::exists(const char* filePath)
 {
-#if __cplusplus >= 201703L
-    return std::filesystem::exists(filePath);
-#else
     std::ifstream infile(filePath);
     return infile.good();
-#endif
 }
 
 //=============================================================================================================
@@ -79,11 +75,6 @@ bool File::copy(const char* sourcePath, const char* destPath)
     if (!exists(sourcePath) || exists(destPath)){
         return false;
     }
-
-#if __cplusplus >= 201703L
-    std::filesystem::copy(sourcePath, destPath);
-    return exists(destPath);
-#else
     std::ifstream source(sourcePath, std::ios::binary);
     std::ofstream destination(destPath, std::ios::binary);
 
@@ -92,7 +83,6 @@ bool File::copy(const char* sourcePath, const char* destPath)
     } else {
         return false;
     }
-#endif
 }
 
 //=============================================================================================================
@@ -109,13 +99,7 @@ bool File::rename(const char* sourcePath, const char* destPath)
     if (!exists(sourcePath) || exists(destPath)){
         return false;
     }
-
-#if __cplusplus >= 201703L
-    std::filesystem::rename(sourcePath, destPath);
-    return (!exists(sourcePath) && exists(destPath));
-#else
     return !std::rename(sourcePath, destPath); //std::rename returns 0 upon success
-#endif
 }
 
 //=============================================================================================================
@@ -133,12 +117,7 @@ bool File::remove(const char* filePath)
         return false;
     }
 
-#if __cplusplus >= 201703L
-    std::filesystem::remove(filePath);
-    return !exists(filePath);
-#else
     return !std::remove(filePath); //std::remove returns 0 upon success
-#endif
 }
 
 //=============================================================================================================

--- a/libraries/utils/file.cpp
+++ b/libraries/utils/file.cpp
@@ -39,11 +39,7 @@
 #include "file.h"
 #include <fstream>
 
-#if __cplusplus >= 201703L
-#include <filesystem>
-#else
 #include <cstdio>
-#endif
 
 //=============================================================================================================
 // USED NAMESPACES

--- a/libraries/utils/generics/observerpattern.cpp
+++ b/libraries/utils/generics/observerpattern.cpp
@@ -73,6 +73,9 @@ void Subject::notify()
         t_Observers::const_iterator it = m_Observers.begin();
         for( ; it != m_Observers.end(); ++it)
             (*it)->update(this);
+//        for(auto observer : m_Observers){
+//            observer->update(this);
+//        }
     }
 }
 

--- a/libraries/utils/generics/observerpattern.h
+++ b/libraries/utils/generics/observerpattern.h
@@ -41,6 +41,7 @@
 //=============================================================================================================
 
 #include "../utils_global.h"
+#include <set>
 
 //=============================================================================================================
 // QT INCLUDES
@@ -147,6 +148,14 @@ public:
      */
     inline t_Observers& observers();
 
+//    //=========================================================================================================
+//    /**
+//     * Returns attached observers.
+
+//     * @return attached observers.
+//     */
+//    inline std::set<IObserver*>& observers();
+
     //=========================================================================================================
     /**
      * Returns number of attached observers.
@@ -165,6 +174,7 @@ protected:
 
 private:
     t_Observers                 m_Observers;    /**< Holds the attached observers.*/
+//    std::set<IObserver*>        m_Observers;    /**< Holds the attached observers.*/
 };
 
 //=============================================================================================================
@@ -175,6 +185,11 @@ inline Subject::t_Observers& Subject::observers()
 {
     return m_Observers;
 }
+
+//inline std::set<IObserver*>& Subject::observers()
+//{
+//    return m_Observers;
+//}
 
 } // Namespace
 

--- a/libraries/utils/ioutils.cpp
+++ b/libraries/utils/ioutils.cpp
@@ -389,7 +389,7 @@ bool IOUtils::check_matching_chnames_conventions(const std::vector<std::string>&
 
     bool bMatching = false;
 
-    for(int i = 0 ; i < chNamesA.size(); ++i){
+    for(size_t i = 0 ; i < chNamesA.size(); ++i){
         if (std::find(chNamesB.begin(), chNamesB.end(), chNamesA.at(i)) != chNamesB.end()){
             bMatching = true;
         } else if(bCheckForNewNamingConvention){

--- a/libraries/utils/ioutils.cpp
+++ b/libraries/utils/ioutils.cpp
@@ -2,13 +2,14 @@
 /**
  * @file     ioutils.cpp
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     March, 2013
  *
  * @section  LICENSE
  *
- * Copyright (C) 2013, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2013, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -497,8 +497,8 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
 
                 Eigen::VectorXd x (fields.size());
 
-                for (int j=0; j<fields.size(); j++) {
-                    x(j)=fields.at(j).toDouble();
+                for (int j = 0; j<fields.size(); j++) {
+                    x(j) = fields.at(j).toDouble();
                 }
 
                 help.append(x);
@@ -506,12 +506,12 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
         }
 
         int rows = help.size();
-        int cols = rows<=0 ? 0 : help.at(0).rows();
+        int cols = rows <= 0 ? 0 : help.at(0).rows();
 
         out.resize(rows, cols);
 
-        for (int i=0; i<help.length(); i++) {
-            out.row(i)=help[i].transpose();
+        for (int i=0; i < help.length(); i++) {
+            out.row(i) = help[i].transpose();
         }
     } else {
         qWarning()<<"IOUtils::read_eigen_matrix - Could not read Eigen element from file! Path does not exist!";
@@ -580,7 +580,7 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
 
                 Eigen::VectorXd x (elements.size());
 
-                for(int i = 0; i < elements.size(); ++i){
+                for(size_t i = 0; i < elements.size(); ++i){
                     x(i) = elements.at(i);
                 }
 
@@ -589,12 +589,12 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
         }
 
         int rows = help.size();
-        int cols = rows<=0 ? 0 : help.at(0).rows();
+        int cols = rows <= 0 ? 0 : help.at(0).rows();
 
         out.resize(rows, cols);
 
-        for (int i=0; i < help.size(); i++) {
-            out.row(i)=help[i].transpose();
+        for (size_t i = 0; i < help.size(); i++) {
+            out.row(i) = help[i].transpose();
         }
     } else {
         qWarning()<<"IOUtils::read_eigen_matrix - Could not read Eigen element from file! Path does not exist!";

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -2,13 +2,14 @@
 /**
  * @file     ioutils.h
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     March, 2013
  *
  * @section  LICENSE
  *
- * Copyright (C) 2013, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2013, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -568,7 +568,7 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
         size_t matSize{0};
 
         while(std::getline(inputFile, line)){
-            if(std::find(line.begin(), line.end(), '#') != line.end()){
+            if(std::find(line.begin(), line.end(), '#') == line.end()){
                 std::vector<double> elements;
                 std::stringstream stream{line};
                 std::string element;

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -575,13 +575,13 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
 
                 stream >> std::ws;
                 while(stream >> element){
-                    element.push_back(std::stod(element));
+                    elements.push_back(std::stod(element));
                 }
 
                 Eigen::VectorXd x (elements.size());
 
                 for(int i = 0; i < elements.size(); ++i){
-                    x(i) = element.at(i);
+                    x(i) = elements.at(i);
                 }
 
                 help.push_back(std::move(x));

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -397,49 +397,49 @@ bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::D
 
 //=============================================================================================================
 
-template<typename T>
-bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
-{
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(1,in.cols());
-    matrixName.row(0)= in;
-    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
-}
+//template<typename T>
+//bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
+//{
+//    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(1,in.cols());
+//    matrixName.row(0)= in;
+//    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
+//}
 
-//=============================================================================================================
+////=============================================================================================================
 
-template<typename T>
-bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription)
-{
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(in.rows(),1);
-    matrixName.col(0)= in;
-    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
-}
+//template<typename T>
+//bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription)
+//{
+//    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(in.rows(),1);
+//    matrixName.col(0)= in;
+//    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
+//}
 
-//=============================================================================================================
+////=============================================================================================================
 
-template<typename T>
-bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
-{
-    std::ofstream outputFile(sPath);
-    if(outputFile.is_open())
-    {
-        if(!sDescription.empty()) {
-            outputFile<<"# Dimensions (rows x cols): "<<in.rows()<<" x "<<in.cols()<<"\n";
-            outputFile<<"# Description: "<<sDescription<<"\n";
-        }
+//template<typename T>
+//bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
+//{
+//    std::ofstream outputFile(sPath);
+//    if(outputFile.is_open())
+//    {
+//        if(!sDescription.empty()) {
+//            outputFile<<"# Dimensions (rows x cols): "<<in.rows()<<" x "<<in.cols()<<"\n";
+//            outputFile<<"# Description: "<<sDescription<<"\n";
+//        }
 
-        for(int row = 0; row<in.rows(); row++) {
-            for(int col = 0; col<in.cols(); col++)
-                outputFile << in(row, col)<<" ";
-            outputFile<<"\n";
-        }
-    } else {
-        qWarning()<<"Could not write Eigen element to file! Path does not exist!";
-        return false;
-    }
+//        for(int row = 0; row<in.rows(); row++) {
+//            for(int col = 0; col<in.cols(); col++)
+//                outputFile << in(row, col)<<" ";
+//            outputFile<<"\n";
+//        }
+//    } else {
+//        qWarning()<<"Could not write Eigen element to file! Path does not exist!";
+//        return false;
+//    }
 
-    return true;
-}
+//    return true;
+//}
 
 //=============================================================================================================
 
@@ -523,86 +523,86 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
 
 //=============================================================================================================
 
-template<typename T>
-bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path)
-{
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
-    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
+//template<typename T>
+//bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path)
+//{
+//    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
+//    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
 
-    if(matrixName.rows() > 0)
-    {
-        out = matrixName.row(0);
-    }
+//    if(matrixName.rows() > 0)
+//    {
+//        out = matrixName.row(0);
+//    }
 
-    return bStatus;
-}
+//    return bStatus;
+//}
 
-//=============================================================================================================
+////=============================================================================================================
 
-template<typename T>
-bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path)
-{
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
-    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
+//template<typename T>
+//bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path)
+//{
+//    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
+//    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
 
-    if(matrixName.cols() > 0)
-    {
-        out = matrixName.col(0);
-    }
+//    if(matrixName.cols() > 0)
+//    {
+//        out = matrixName.col(0);
+//    }
 
-    return bStatus;
-}
+//    return bStatus;
+//}
 
-//=============================================================================================================
+////=============================================================================================================
 
-template<typename T>
-bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path)
-{
-    std::ifstream inputFile(path);
+//template<typename T>
+//bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path)
+//{
+//    std::ifstream inputFile(path);
 
-    if(inputFile.is_open()) {
-        //Start reading from file
-        std::vector<Eigen::VectorXd> help;
+//    if(inputFile.is_open()) {
+//        //Start reading from file
+//        std::vector<Eigen::VectorXd> help;
 
-        std::string line;
+//        std::string line;
 
-        while(std::getline(inputFile, line)){
-            if(line.find('#') == std::string::npos){
-                std::vector<double> elements;
-                std::stringstream stream{line};
-                std::string element;
+//        while(std::getline(inputFile, line)){
+//            if(line.find('#') == std::string::npos){
+//                std::vector<double> elements;
+//                std::stringstream stream{line};
+//                std::string element;
 
-                stream >> std::ws;
-                while(stream >> element){
-                    elements.push_back(std::stod(element));
-                    stream >> std::ws;
-                }
+//                stream >> std::ws;
+//                while(stream >> element){
+//                    elements.push_back(std::stod(element));
+//                    stream >> std::ws;
+//                }
 
-                Eigen::VectorXd x (elements.size());
+//                Eigen::VectorXd x (elements.size());
 
-                for(size_t i = 0; i < elements.size(); ++i){
-                    x(i) = elements.at(i);
-                }
+//                for(size_t i = 0; i < elements.size(); ++i){
+//                    x(i) = elements.at(i);
+//                }
 
-                help.push_back(std::move(x));
-            }
-        }
+//                help.push_back(std::move(x));
+//            }
+//        }
 
-        int rows = help.size();
-        int cols = rows <= 0 ? 0 : help.at(0).rows();
+//        int rows = help.size();
+//        int cols = rows <= 0 ? 0 : help.at(0).rows();
 
-        out.resize(rows, cols);
+//        out.resize(rows, cols);
 
-        for (size_t i = 0; i < help.size(); i++) {
-            out.row(i) = help[i].transpose();
-        }
-    } else {
-        qWarning()<<"IOUtils::read_eigen_matrix - Could not read Eigen element from file! Path does not exist!";
-        return false;
-    }
+//        for (size_t i = 0; i < help.size(); i++) {
+//            out.row(i) = help[i].transpose();
+//        }
+//    } else {
+//        qWarning()<<"IOUtils::read_eigen_matrix - Could not read Eigen element from file! Path does not exist!";
+//        return false;
+//    }
 
-    return true;
-}
+//    return true;
+//}
 } // NAMESPACE
 
 #endif // IOUTILS_H

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -237,19 +237,19 @@ public:
     template<typename T>
     static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const QString& sPath, const QString& sDescription = QString());
 
-    //=========================================================================================================
-    /**
-     * Write Eigen Matrix to file
-     *
-     * @param[in] in         input eigen value which is to be written to file.
-     * @param[in] path       path and file name to write to.
-     */
-    template<typename T>
-    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
-    template<typename T>
-    static bool write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
-    template<typename T>
-    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription = std::string());
+//    //=========================================================================================================
+//    /**
+//     * Write Eigen Matrix to file
+//     *
+//     * @param[in] in         input eigen value which is to be written to file.
+//     * @param[in] path       path and file name to write to.
+//     */
+//    template<typename T>
+//    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
+//    template<typename T>
+//    static bool write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
+//    template<typename T>
+//    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription = std::string());
 
     //=========================================================================================================
     /**
@@ -265,19 +265,19 @@ public:
     template<typename T>
     static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const QString& path);
 
-    //=========================================================================================================
-    /**
-     * Read Eigen Matrix from file
-     *
-     * @param[out] out       output eigen value.
-     * @param[in] path       path and file name to read from.
-     */
-    template<typename T>
-    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path);
-    template<typename T>
-    static bool read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path);
-    template<typename T>
-    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path);
+//    //=========================================================================================================
+//    /**
+//     * Read Eigen Matrix from file
+//     *
+//     * @param[out] out       output eigen value.
+//     * @param[in] path       path and file name to read from.
+//     */
+//    template<typename T>
+//    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path);
+//    template<typename T>
+//    static bool read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path);
+//    template<typename T>
+//    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path);
 
     //=========================================================================================================
     /**

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -237,19 +237,19 @@ public:
     template<typename T>
     static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const QString& sPath, const QString& sDescription = QString());
 
-//    //=========================================================================================================
-//    /**
-//     * Write Eigen Matrix to file
-//     *
-//     * @param[in] in         input eigen value which is to be written to file.
-//     * @param[in] path       path and file name to write to.
-//     */
-//    template<typename T>
-//    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
-//    template<typename T>
-//    static bool write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
-//    template<typename T>
-//    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription = std::string());
+    //=========================================================================================================
+    /**
+     * Write Eigen Matrix to file
+     *
+     * @param[in] in         input eigen value which is to be written to file.
+     * @param[in] path       path and file name to write to.
+     */
+    template<typename T>
+    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
+    template<typename T>
+    static bool write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
+    template<typename T>
+    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription = std::string());
 
     //=========================================================================================================
     /**
@@ -265,19 +265,19 @@ public:
     template<typename T>
     static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const QString& path);
 
-//    //=========================================================================================================
-//    /**
-//     * Read Eigen Matrix from file
-//     *
-//     * @param[out] out       output eigen value.
-//     * @param[in] path       path and file name to read from.
-//     */
-//    template<typename T>
-//    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path);
-//    template<typename T>
-//    static bool read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path);
-//    template<typename T>
-//    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path);
+    //=========================================================================================================
+    /**
+     * Read Eigen Matrix from file
+     *
+     * @param[out] out       output eigen value.
+     * @param[in] path       path and file name to read from.
+     */
+    template<typename T>
+    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path);
+    template<typename T>
+    static bool read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path);
+    template<typename T>
+    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path);
 
     //=========================================================================================================
     /**
@@ -397,49 +397,49 @@ bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::D
 
 //=============================================================================================================
 
-//template<typename T>
-//bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
-//{
-//    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(1,in.cols());
-//    matrixName.row(0)= in;
-//    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
-//}
+template<typename T>
+bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
+{
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(1,in.cols());
+    matrixName.row(0)= in;
+    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
+}
 
-////=============================================================================================================
+//=============================================================================================================
 
-//template<typename T>
-//bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription)
-//{
-//    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(in.rows(),1);
-//    matrixName.col(0)= in;
-//    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
-//}
+template<typename T>
+bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription)
+{
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(in.rows(),1);
+    matrixName.col(0)= in;
+    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
+}
 
-////=============================================================================================================
+//=============================================================================================================
 
-//template<typename T>
-//bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
-//{
-//    std::ofstream outputFile(sPath);
-//    if(outputFile.is_open())
-//    {
-//        if(!sDescription.empty()) {
-//            outputFile<<"# Dimensions (rows x cols): "<<in.rows()<<" x "<<in.cols()<<"\n";
-//            outputFile<<"# Description: "<<sDescription<<"\n";
-//        }
+template<typename T>
+bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
+{
+    std::ofstream outputFile(sPath);
+    if(outputFile.is_open())
+    {
+        if(!sDescription.empty()) {
+            outputFile<<"# Dimensions (rows x cols): "<<in.rows()<<" x "<<in.cols()<<"\n";
+            outputFile<<"# Description: "<<sDescription<<"\n";
+        }
 
-//        for(int row = 0; row<in.rows(); row++) {
-//            for(int col = 0; col<in.cols(); col++)
-//                outputFile << in(row, col)<<" ";
-//            outputFile<<"\n";
-//        }
-//    } else {
-//        qWarning()<<"Could not write Eigen element to file! Path does not exist!";
-//        return false;
-//    }
+        for(int row = 0; row<in.rows(); row++) {
+            for(int col = 0; col<in.cols(); col++)
+                outputFile << in(row, col)<<" ";
+            outputFile<<"\n";
+        }
+    } else {
+        qWarning()<<"Could not write Eigen element to file! Path does not exist!";
+        return false;
+    }
 
-//    return true;
-//}
+    return true;
+}
 
 //=============================================================================================================
 
@@ -523,86 +523,86 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
 
 //=============================================================================================================
 
-//template<typename T>
-//bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path)
-//{
-//    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
-//    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
+template<typename T>
+bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path)
+{
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
+    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
 
-//    if(matrixName.rows() > 0)
-//    {
-//        out = matrixName.row(0);
-//    }
+    if(matrixName.rows() > 0)
+    {
+        out = matrixName.row(0);
+    }
 
-//    return bStatus;
-//}
+    return bStatus;
+}
 
-////=============================================================================================================
+//=============================================================================================================
 
-//template<typename T>
-//bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path)
-//{
-//    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
-//    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
+template<typename T>
+bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path)
+{
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
+    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
 
-//    if(matrixName.cols() > 0)
-//    {
-//        out = matrixName.col(0);
-//    }
+    if(matrixName.cols() > 0)
+    {
+        out = matrixName.col(0);
+    }
 
-//    return bStatus;
-//}
+    return bStatus;
+}
 
-////=============================================================================================================
+//=============================================================================================================
 
-//template<typename T>
-//bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path)
-//{
-//    std::ifstream inputFile(path);
+template<typename T>
+bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path)
+{
+    std::ifstream inputFile(path);
 
-//    if(inputFile.is_open()) {
-//        //Start reading from file
-//        std::vector<Eigen::VectorXd> help;
+    if(inputFile.is_open()) {
+        //Start reading from file
+        std::vector<Eigen::VectorXd> help;
 
-//        std::string line;
+        std::string line;
 
-//        while(std::getline(inputFile, line)){
-//            if(line.find('#') == std::string::npos){
-//                std::vector<double> elements;
-//                std::stringstream stream{line};
-//                std::string element;
+        while(std::getline(inputFile, line)){
+            if(line.find('#') == std::string::npos){
+                std::vector<double> elements;
+                std::stringstream stream{line};
+                std::string element;
 
-//                stream >> std::ws;
-//                while(stream >> element){
-//                    elements.push_back(std::stod(element));
-//                    stream >> std::ws;
-//                }
+                stream >> std::ws;
+                while(stream >> element){
+                    elements.push_back(std::stod(element));
+                    stream >> std::ws;
+                }
 
-//                Eigen::VectorXd x (elements.size());
+                Eigen::VectorXd x (elements.size());
 
-//                for(size_t i = 0; i < elements.size(); ++i){
-//                    x(i) = elements.at(i);
-//                }
+                for(size_t i = 0; i < elements.size(); ++i){
+                    x(i) = elements.at(i);
+                }
 
-//                help.push_back(std::move(x));
-//            }
-//        }
+                help.push_back(std::move(x));
+            }
+        }
 
-//        int rows = help.size();
-//        int cols = rows <= 0 ? 0 : help.at(0).rows();
+        int rows = help.size();
+        int cols = rows <= 0 ? 0 : help.at(0).rows();
 
-//        out.resize(rows, cols);
+        out.resize(rows, cols);
 
-//        for (size_t i = 0; i < help.size(); i++) {
-//            out.row(i) = help[i].transpose();
-//        }
-//    } else {
-//        qWarning()<<"IOUtils::read_eigen_matrix - Could not read Eigen element from file! Path does not exist!";
-//        return false;
-//    }
+        for (size_t i = 0; i < help.size(); i++) {
+            out.row(i) = help[i].transpose();
+        }
+    } else {
+        qWarning()<<"IOUtils::read_eigen_matrix - Could not read Eigen element from file! Path does not exist!";
+        return false;
+    }
 
-//    return true;
-//}
+    return true;
+}
 } // NAMESPACE
 
 #endif // IOUTILS_H

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -576,6 +576,7 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
                 stream >> std::ws;
                 while(stream >> element){
                     elements.push_back(std::stod(element));
+                    stream >> std::ws;
                 }
 
                 Eigen::VectorXd x (elements.size());

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -565,10 +565,9 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
         std::vector<Eigen::VectorXd> help;
 
         std::string line;
-        size_t matSize{0};
 
         while(std::getline(inputFile, line)){
-            if(std::find(line.begin(), line.end(), '#') == line.end()){
+            if(line.find('#') == std::string::npos){
                 std::vector<double> elements;
                 std::stringstream stream{line};
                 std::string element;

--- a/libraries/utils/ioutils.h
+++ b/libraries/utils/ioutils.h
@@ -40,6 +40,11 @@
 //=============================================================================================================
 
 #include "utils_global.h"
+#include <ios>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <fstream>
 
 //=============================================================================================================
 // QT INCLUDES
@@ -110,6 +115,18 @@ public:
 
     //=========================================================================================================
     /**
+     * mne_fread3(fid)
+     *
+     * Reads a 3-byte integer out of a stream
+     *
+     * @param[in] stream  Stream to read from.
+     *
+     * @return the read 3-byte integer.
+     */
+    static qint32 fread3(std::iostream& stream);
+
+    //=========================================================================================================
+    /**
      * fread3_many(fid,count)
      *
      * Reads a 3-byte integer out of a stream
@@ -120,6 +137,19 @@ public:
      * @return the read 3-byte integer.
      */
     static Eigen::VectorXi fread3_many(QDataStream &p_qStream, qint32 count);
+
+    //=========================================================================================================
+    /**
+     * fread3_many(fid,count)
+     *
+     * Reads a 3-byte integer out of a stream
+     *
+     * @param[in] stream     Stream to read from.
+     * @param[in] count      Number of elements to read.
+     *
+     * @return the read 3-byte integer.
+     */
+    static Eigen::VectorXi fread3_many(std::iostream &stream, qint32 count);
 
     //=========================================================================================================
     /**
@@ -209,6 +239,20 @@ public:
 
     //=========================================================================================================
     /**
+     * Write Eigen Matrix to file
+     *
+     * @param[in] in         input eigen value which is to be written to file.
+     * @param[in] path       path and file name to write to.
+     */
+    template<typename T>
+    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
+    template<typename T>
+    static bool write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription = std::string());
+    template<typename T>
+    static bool write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription = std::string());
+
+    //=========================================================================================================
+    /**
      * Read Eigen Matrix from file
      *
      * @param[out] out       output eigen value.
@@ -223,6 +267,20 @@ public:
 
     //=========================================================================================================
     /**
+     * Read Eigen Matrix from file
+     *
+     * @param[out] out       output eigen value.
+     * @param[in] path       path and file name to read from.
+     */
+    template<typename T>
+    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path);
+    template<typename T>
+    static bool read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path);
+    template<typename T>
+    static bool read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path);
+
+    //=========================================================================================================
+    /**
      * Returns the new channel naming conventions (whitespcae between channel type and number) for the input list.
      *
      * @param[in] chNames    The channel names.
@@ -230,6 +288,16 @@ public:
      * @return The new channel names.
      */
     static QStringList get_new_chnames_conventions(const QStringList& chNames);
+
+    //=========================================================================================================
+    /**
+     * Returns the new channel naming conventions (whitespcae between channel type and number) for the input list.
+     *
+     * @param[in] chNames    The channel names.
+     *
+     * @return The new channel names.
+     */
+    static std::vector<std::string> get_new_chnames_conventions(const std::vector<std::string>& chNames);
 
     //=========================================================================================================
     /**
@@ -243,6 +311,16 @@ public:
 
     //=========================================================================================================
     /**
+     * Returns the old channel naming conventions (whitespcae between channel type and number) for the input list.
+     *
+     * @param[in] chNames    The channel names.
+     *
+     * @return The new channel names.
+     */
+    static std::vector<std::string> get_old_chnames_conventions(const std::vector<std::string>& chNames);
+
+    //=========================================================================================================
+    /**
      * Checks if all names from chNamesA are in chNamesB. If wanted each name in chNamesA is transformed to the old and new naming convention and checked if in chNamesB.
      *
      * @param[in] chNamesA    The channel names.
@@ -252,6 +330,18 @@ public:
      * @return True if all names in chNamesA are present in chNamesB, false otherwise.
      */
     static bool check_matching_chnames_conventions(const QStringList& chNamesA, const QStringList& chNamesB, bool bCheckForNewNamingConvention = false);
+
+    //=========================================================================================================
+    /**
+     * Checks if all names from chNamesA are in chNamesB. If wanted each name in chNamesA is transformed to the old and new naming convention and checked if in chNamesB.
+     *
+     * @param[in] chNamesA    The channel names.
+     * @param[in] chNamesB    The channel names which is to be compared to.
+     * @param[in] bCheckForNewNamingConvention    Whether to use old and new naming conventions while checking.
+     *
+     * @return True if all names in chNamesA are present in chNamesB, false otherwise.
+     */
+    static bool check_matching_chnames_conventions(const std::vector<std::string>& chNamesA, const std::vector<std::string>& chNamesB, bool bCheckForNewNamingConvention = false);
 };
 
 //=============================================================================================================
@@ -301,6 +391,52 @@ bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::D
     }
 
     file.close();
+
+    return true;
+}
+
+//=============================================================================================================
+
+template<typename T>
+bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, 1, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
+{
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(1,in.cols());
+    matrixName.row(0)= in;
+    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
+}
+
+//=============================================================================================================
+
+template<typename T>
+bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, 1>& in, const std::string& sPath, const std::string& sDescription)
+{
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName(in.rows(),1);
+    matrixName.col(0)= in;
+    return IOUtils::write_eigen_matrix(matrixName, sPath, sDescription);
+}
+
+//=============================================================================================================
+
+template<typename T>
+bool IOUtils::write_eigen_matrix(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& in, const std::string& sPath, const std::string& sDescription)
+{
+    std::ofstream outputFile(sPath);
+    if(outputFile.is_open())
+    {
+        if(!sDescription.empty()) {
+            outputFile<<"# Dimensions (rows x cols): "<<in.rows()<<" x "<<in.cols()<<"\n";
+            outputFile<<"# Description: "<<sDescription<<"\n";
+        }
+
+        for(int row = 0; row<in.rows(); row++) {
+            for(int col = 0; col<in.cols(); col++)
+                outputFile << in(row, col)<<" ";
+            outputFile<<"\n";
+        }
+    } else {
+        qWarning()<<"Could not write Eigen element to file! Path does not exist!";
+        return false;
+    }
 
     return true;
 }
@@ -375,6 +511,89 @@ bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
         out.resize(rows, cols);
 
         for (int i=0; i<help.length(); i++) {
+            out.row(i)=help[i].transpose();
+        }
+    } else {
+        qWarning()<<"IOUtils::read_eigen_matrix - Could not read Eigen element from file! Path does not exist!";
+        return false;
+    }
+
+    return true;
+}
+
+//=============================================================================================================
+
+template<typename T>
+bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, 1, Eigen::Dynamic>& out, const std::string& path)
+{
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
+    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
+
+    if(matrixName.rows() > 0)
+    {
+        out = matrixName.row(0);
+    }
+
+    return bStatus;
+}
+
+//=============================================================================================================
+
+template<typename T>
+bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, 1>& out, const std::string& path)
+{
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrixName;
+    bool bStatus = IOUtils::read_eigen_matrix(matrixName, path);
+
+    if(matrixName.cols() > 0)
+    {
+        out = matrixName.col(0);
+    }
+
+    return bStatus;
+}
+
+//=============================================================================================================
+
+template<typename T>
+bool IOUtils::read_eigen_matrix(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& out, const std::string& path)
+{
+    std::ifstream inputFile(path);
+
+    if(inputFile.is_open()) {
+        //Start reading from file
+        std::vector<Eigen::VectorXd> help;
+
+        std::string line;
+        size_t matSize{0};
+
+        while(std::getline(inputFile, line)){
+            if(std::find(line.begin(), line.end(), '#') != line.end()){
+                std::vector<double> elements;
+                std::stringstream stream{line};
+                std::string element;
+
+                stream >> std::ws;
+                while(stream >> element){
+                    element.push_back(std::stod(element));
+                }
+
+                Eigen::VectorXd x (elements.size());
+
+                for(int i = 0; i < elements.size(); ++i){
+                    x(i) = element.at(i);
+                }
+
+                help.push_back(std::move(x));
+            }
+        }
+
+        int rows = help.size();
+        int cols = rows<=0 ? 0 : help.at(0).rows();
+
+        out.resize(rows, cols);
+
+        for (int i=0; i < help.size(); i++) {
             out.row(i)=help[i].transpose();
         }
     } else {

--- a/libraries/utils/kmeans.cpp
+++ b/libraries/utils/kmeans.cpp
@@ -2,13 +2,14 @@
 /**
  * @file     kmeans.cpp
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     July, 2012
  *
  * @section  LICENSE
  *
- * Copyright (C) 2012, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2012, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/kmeans.cpp
+++ b/libraries/utils/kmeans.cpp
@@ -89,30 +89,30 @@ KMeans::KMeans(QString distance,
 
 //=============================================================================================================
 
-KMeans::KMeans(std::string distance,
-               std::string start,
-               qint32 replicates,
-               std::string emptyact,
-               bool online,
-               qint32 maxit)
-: m_sDistance(distance)
-, m_sStart(start)
-, m_iReps(replicates)
-, m_sEmptyact(emptyact)
-, m_iMaxit(maxit)
-, m_bOnline(online)
-, emptyErrCnt(0)
-, iter(0)
-, k(0)
-, n(0)
-, p(0)
-, totsumD(0)
-, prevtotsumD(0)
-{
-    // Assume one replicate
-    if (m_iReps < 1)
-        m_iReps = 1;
-}
+//KMeans::KMeans(std::string distance,
+//               std::string start,
+//               qint32 replicates,
+//               std::string emptyact,
+//               bool online,
+//               qint32 maxit)
+//: m_sDistance(distance)
+//, m_sStart(start)
+//, m_iReps(replicates)
+//, m_sEmptyact(emptyact)
+//, m_iMaxit(maxit)
+//, m_bOnline(online)
+//, emptyErrCnt(0)
+//, iter(0)
+//, k(0)
+//, n(0)
+//, p(0)
+//, totsumD(0)
+//, prevtotsumD(0)
+//{
+//    // Assume one replicate
+//    if (m_iReps < 1)
+//        m_iReps = 1;
+//}
 
 //=============================================================================================================
 

--- a/libraries/utils/kmeans.cpp
+++ b/libraries/utils/kmeans.cpp
@@ -68,6 +68,33 @@ KMeans::KMeans(QString distance,
                QString emptyact,
                bool online,
                qint32 maxit)
+: m_sDistance(distance.toStdString())
+, m_sStart(start.toStdString())
+, m_iReps(replicates)
+, m_sEmptyact(emptyact.toStdString())
+, m_iMaxit(maxit)
+, m_bOnline(online)
+, emptyErrCnt(0)
+, iter(0)
+, k(0)
+, n(0)
+, p(0)
+, totsumD(0)
+, prevtotsumD(0)
+{
+    // Assume one replicate
+    if (m_iReps < 1)
+        m_iReps = 1;
+}
+
+//=============================================================================================================
+
+KMeans::KMeans(std::string distance,
+               std::string start,
+               qint32 replicates,
+               std::string emptyact,
+               bool online,
+               qint32 maxit)
 : m_sDistance(distance)
 , m_sStart(start)
 , m_iReps(replicates)

--- a/libraries/utils/kmeans.h
+++ b/libraries/utils/kmeans.h
@@ -46,7 +46,7 @@
 // QT INCLUDES
 //=============================================================================================================
 
-#include <QString>
+#include <string>
 #include <QSharedPointer>
 
 //=============================================================================================================
@@ -93,6 +93,24 @@ public:
                     QString start = QString("sample"),
                     qint32 replicates = 1,
                     QString emptyact = QString("error"),
+                    bool online = true,
+                    qint32 maxit = 100);
+
+    //=========================================================================================================
+    /**
+     * Constructs a KMeans algorithm object.
+     *
+     * @param[in] distance   (optional) K-Means distance measure: "sqeuclidean" (default), "cityblock" , "cosine", "correlation", "hamming".
+     * @param[in] start      (optional) Cluster initialization: "sample" (default), "uniform", "cluster".
+     * @param[in] replicates (optional) Number of K-Means replicates, which are generated. Best is returned.
+     * @param[in] emptyact   (optional) What happens if a cluster wents empty: "error" (default), "drop", "singleton".
+     * @param[in] online     (optional) If centroids should be updated during iterations: true (default), false.
+     * @param[in] maxit      (optional) maximal number of iterations per replicate; 100 by default.
+     */
+    explicit KMeans(std::string distance = std::string{"sqeuclidean"} ,
+                    std::string start = std::string{"sample"},
+                    qint32 replicates = 1,
+                    std::string emptyact = std::string{"error"},
                     bool online = true,
                     qint32 maxit = 100);
 
@@ -182,10 +200,10 @@ private:
      */
     double unifrnd(double a, double b);
 
-    QString m_sDistance;    /**< Distance measurement to use: "sqeuclidean" (default), "cityblock" , "cosine", "correlation", "hamming". */
-    QString m_sStart;       /**< Initialization to use: "sample" (default), "uniform", "cluster". */
+    std::string m_sDistance;    /**< Distance measurement to use: "sqeuclidean" (default), "cityblock" , "cosine", "correlation", "hamming". */
+    std::string m_sStart;       /**< Initialization to use: "sample" (default), "uniform", "cluster". */
     qint32 m_iReps;         /**< Number of K-Means replicates, which should be generated. */
-    QString m_sEmptyact;    /**< What should be done if a cluster wents empty: "error" (default), "drop", "singleton". */
+    std::string m_sEmptyact;    /**< What should be done if a cluster wents empty: "error" (default), "drop", "singleton". */
     qint32 m_iMaxit;        /**< Maximal number of iterations per replicate. */
     bool m_bOnline;         /**< If online update should be performed. */
 

--- a/libraries/utils/kmeans.h
+++ b/libraries/utils/kmeans.h
@@ -2,13 +2,14 @@
 /**
  * @file     kmeans.h
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     July, 2012
  *
  * @section  LICENSE
  *
- * Copyright (C) 2012, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2012, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/kmeans.h
+++ b/libraries/utils/kmeans.h
@@ -96,23 +96,23 @@ public:
                     bool online = true,
                     qint32 maxit = 100);
 
-    //=========================================================================================================
-    /**
-     * Constructs a KMeans algorithm object.
-     *
-     * @param[in] distance   (optional) K-Means distance measure: "sqeuclidean" (default), "cityblock" , "cosine", "correlation", "hamming".
-     * @param[in] start      (optional) Cluster initialization: "sample" (default), "uniform", "cluster".
-     * @param[in] replicates (optional) Number of K-Means replicates, which are generated. Best is returned.
-     * @param[in] emptyact   (optional) What happens if a cluster wents empty: "error" (default), "drop", "singleton".
-     * @param[in] online     (optional) If centroids should be updated during iterations: true (default), false.
-     * @param[in] maxit      (optional) maximal number of iterations per replicate; 100 by default.
-     */
-    explicit KMeans(std::string distance = std::string{"sqeuclidean"} ,
-                    std::string start = std::string{"sample"},
-                    qint32 replicates = 1,
-                    std::string emptyact = std::string{"error"},
-                    bool online = true,
-                    qint32 maxit = 100);
+//    //=========================================================================================================
+//    /**
+//     * Constructs a KMeans algorithm object.
+//     *
+//     * @param[in] distance   (optional) K-Means distance measure: "sqeuclidean" (default), "cityblock" , "cosine", "correlation", "hamming".
+//     * @param[in] start      (optional) Cluster initialization: "sample" (default), "uniform", "cluster".
+//     * @param[in] replicates (optional) Number of K-Means replicates, which are generated. Best is returned.
+//     * @param[in] emptyact   (optional) What happens if a cluster wents empty: "error" (default), "drop", "singleton".
+//     * @param[in] online     (optional) If centroids should be updated during iterations: true (default), false.
+//     * @param[in] maxit      (optional) maximal number of iterations per replicate; 100 by default.
+//     */
+//    explicit KMeans(std::string distance = std::string{"sqeuclidean"} ,
+//                    std::string start = std::string{"sample"},
+//                    qint32 replicates = 1,
+//                    std::string emptyact = std::string{"error"},
+//                    bool online = true,
+//                    qint32 maxit = 100);
 
     //=========================================================================================================
     /**

--- a/libraries/utils/layoutloader.cpp
+++ b/libraries/utils/layoutloader.cpp
@@ -156,7 +156,7 @@ bool LayoutLoader::readAsaElcFile(const std::string &path,
                                   std::string &unit)
 {
 
-    if(std::find(path.begin(), path.end(), ".elc") == path.end()){
+    if(path.find(".elc") == std::string::npos){
         return false;
     }
 
@@ -174,7 +174,7 @@ bool LayoutLoader::readAsaElcFile(const std::string &path,
     std::string line;
 
     while(std::getline(inFile, line)){
-        if(std::find(line.begin(), line.end(), '#') == line.end()){
+        if(line.find('#') == std::string::npos){
             std::vector<std::string> elements;
             std::stringstream stream{line};
             std::string element;
@@ -186,18 +186,18 @@ bool LayoutLoader::readAsaElcFile(const std::string &path,
             }
 
             //Read number of electrodes
-            if(std::find(line.begin(), line.end(), "NumberPositions") != line.end())
+            if(line.find("NumberPositions") != std::string::npos)
                 numberElectrodes = std::stod(elements.at(1));
 
             //Read the unit of the position values
-            if(std::find(line.begin(), line.end(), "UnitPosition") != line.end())
+            if(line.find("UnitPosition") != std::string::npos)
                 unit = elements.at(1);
 
             //Read actual electrode positions
-            if(std::find(line.begin(), line.end(), "Positions2D") != line.end())
+            if(line.find("Positions2D") != std::string::npos)
                 read2D = true;
 
-            if(std::find(line.begin(), line.end(), ":") != line.end() && !read2D) //Read 3D positions
+            if(line.find(':') != std::string::npos && !read2D) //Read 3D positions
             {
                 channelNames.push_back(elements.at(0));
                 std::vector<float> posTemp;
@@ -209,7 +209,7 @@ bool LayoutLoader::readAsaElcFile(const std::string &path,
                 location3D.push_back(std::move(posTemp));
             }
 
-            if(std::find(line.begin(), line.end(), ":") != line.end() && read2D) //Read 2D positions
+            if(line.find(":") != std::string::npos && read2D) //Read 2D positions
             {
                 std::vector<float> posTemp;
                 posTemp.push_back(std::stod(elements.at(elements.size()-2)));    //x
@@ -218,7 +218,7 @@ bool LayoutLoader::readAsaElcFile(const std::string &path,
             }
 
             //Read channel names
-            if(std::find(line.begin(), line.end(), "Labels") != line.end())
+            if(line.find("Labels") != std::string::npos)
             {
                 std::getline(inFile, line);
                 std::stringstream channels{line};
@@ -292,7 +292,7 @@ bool LayoutLoader::readMNELoutFile(const QString &path, QMap<QString, QPointF> &
 bool LayoutLoader::readMNELoutFile(const std::string &path, QMap<std::string, QPointF> &channelData)
 {
 
-    if(std::find(path.begin(), path.end(), ".lout") == path.end()){
+    if(path.find(".lout") == std::string::npos){
         return false;
     }
 
@@ -308,7 +308,7 @@ bool LayoutLoader::readMNELoutFile(const std::string &path, QMap<std::string, QP
     std::string line;
 
     while(std::getline(inFile, line)){
-        if(std::find(line.begin(), line.end(), '#') == line.end()){
+        if(line.find('#') != std::string::npos){
             std::vector<std::string> elements;
             std::stringstream stream{line};
             std::string element;

--- a/libraries/utils/layoutloader.cpp
+++ b/libraries/utils/layoutloader.cpp
@@ -2,13 +2,14 @@
 /**
  * @file     layoutloader.cpp
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     September, 2014
  *
  * @section  LICENSE
  *
- * Copyright (C) 2014, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2014, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/layoutloader.h
+++ b/libraries/utils/layoutloader.h
@@ -3,12 +3,13 @@
  * @file     layoutloader.h
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
  *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     September, 2014
  *
  * @section  LICENSE
  *
- * Copyright (C) 2014, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2014, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/layoutloader.h
+++ b/libraries/utils/layoutloader.h
@@ -42,6 +42,9 @@
 
 #include "utils_global.h"
 
+#include <string>
+#include <vector>
+
 //=============================================================================================================
 // QT INCLUDES
 //=============================================================================================================
@@ -83,12 +86,6 @@ public:
 
     //=========================================================================================================
     /**
-     * Constructs a LayoutLoader object.
-     */
-    LayoutLoader();
-
-    //=========================================================================================================
-    /**
      * Reads the specified ANT elc-layout file.
      * @param[in] path holds the file path of the elc file which is to be read.
      * @param[in] location3D holds the vector to which the read 3D positions are stored.
@@ -103,6 +100,20 @@ public:
 
     //=========================================================================================================
     /**
+     * Reads the specified ANT elc-layout file.
+     * @param[in] path holds the file path of the elc file which is to be read.
+     * @param[in] location3D holds the vector to which the read 3D positions are stored.
+     * @param[in] location2D holds the vector to which the read 2D positions are stored.
+     * @return true if reading was successful, false otherwise.
+     */
+    static bool readAsaElcFile(const std::string &path,
+                               std::vector<std::string> &channelNames,
+                               std::vector<std::vector<float> > &location3D,
+                               std::vector<std::vector<float> > &location2D,
+                               std::string &unit);
+
+    //=========================================================================================================
+    /**
      * Reads the specified MNE .lout file.
      * @param[in] path holds the file path of the lout file which is to be read.
      * @param[in] channel data holds the x,y and channel number for every channel. The map keys are the channel names (i.e. 'MEG 0113').
@@ -110,6 +121,16 @@ public:
      */
     static bool readMNELoutFile(const QString &path,
                                 QMap<QString, QPointF> &channelData);
+
+    //=========================================================================================================
+    /**
+     * Reads the specified MNE .lout file.
+     * @param[in] path holds the file path of the lout file which is to be read.
+     * @param[in] channel data holds the x,y and channel number for every channel. The map keys are the channel names (i.e. 'MEG 0113').
+     * @return bool true if reading was successful, false otherwise.
+     */
+    static bool readMNELoutFile(const std::string &path,
+                                QMap<std::string, QPointF> &channelData);
 
 private:
 };

--- a/libraries/utils/layoutmaker.cpp
+++ b/libraries/utils/layoutmaker.cpp
@@ -2,13 +2,14 @@
 /**
  * @file     layoutmaker.cpp
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     September, 2014
  *
  * @section  LICENSE
  *
- * Copyright (C) 2014, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2014, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/layoutmaker.h
+++ b/libraries/utils/layoutmaker.h
@@ -42,6 +42,10 @@
 
 #include "utils_global.h"
 
+#include <vector>
+#include <string>
+#include <fstream>
+
 //=============================================================================================================
 // QT INCLUDES
 //=============================================================================================================
@@ -83,11 +87,6 @@ typedef struct {
 class UTILSSHARED_EXPORT LayoutMaker
 {
 public:
-    //=========================================================================================================
-    /**
-     * Constructs a LayoutMaker object.
-     */
-    LayoutMaker();
 
     //=========================================================================================================
     /**
@@ -117,6 +116,36 @@ public:
                            bool writeFile = false,
                            bool mirrorXAxis = false,
                            bool mirrorYAxis = false);
+
+    //=========================================================================================================
+    /**
+     * Reads the specified ANT elc-layout file.
+     * @param[in] inputPoints       The input points in 3D space.
+     * @param[in, out] outputPoints     The output layout points in 2D space.
+     * @param[in] names             The channel names.
+     * @param[in] outFile           The outout file.
+     * @param[in] do_fit            The flag whether to do a sphere fitting.
+     * @param[in] prad.
+     * @param[in] w.
+     * @param[in] h.
+     * @param[in] writeFile         The flag whether to write to file.
+     * @param[in] mirrorXAxis       Mirror points at x axis.
+     * @param[in] mirrorYAxis       Mirror points at y axis.
+     *
+     * @return true if making layout was successful, false otherwise.
+     */
+    static bool makeLayout(const std::vector<std::vector<float> > &inputPoints,
+                           std::vector<std::vector<float> > &outputPoints,
+                           const std::vector<std::string> &names,
+                           const std::string& outFilePath,
+                           bool do_fit,
+                           float prad,
+                           float w,
+                           float h,
+                           bool writeFile = false,
+                           bool mirrorXAxis = false,
+                           bool mirrorYAxis = false);
+
 
 private:
     static void sphere_coord(float x,

--- a/libraries/utils/layoutmaker.h
+++ b/libraries/utils/layoutmaker.h
@@ -2,13 +2,14 @@
 /**
  * @file     layoutmaker.h
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     September, 2014
  *
  * @section  LICENSE
  *
- * Copyright (C) 2014, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2014, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/mnemath.cpp
+++ b/libraries/utils/mnemath.cpp
@@ -2,13 +2,14 @@
 /**
  * @file     mnemath.cpp
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     July, 2012
  *
  * @section  LICENSE
  *
- * Copyright (C) 2012, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2012, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/mnemath.cpp
+++ b/libraries/utils/mnemath.cpp
@@ -39,7 +39,7 @@
 
 #define _USE_MATH_DEFINES
 #include <math.h>
-
+#include <iostream>
 #include "mnemath.h"
 
 //=============================================================================================================
@@ -497,7 +497,11 @@ MatrixXd MNEMath::rescale(const MatrixXd& data,
     std::vector<std::string> valid_modes{"logratio", "ratio", "zscore", "mean", "percent"};
     if(std::find(valid_modes.begin(),valid_modes.end(), mode) == valid_modes.end())
     {
-        qWarning().noquote() << "[MNEMath::rescale] Mode" << QString(mode.c_str()) << "is not supported. Supported modes are:" << valid_modes << "Returning input data.";
+        qWarning().noquote() << "[MNEMath::rescale] Mode" << mode.c_str() << "is not supported. Supported modes are:";
+        for(auto& mode : valid_modes){
+            std::cout << mode << " ";
+        }
+        std::cout << "\n" << "Returning input data.\n";
         return data_out;
     }
 

--- a/libraries/utils/mnemath.h
+++ b/libraries/utils/mnemath.h
@@ -44,6 +44,10 @@
 
 #include "utils_global.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
 //=============================================================================================================
 // EIGEN INCLUDES
 //=============================================================================================================
@@ -164,6 +168,21 @@ public:
 
     //=========================================================================================================
     /**
+     * Returns the whitener of a given matrix.
+     *
+     * @param[in] A      Matrix to compute the whitener from.
+     * @param[in] pca    perform a pca.
+     *
+     * @return rank of matrix A.
+     */
+    static void get_whitener(Eigen::MatrixXd& A,
+                             bool pca,
+                             const std::string& ch_type,
+                             Eigen::VectorXd& eig,
+                             Eigen::MatrixXd& eigvec);
+
+    //=========================================================================================================
+    /**
      * Find the intersection of two vectors
      *
      * @param[in] v1         Input vector 1.
@@ -201,6 +220,21 @@ public:
     static Eigen::MatrixXd legendre(qint32 n,
                                     const Eigen::VectorXd &X,
                                     QString normalize = QString("unnorm"));
+
+    //=========================================================================================================
+    /**
+     * LEGENDRE Associated Legendre function.
+     *
+     *   P = LEGENDRE(N,X) computes the associated Legendre functions
+     *   of degree N and order M = 0, 1, ..., N, evaluated for each element
+     *   of X.  N must be a scalar integer and X must contain real values
+     *   between -1 <= X <= 1.
+     *
+     * @return associated Legendre functions.
+     */
+    static Eigen::MatrixXd legendre(qint32 n,
+                                    const Eigen::VectorXd &X,
+                                    std::string normalize = "unnorm");
 
     //=========================================================================================================
     /**
@@ -265,6 +299,27 @@ public:
                                    const Eigen::RowVectorXf &times,
                                    const QPair<float, float> &baseline,
                                    QString mode);
+
+    //=========================================================================================================
+    /**
+     * ToDo: Maybe new processing class
+     *
+     * Rescale aka baseline correct data
+     *
+     * @param[in] data           Data Matrix (m x n_time).
+     * @param[in] times          Time instants is seconds.
+     * @param[in] baseline       If baseline is (a, b) the interval is between "a (s)" and "b (s)".
+     *                           If a and b are equal use interval between the beginning of the data and the time point 0 (stimulus onset).
+     * @param[in] mode           Do baseline correction with ratio (power is divided by mean power during baseline) or zscore (power is divided by standard.
+     *                           deviatio of power during baseline after substracting the mean, power = [power - mean(power_baseline)] / std(power_baseline)).
+     *                           ("logratio" | "ratio" | "zscore" | "mean" | "percent")
+     *
+     * @return   rescaled data matrix rescaling.
+     */
+    static Eigen::MatrixXd rescale(const Eigen::MatrixXd& data,
+                                   const Eigen::RowVectorXf& times,
+                                   const std::pair<float, float>& baseline,
+                                   const std::string& mode);
 
     //=========================================================================================================
     /**

--- a/libraries/utils/selectionio.cpp
+++ b/libraries/utils/selectionio.cpp
@@ -42,7 +42,6 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <filesystem>
 
 //=============================================================================================================
 // QT INCLUDES

--- a/libraries/utils/selectionio.cpp
+++ b/libraries/utils/selectionio.cpp
@@ -340,7 +340,7 @@ bool SelectionIO::writeBrainstormMonFiles(const std::string& path, const std::ma
 
     for(auto& mapElement : selectionMap){
         //logic of using parent_path here might not be "correct"
-        std::string newPath = std::filesystem::absolute(std::filesystem::path(path).parent_path()) /= (mapElement.first + ".mon");
+        std::string newPath{path.substr(0, path.find_last_of("/") + 1) + mapElement.first + ".mon"};
         std::ofstream outFile(newPath);
         if(!outFile.is_open()){
             qDebug()<<"Error opening mon file for writing";

--- a/libraries/utils/selectionio.cpp
+++ b/libraries/utils/selectionio.cpp
@@ -2,13 +2,14 @@
 /**
  * @file     selectionio.cpp
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     October, 2014
  *
  * @section  LICENSE
  *
- * Copyright (C) 2014, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2014, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/selectionio.h
+++ b/libraries/utils/selectionio.h
@@ -2,13 +2,14 @@
 /**
  * @file     selectionio.h
  * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
- *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>
+ *           Christoph Dinh <chdinh@nmr.mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     October, 2014
  *
  * @section  LICENSE
  *
- * Copyright (C) 2014, Lorenz Esch, Christoph Dinh. All rights reserved.
+ * Copyright (C) 2014, Lorenz Esch, Christoph Dinh, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/selectionio.h
+++ b/libraries/utils/selectionio.h
@@ -42,6 +42,10 @@
 
 #include "utils_global.h"
 
+#include <vector>
+#include <string>
+#include <map>
+
 //=============================================================================================================
 // QT INCLUDES
 //=============================================================================================================
@@ -85,11 +89,27 @@ public:
 
     //=========================================================================================================
     /**
+     * Reads the specified MNE sel file.
+     * @param[in] path holds the file path of the .sel file which is to be read.
+     * @param[in] selectionMap holds the map to which the read selection groups are stored.
+     */
+    static bool readMNESelFile(const std::string& path, std::multimap<std::string,std::vector<std::string>>& selectionMap);
+
+    //=========================================================================================================
+    /**
      * Reads the specified Brainstorm montage file.
      * @param[in] path holds the file path of the .mon file which is to be read.
      * @param[in] selectionMap holds the map to which the read selection groups are stored.
      */
     static bool readBrainstormMonFile(QString path, QMap<QString,QStringList> &selectionMap);
+
+    //=========================================================================================================
+    /**
+     * Reads the specified Brainstorm montage file.
+     * @param[in] path holds the file path of the .mon file which is to be read.
+     * @param[in] selectionMap holds the map to which the read selection groups are stored.
+     */
+    static bool readBrainstormMonFile(const std::string& path, std::multimap<std::string,std::vector<std::string>>& selectionMap);
 
     //=========================================================================================================
     /**
@@ -101,11 +121,27 @@ public:
 
     //=========================================================================================================
     /**
+     * Writes the specified selection groups to a single MNE .sel file.
+     * @param[in] path holds the file path of the .sel file which is to be read.
+     * @param[in] selectionMap holds the map to which the read selection groups are stored.
+     */
+    static bool writeMNESelFile(const std::string& path, const std::map<std::string,std::vector<std::string>>& selectionMap);
+
+    //=========================================================================================================
+    /**
      * Writes the specified selection groups to different Brainstorm .mon files. The amount of written files depend on the number of selection groups in selectionMap
      * @param[in] path holds the file path of the .mon file which is to be read.
      * @param[in] selectionMap holds the map to which the read selection groups are stored.
      */
     static bool writeBrainstormMonFiles(QString path, const QMap<QString,QStringList> &selectionMap);
+
+    //=========================================================================================================
+    /**
+     * Writes the specified selection groups to different Brainstorm .mon files. The amount of written files depend on the number of selection groups in selectionMap
+     * @param[in] path holds the file path of the .mon file which is to be read.
+     * @param[in] selectionMap holds the map to which the read selection groups are stored.
+     */
+    static bool writeBrainstormMonFiles(const std::string& path, const std::map<std::string,std::vector<std::string>>& selectionMap);
 };
 } // NAMESPACE
 

--- a/libraries/utils/spectral.cpp
+++ b/libraries/utils/spectral.cpp
@@ -2,13 +2,14 @@
 /**
  * @file     spectral.cpp
  * @author   Daniel Strohmeier <Daniel.Strohmeier@tu-ilmenau.de>;
- *           Lorenz Esch <lesch@mgh.harvard.edu>
+ *           Lorenz Esch <lesch@mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     March, 2018
  *
  * @section  LICENSE
  *
- * Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch. All rights reserved.
+ * Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/spectral.cpp
+++ b/libraries/utils/spectral.cpp
@@ -186,6 +186,14 @@ void Spectral::reduce(QVector<MatrixXcd>& finalData,
 
 //=============================================================================================================
 
+//void Spectral::reduce(std::vector<MatrixXcd>& finalData,
+//                      const MatrixXcd& resultData)
+//{
+//    finalData.push_back(resultData);
+//}
+
+//=============================================================================================================
+
 Eigen::RowVectorXd Spectral::psdFromTaperedSpectra(const Eigen::MatrixXcd &matTapSpectrum,
                                                    const Eigen::VectorXd &vecTapWeights,
                                                    int iNfft,
@@ -283,6 +291,24 @@ VectorXd Spectral::calculateFFTFreqs(int iNfft, double dSampFreq)
 QPair<MatrixXd, VectorXd> Spectral::generateTapers(int iSignalLength, const QString &sWindowType)
 {
     QPair<MatrixXd, VectorXd> pairOut;
+    if (sWindowType == "hanning") {
+        pairOut.first = hanningWindow(iSignalLength);
+        pairOut.second = VectorXd::Ones(1);
+    } else if (sWindowType == "ones") {
+        pairOut.first = MatrixXd::Ones(1, iSignalLength) / double(iSignalLength);
+        pairOut.second = VectorXd::Ones(1);
+    } else {
+        pairOut.first = hanningWindow(iSignalLength);
+        pairOut.second = VectorXd::Ones(1);
+    }
+    return pairOut;
+}
+
+//=============================================================================================================
+
+std::pair<MatrixXd, VectorXd> Spectral::generateTapers(int iSignalLength, const std::string &sWindowType)
+{
+    std::pair<MatrixXd, VectorXd> pairOut;
     if (sWindowType == "hanning") {
         pairOut.first = hanningWindow(iSignalLength);
         pairOut.second = VectorXd::Ones(1);

--- a/libraries/utils/spectral.h
+++ b/libraries/utils/spectral.h
@@ -45,6 +45,9 @@
 
 #include "utils_global.h"
 
+#include <vector>
+#include <utility>
+
 //=============================================================================================================
 // EIGEN INCLUDES
 //=============================================================================================================
@@ -118,6 +121,22 @@ public:
                                                                  int iNfft,
                                                                  bool bUseThreads = true);
 
+//    //=========================================================================================================
+//    /**
+//     * Calculates the full tapered spectra of a given input matrix data. This function calculates each row in parallel.
+//     *
+//     * @param[in] matData         input matrix data (time domain), for which the spectrum is computed.
+//     * @param[in] matTaper        tapers used to compute the spectra.
+//     * @param[in] iNfft           FFT length.
+//     * @param[in] bUseThreads Whether to use multiple threads.
+//     *
+//     * @return tapered spectra of the input data.
+//     */
+//    static std::vector<Eigen::MatrixXcd> computeTaperedSpectraMatrix(const Eigen::MatrixXd &matData,
+//                                                                    const Eigen::MatrixXd &matTaper,
+//                                                                    int iNfft,
+//                                                                    bool bUseThreads = true);
+
     //=========================================================================================================
     /**
      * Computes the tapered spectra for a row vector. This function gets called in parallel.
@@ -137,6 +156,16 @@ public:
      */
     static void reduce(QVector<Eigen::MatrixXcd>& finalData,
                        const Eigen::MatrixXcd& resultData);
+
+//    //=========================================================================================================
+//    /**
+//     * Reduces the taperedSpectra results to a final result. This function gets called in parallel.
+//     *
+//     * @param[out] finalData    The final data data.
+//     * @param[in] resultData   The resulting data from the computation step.
+//     */
+//    static void reduce(std::vector<Eigen::MatrixXcd>& finalData,
+//                       const Eigen::MatrixXcd& resultData);
 
     //=========================================================================================================
     /**
@@ -196,6 +225,18 @@ public:
      */
     static QPair<Eigen::MatrixXd, Eigen::VectorXd> generateTapers(int iSignalLength,
                                                                   const QString &sWindowType = "hanning");
+
+    //=========================================================================================================
+    /**
+     * Calculates a hanning window of given length
+     *
+     * @param[in] iSignalLength    length of the hanning window.
+     * @param[in] sWindowType      type of the window function used to compute tapered spectra.
+     *
+     * @return Qpair of tapers and taper weights.
+     */
+    static std::pair<Eigen::MatrixXd, Eigen::VectorXd> generateTapers(int iSignalLength,
+                                                                  const std::string &sWindowType = "hanning");
 
 private:
     //=========================================================================================================

--- a/libraries/utils/spectral.h
+++ b/libraries/utils/spectral.h
@@ -2,13 +2,14 @@
 /**
  * @file     spectral.h
  * @author   Daniel Strohmeier <Daniel.Strohmeier@tu-ilmenau.de>;
- *           Lorenz Esch <lesch@mgh.harvard.edu>
+ *           Lorenz Esch <lesch@mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     March, 2018
  *
  * @section  LICENSE
  *
- * Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch. All rights reserved.
+ * Copyright (C) 2018, Daniel Strohmeier, Lorenz Esch, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/warp.cpp
+++ b/libraries/utils/warp.cpp
@@ -38,6 +38,7 @@
 #include "warp.h"
 
 #include <iostream>
+#include <fstream>
 
 //=============================================================================================================
 // EIGEN INCLUDES
@@ -183,5 +184,52 @@ MatrixXf Warp::readsLm(const QString &electrodeFileName)
         }
         i++;
     }
+    return electrodes;
+}
+
+//=============================================================================================================
+
+MatrixXf Warp::readsLm(const std::string &electrodeFileName)
+{
+    MatrixXf electrodes;
+    std::ifstream inFile(electrodeFileName);
+
+    if(!inFile.is_open()) {
+        qDebug()<<"Error opening file";
+        //Why are we not returning?
+//        return false;
+    }
+
+    //Start reading from file
+    double numberElectrodes;
+    int i = 0;
+
+    std::string line;
+    while(std::getline(inFile, line)){
+        std::vector<std::string> fields;
+        std::stringstream stream{line};
+        std::string element;
+
+        stream >> std::ws;
+        while(stream >> element){
+            fields.push_back(std::move(element));
+            stream >> std::ws;
+        }
+
+        //Read number of electrodes
+        if(i == 0){
+            numberElectrodes = std::stod(fields.at(fields.size()-1));
+            electrodes = MatrixXf::Zero(numberElectrodes, 3);
+        }
+
+        //Read actual electrode positions
+        else{
+            Vector3f x;
+            x << std::stof(fields.at(fields.size()-3)), std::stof(fields.at(fields.size()-2)), std::stof(fields.at(fields.size()-1));
+            electrodes.row(i-1)=x.transpose();
+        }
+        i++;
+    }
+
     return electrodes;
 }

--- a/libraries/utils/warp.cpp
+++ b/libraries/utils/warp.cpp
@@ -1,13 +1,14 @@
 //=============================================================================================================
 /**
  * @file     warp.cpp
- * @author   Lorenz Esch <lesch@mgh.harvard.edu>
+ * @author   Lorenz Esch <lesch@mgh.harvard.edu>;
+ *           Gabriel Motta <gbmotta@mgh.harvard.edu>
  * @since    0.1.0
  * @date     November, 2015
  *
  * @section  LICENSE
  *
- * Copyright (C) 2015, Lorenz Esch. All rights reserved.
+ * Copyright (C) 2015, Lorenz Esch, Gabriel Motta. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:

--- a/libraries/utils/warp.h
+++ b/libraries/utils/warp.h
@@ -112,6 +112,16 @@ public:
      */
     Eigen::MatrixXf readsLm(const QString &electrodeFileName);
 
+    //=========================================================================================================
+    /**
+     * Read electrode positions from MRI Database
+     *
+     * @param[in] electrodeFileName    .txt file of electrodes.
+     *
+     * @return electrodes   Matrix with electrode positions.
+     */
+    Eigen::MatrixXf readsLm(const std::string &electrodeFileName);
+
 private:
 
     //=========================================================================================================

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -59,7 +59,7 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2020 Authors of MNE-CPP. All rights reser
 MNECPP_CONFIG +=
 
 # Define c++ version
-CONFIG += c++17
+CONFIG += c++14
 
 # Suppress untested SDK version checks on MacOS
 macx {

--- a/mne-cpp.pri
+++ b/mne-cpp.pri
@@ -59,7 +59,7 @@ QMAKE_TARGET_COPYRIGHT = Copyright (C) 2020 Authors of MNE-CPP. All rights reser
 MNECPP_CONFIG +=
 
 # Define c++ version
-CONFIG += c++14
+CONFIG += c++17
 
 # Suppress untested SDK version checks on MacOS
 macx {

--- a/testframes/test_utils_circularbuffer/test_utils_circularbuffer.cpp
+++ b/testframes/test_utils_circularbuffer/test_utils_circularbuffer.cpp
@@ -32,11 +32,116 @@
  *
  */
 
+//=============================================================================================================
+// INCLUDES
+//=============================================================================================================
+
+#include <utils/generics/circularbuffer.h>
+
+//=============================================================================================================
+// QT INCLUDES
+//=============================================================================================================
+
 #include <QCoreApplication>
+#include <QObject>
+#include <QDebug>
+#include <QTest>
 
-int main(int argc, char *argv[])
+//=============================================================================================================
+// USED NAMESPACES
+//=============================================================================================================
+
+using namespace UTILSLIB;
+
+//=============================================================================================================
+/**
+ * DECLARE CLASS TestCircularBuffer
+ *
+ * @brief The TestCircularBuffer class provides tests for verifying circular buffer functionality
+ *
+ */
+
+class TestCircularBuffer : public QObject
 {
-    QCoreApplication a(argc, argv);
+    Q_OBJECT
 
-    return a.exec();
+private slots:
+    void testBufferCreationDestruction();
+    void testBufferPushingPopping();
+    void testBufferCapacity();
+};
+
+//=============================================================================================================
+
+void TestCircularBuffer::testBufferCreationDestruction()
+{
+    //Test Constructors/Destructors
+    {
+        CircularBuffer<float> testBuffer(10);
+    }
+    {
+        CircularBuffer<int> *testBuffer = new CircularBuffer<int>(10);
+        delete testBuffer;
+    }
 }
+
+//=============================================================================================================
+
+void TestCircularBuffer::testBufferPushingPopping()
+{
+    CircularBuffer<int> testBuffer(10);
+
+    int testVal = 5;
+    int testArray[3] = {1, 2, 3};
+
+    //Verify Push
+    QVERIFY(testBuffer.push(testVal));
+    QVERIFY(testBuffer.push(testArray, 3));
+
+    int resultVal = 0;
+    int resultArray[3] = {0, 0, 0};
+
+    QVERIFY(testBuffer.pop(resultVal));
+    for (int i = 0; i < 3; ++i){
+        QVERIFY(testBuffer.pop(resultArray[i]));
+    }
+
+    QVERIFY(resultVal == testVal);
+    for (int i = 0; i < 3; ++i){
+        QVERIFY(resultArray[i] == resultArray[i]);
+    }
+}
+
+//=============================================================================================================
+
+void TestCircularBuffer::testBufferCapacity()
+{
+    CircularBuffer<int> testBuffer(2);
+    int testSink = 0;
+
+    QVERIFY(!testBuffer.pop(testSink));
+
+    testBuffer.push(5);
+    testBuffer.push(10);
+
+    QVERIFY(!testBuffer.push(15));
+
+    testBuffer.clear();
+
+    QVERIFY(!testBuffer.pop(testSink));
+
+    QVERIFY(testBuffer.push(20));
+
+    QVERIFY(testBuffer.pop(testSink));
+
+    QVERIFY(testSink == 20);
+
+    QVERIFY(!testBuffer.pop(testSink));
+}
+
+//=============================================================================================================
+// MAIN
+//=============================================================================================================
+
+QTEST_GUILESS_MAIN(TestCircularBuffer);
+#include "test_utils_circularbuffer.moc"

--- a/testframes/test_utils_circularbuffer/test_utils_circularbuffer.cpp
+++ b/testframes/test_utils_circularbuffer/test_utils_circularbuffer.cpp
@@ -1,0 +1,42 @@
+//=============================================================================================================
+/**
+ * @file     test_utils_circularbuffer.cpp
+ * @author   Gabriel Motta <gbmotta@mgh.harvard.edu>
+ * @since    0.1.9
+ * @date     August, 2022
+ *
+ * @section  LICENSE
+ *
+ * Copyright (C) 2022, Gabriel Motta. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *     * Neither the name of MNE-CPP authors nor the names of its contributors may be used
+ *       to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * @brief     Test for the circular buffer.
+ *
+ */
+
+#include <QCoreApplication>
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
+
+    return a.exec();
+}

--- a/testframes/test_utils_circularbuffer/test_utils_circularbuffer.pro
+++ b/testframes/test_utils_circularbuffer/test_utils_circularbuffer.pro
@@ -1,0 +1,109 @@
+#==============================================================================================================
+#
+# @file     test_coregistration.pro
+# @author   Gabriel Motta <gbmotta@mgh.harvard.edu>
+# @since    0.1.9
+# @date     January, 2022
+#
+# @section  LICENSE
+#
+# Copyright (C) 2022, Gabriel Motta. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+# the following conditions are met:
+#     * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+#       following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+#       the following disclaimer in the documentation and/or other materials provided with the distribution.
+#     * Neither the name of MNE-CPP authors nor the names of its contributors may be used
+#       to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# @brief    This project file generates the makefile to build the test_utils_circularbuffer test.
+#
+#==============================================================================================================
+
+include(../../mne-cpp.pri)
+
+TEMPLATE = app
+
+VERSION = $${MNE_CPP_VERSION}
+
+QT += testlib network
+QT -= gui
+
+CONFIG   += console
+!contains(MNECPP_CONFIG, withAppBundles) {
+    CONFIG -= app_bundle
+}
+
+DESTDIR =  $${MNE_BINARY_DIR}
+
+TARGET = test_utils_circularbuffer
+CONFIG(debug, debug|release) {
+    TARGET = $$join(TARGET,,,d)
+}
+
+contains(MNECPP_CONFIG, static) {
+    CONFIG += static
+    DEFINES += STATICBUILD
+}
+
+LIBS += -L$${MNE_LIBRARY_DIR}
+CONFIG(debug, debug|release) {
+    LIBS += -lmnecppUtilsd \
+} else {
+    LIBS += -lmnecppUtils \
+}
+
+SOURCES += \
+    test_utils_circularbuffer.cpp
+
+clang {
+    QMAKE_CXXFLAGS += -isystem $${EIGEN_INCLUDE_DIR}
+} else {
+    INCLUDEPATH += $${EIGEN_INCLUDE_DIR}
+}
+INCLUDEPATH += $${MNE_INCLUDE_DIR}
+
+contains(MNECPP_CONFIG, withCodeCov) {
+    QMAKE_CXXFLAGS += --coverage
+    QMAKE_LFLAGS += --coverage
+}
+
+unix:!macx {
+    QMAKE_RPATHDIR += $ORIGIN/../lib
+}
+
+macx {
+    QMAKE_LFLAGS += -Wl,-rpath,@executable_path/../lib
+}
+
+# Activate FFTW backend in Eigen for non-static builds only
+contains(MNECPP_CONFIG, useFFTW):!contains(MNECPP_CONFIG, static) {
+    DEFINES += EIGEN_FFTW_DEFAULT
+    INCLUDEPATH += $$shell_path($${FFTW_DIR_INCLUDE})
+    LIBS += -L$$shell_path($${FFTW_DIR_LIBS})
+
+    win32 {
+        # On Windows
+        LIBS += -llibfftw3-3 \
+                -llibfftw3f-3 \
+                -llibfftw3l-3 \
+    }
+
+    unix:!macx {
+        # On Linux
+        LIBS += -lfftw3 \
+                -lfftw3_threads \
+    }
+}

--- a/testframes/testframes.pro
+++ b/testframes/testframes.pro
@@ -58,6 +58,7 @@ SUBDIRS += \
     test_fiff_digitizer \
     test_mne_msh_display_surface_set \
     test_mne_project_to_surface \
+    test_utils_circularbuffer
 
     qtHaveModule(charts) {
         SUBDIRS += \


### PR DESCRIPTION
This goes over a majority of the utils library and adds a std lib api (and a std lib backend) to most classes and static functions.

- Overloaded functions with Qt-type parameters and return values with std lib versions.
- Changes internal logic where applicable to use std lib containers/classes
- When faced with functions with no input parameters and a qt return type, overloaded added and commented out.

Also:

- ~~min c++ version set to c++ 17 for use of filesystem library. Is this ok? this is a 5 year old standard at this point.~~
(reverted, was causing issues with ubuntu 18 and osx 10.15 and lower std lib version. No longer using filesystem lib. )

- Because adding more code results in a lower code coverage percentage even though the functions I overloaded were not being tested anyway (I think), I also wrote a test for circular buffer to bump up code coverage.

What is missing:
- Going over threading use of QtConcurrent::mapReduced in spectrogram.h/cpp. Somewhat relates to the now-dormant time frequency PR #785 
- QSemaphore use in circular buffer. Std lib of semaphore is c++20, and that is perhaps too recent a cut off point. We could implement our own semaphore with the same api as the c++20 version to make later replacement easy.