### PR TITLE
[ENH] MNE Scan: change plugin gui items

### DIFF
--- a/applications/mne_scan/mne_scan/pluginitem.cpp
+++ b/applications/mne_scan/mne_scan/pluginitem.cpp
@@ -104,6 +104,13 @@ PluginItem::~PluginItem()
 
 void PluginItem::paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget)
 {
+    auto textSize = painter->fontMetrics().size(Qt::TextSingleLine, m_pPlugin->getName());
+    int iHorizontalSpacing = 4;
+    int iVerticalSpacing = 4;
+
+    resizeAsRectangle(textSize.width() + 2 * iHorizontalSpacing,
+                      textSize.height() + 2* iVerticalSpacing);
+
     QGraphicsPolygonItem::paint(painter, option, widget);
 
     painter->setPen(QPen(m_qColorContour, 1));
@@ -123,9 +130,7 @@ void PluginItem::paint(QPainter * painter, const QStyleOptionGraphicsItem * opti
 //            break;
 //    }
 
-    painter->drawText(-m_iWidth/2+4,-m_iHeight/2+14,m_pPlugin->getName().mid(0,8));
-
-    painter->drawText(-m_iWidth/2+4,-m_iHeight/2+28,m_pPlugin->getName().mid(8,8));
+    painter->drawText(-m_iWidth/2+ iHorizontalSpacing, iVerticalSpacing,m_pPlugin->getName());
 }
 
 //=============================================================================================================
@@ -208,4 +213,23 @@ QVariant PluginItem::itemChange(GraphicsItemChange change, const QVariant &value
 //    }
 
 //    return QGraphicsItem::itemChange(change, value);
+}
+
+//=============================================================================================================
+
+void PluginItem::resizeAsRectangle(int width, int height)
+{
+    if(m_iWidth == width && m_iHeight == height){
+        return;
+    }
+
+    m_iWidth = width;
+    m_iHeight = height;
+
+    m_qPolygon = QPolygonF();
+    m_qPolygon << QPointF(-m_iWidth/2, -m_iHeight/2) << QPointF(m_iWidth/2, -m_iHeight/2)
+               << QPointF(m_iWidth/2, m_iHeight/2) << QPointF(-m_iWidth/2, m_iHeight/2)
+               << QPointF(-m_iWidth/2, -m_iHeight/2);
+
+    this->setPolygon(m_qPolygon);
 }

--- a/applications/mne_scan/mne_scan/pluginitem.h
+++ b/applications/mne_scan/mne_scan/pluginitem.h
@@ -85,6 +85,7 @@ public:
 protected:
     void contextMenuEvent(QGraphicsSceneContextMenuEvent *event);
     QVariant itemChange(GraphicsItemChange change, const QVariant &value);
+    void resizeAsRectangle(int width, int height);
 
 private:
     SCSHAREDLIB::AbstractPlugin::SPtr m_pPlugin;


### PR DESCRIPTION
- Sets the bounding rectangle around the text based on the size of the printed text with the used QPainter object.

#### For reference:


Plugin GUI now             |  Plugin GUI in this PR
:-------------------------:|:-------------------------:
![plugins_old](https://user-images.githubusercontent.com/34070103/150410077-63b9e5eb-f0f5-45e3-b9fa-5d11e7738a38.png)  |  ![plugins](https://user-images.githubusercontent.com/34070103/150409386-2d4c314c-b2a1-4297-84a7-4ca8c6756865.png)

Let me know if more/less spacing would look better. Or if we should look at doing line breaks on whitespace.