### PR TITLE
[Fix]: disable window size change during runtime for now.

### DIFF
--- a/libraries/disp/viewers/formfiles/hpisettingsview.ui
+++ b/libraries/disp/viewers/formfiles/hpisettingsview.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab_loadDigitizers">
       <attribute name="title">
@@ -327,7 +327,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QFrame" name="frame">
+        <widget class="QFrame" name="frame_samplesToFit">
          <property name="minimumSize">
           <size>
            <width>61</width>

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -80,6 +80,12 @@ HpiSettingsView::HpiSettingsView(const QString& sSettingsPath,
     m_sSettingsPath = sSettingsPath;
     m_pUi->setupUi(this);
 
+    // Disable change of window size for now
+    bool bWindowsize = false;
+    m_pUi->frame_samplesToFit->setVisible(bWindowsize);
+    m_pUi->label_3->setVisible(bWindowsize);
+    m_pUi->m_spinBox_samplesToFit->setVisible(bWindowsize);
+
     connect(m_pUi->m_pushButton_loadDigitizers, &QPushButton::released,
             this, &HpiSettingsView::onLoadDigitizers);
     connect(m_pUi->m_pushButton_doFreqOrder, &QPushButton::clicked,


### PR DESCRIPTION
This PR addresses issue #891. So far, I was not able to reproduce the issue using the FiffSimulator. Also investigated the influence of window size on error and gof and could not find any indication for the observed behavior. See comments for results of the mentioned investigation.

This PR closes #891.