### PR TITLE
[ENH] MNE-Scan: show gof as well

### DIFF
--- a/applications/mne_scan/plugins/hpi/hpi.cpp
+++ b/applications/mne_scan/plugins/hpi/hpi.cpp
@@ -326,6 +326,8 @@ void Hpi::initPluginControlWidgets()
                 this, &Hpi::setFittingWindowSize);
         connect(this, &Hpi::errorsChanged,
                 pHpiSettingsView, &HpiSettingsView::setErrorLabels, Qt::BlockingQueuedConnection);
+        connect(this, &Hpi::gofChanged,
+                pHpiSettingsView, &HpiSettingsView::setGoFLabels, Qt::BlockingQueuedConnection);
         connect(this, &Hpi::movementResultsChanged,
                 pHpiSettingsView, &HpiSettingsView::setMovementResults, Qt::BlockingQueuedConnection);
         connect(this, &Hpi::newDigitizerList,
@@ -566,6 +568,7 @@ void Hpi::run()
 
     double dErrorMax = 0.0;
     double dMeanErrorDist = 0.0;
+    double dMeanGoF = 0.0;
     double dAllowedMovement = 0.0;
     double dAllowedRotation = 0.0;
     double dMovement = 0.0;
@@ -638,8 +641,10 @@ void Hpi::run()
                 //Check if the error meets distance requirement
                 if(fitResult.errorDistances.size() > 0) {
                     dMeanErrorDist = std::accumulate(fitResult.errorDistances.begin(), fitResult.errorDistances.end(), .0) / fitResult.errorDistances.size();
+                    dMeanGoF = fitResult.GoF.mean();
 
                     emit errorsChanged(fitResult.errorDistances, dMeanErrorDist);
+                    emit gofChanged(fitResult.GoF, dMeanGoF);
 
                     m_mutex.lock();
                     dErrorMax = m_dAllowedMeanErrorDist;

--- a/applications/mne_scan/plugins/hpi/hpi.h
+++ b/applications/mne_scan/plugins/hpi/hpi.h
@@ -323,6 +323,8 @@ private:
 signals:
     void errorsChanged(const QVector<double>& vErrors,
                        double dMeanErrorDist);
+    void gofChanged(const Eigen::VectorXd& vGoF,
+                    const double dMeanGoF);
     void movementResultsChanged(double dMovement,
                                 double dRotation);
     void devHeadTransAvailable(const FIFFLIB::FiffCoordTrans& devHeadTrans);

--- a/libraries/disp/viewers/formfiles/hpisettingsview.ui
+++ b/libraries/disp/viewers/formfiles/hpisettingsview.ui
@@ -411,7 +411,7 @@
        <item>
         <widget class="QLabel" name="label_11">
          <property name="text">
-          <string>Fitting errors:</string>
+          <string>Fitting Results:</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -454,12 +454,17 @@
            <string>Error in mm</string>
           </property>
          </column>
+         <column>
+          <property name="text">
+           <string>GoF</string>
+          </property>
+         </column>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_2">
+        <widget class="QGroupBox" name="m_groupBox_average_error">
          <property name="title">
-          <string>Mean Average Error</string>
+          <string>Fitting Quality:</string>
          </property>
          <property name="flat">
           <bool>false</bool>
@@ -468,7 +473,7 @@
           <bool>false</bool>
          </property>
          <layout class="QFormLayout" name="formLayout_4">
-          <item row="0" column="0">
+          <item row="1" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
              <string>Average error:</string>
@@ -478,7 +483,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="1" column="1">
            <widget class="QLabel" name="m_label_averagedFitError">
             <property name="text">
              <string>0mm</string>
@@ -488,14 +493,14 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="label">
             <property name="text">
              <string>Error threshold:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QDoubleSpinBox" name="m_doubleSpinBox_maxHPIContinousDist">
             <property name="suffix">
              <string> mm</string>
@@ -508,13 +513,27 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="2">
+          <item row="3" column="0" colspan="2">
            <widget class="QLabel" name="m_label_fitFeedback">
             <property name="text">
              <string>No fit yet</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_average_gof">
+            <property name="text">
+             <string>Average GoF:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="m_average_gof_set">
+            <property name="text">
+             <string>0.00</string>
             </property>
            </widget>
           </item>

--- a/libraries/disp/viewers/formfiles/hpisettingsview.ui
+++ b/libraries/disp/viewers/formfiles/hpisettingsview.ui
@@ -419,7 +419,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QTableWidget" name="m_tableWidget_errors">
+        <widget class="QTableWidget" name="m_tableWidget_results">
          <property name="minimumSize">
           <size>
            <width>0</width>
@@ -690,7 +690,7 @@
   <tabstop>m_checkBox_useSSP</tabstop>
   <tabstop>m_checkBox_useComp</tabstop>
   <tabstop>m_pushButton_doSingleFit</tabstop>
-  <tabstop>m_tableWidget_errors</tabstop>
+  <tabstop>m_tableWidget_results</tabstop>
   <tabstop>m_doubleSpinBox_maxHPIContinousDist</tabstop>
   <tabstop>m_doubleSpinBox_moveThreshold</tabstop>
   <tabstop>m_doubleSpinBox_rotThreshold</tabstop>

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -128,7 +128,7 @@ HpiSettingsView::~HpiSettingsView()
 //=============================================================================================================
 
 void HpiSettingsView::setErrorLabels(const QVector<double>& vError,
-                                     double dMeanErrorDist)
+                                     const double dMeanErrorDist)
 {
     //Update eror labels and change from m to mm
     QString sGof("0mm");
@@ -150,6 +150,25 @@ void HpiSettingsView::setErrorLabels(const QVector<double>& vError,
         m_pUi->m_label_fitFeedback->setText("Last fit: Good");
         m_pUi->m_label_fitFeedback->setStyleSheet("QLabel { background-color : green;}");
     }
+}
+
+//=============================================================================================================
+
+void HpiSettingsView::setGoFLabels(const Eigen::VectorXd & vGoF,
+                                   const double dMeanGof)
+{
+    //Update eror labels and change from m to mm
+    QString sGof("00.00");
+
+    for(int i = 0; i < vGoF.size(); ++i) {
+        if(i < m_pUi->m_tableWidget_errors->rowCount()) {
+            sGof = QString::number(vGoF[i]*100,'f',2)+QString(" %");
+            m_pUi->m_tableWidget_errors->item(i, 2)->setText(sGof);
+        }
+    }
+
+    m_pUi->m_average_gof_set->setText(QString::number(dMeanGof*100,'f',2)+QString(" %"));
+
 }
 
 //=========================================================================================================
@@ -377,7 +396,7 @@ void HpiSettingsView::onAddCoil()
         m_vCoilFreqs.append(-1);
     }
 
-    // Add column 0 in error table widget
+    // Add column 0 in error table widget (coil number)
     m_pUi->m_tableWidget_errors->insertRow(m_pUi->m_tableWidget_errors->rowCount());
     QTableWidgetItem* pTableItemB = new QTableWidgetItem(QString::number(m_pUi->m_tableWidget_Frequencies->rowCount()));
     pTableItemB->setFlags(Qt::ItemIsEnabled);
@@ -385,12 +404,19 @@ void HpiSettingsView::onAddCoil()
                                         0,
                                         pTableItemB);
 
-    // Add column 1 in error table widget
+    // Add column 1 in error table widget (error)
     QTableWidgetItem* pTableItemC = new QTableWidgetItem("0mm");
     pTableItemC->setFlags(Qt::ItemIsEnabled);
     m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
                                         1,
                                         pTableItemC);
+
+    // Add column 2 in error table widget (gof)
+    QTableWidgetItem* pTableItemD = new QTableWidgetItem("00.00");
+    pTableItemD->setFlags(Qt::ItemIsEnabled);
+    m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
+                                         2,
+                                         pTableItemD);
 
     emit coilFrequenciesChanged(m_vCoilFreqs);
 }
@@ -532,6 +558,13 @@ void HpiSettingsView::addCoilErrorToGUI()
     m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
                                         1,
                                         pTableItemC);
+
+    // Add column 2 in error table widget
+    QTableWidgetItem* pTableItemD = new QTableWidgetItem("00.00%");
+    pTableItemD->setFlags(Qt::ItemIsEnabled);
+    m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
+                                         2,
+                                         pTableItemD);
 }
 
 //=============================================================================================================
@@ -547,6 +580,8 @@ void HpiSettingsView::clearCoilGUI()
     m_pUi->m_tableWidget_errors->setRowCount(0);
     m_pUi->m_tableWidget_errors->setHorizontalHeaderItem(0, new QTableWidgetItem("#Coil"));
     m_pUi->m_tableWidget_errors->setHorizontalHeaderItem(1, new QTableWidgetItem("Error"));
+    m_pUi->m_tableWidget_errors->setHorizontalHeaderItem(2, new QTableWidgetItem("GoF"));
+
 }
 
 //=============================================================================================================

--- a/libraries/disp/viewers/hpisettingsview.cpp
+++ b/libraries/disp/viewers/hpisettingsview.cpp
@@ -134,9 +134,9 @@ void HpiSettingsView::setErrorLabels(const QVector<double>& vError,
     QString sGof("0mm");
 
     for(int i = 0; i < vError.size(); ++i) {
-        if(i < m_pUi->m_tableWidget_errors->rowCount()) {
+        if(i < m_pUi->m_tableWidget_results->rowCount()) {
             sGof = QString::number(vError[i]*1000,'f',2)+QString(" mm");
-            m_pUi->m_tableWidget_errors->item(i, 1)->setText(sGof);
+            m_pUi->m_tableWidget_results->item(i, 1)->setText(sGof);
         }
     }
 
@@ -157,13 +157,13 @@ void HpiSettingsView::setErrorLabels(const QVector<double>& vError,
 void HpiSettingsView::setGoFLabels(const Eigen::VectorXd & vGoF,
                                    const double dMeanGof)
 {
-    //Update eror labels and change from m to mm
+    //Update gof labels and change to %
     QString sGof("00.00");
 
     for(int i = 0; i < vGoF.size(); ++i) {
-        if(i < m_pUi->m_tableWidget_errors->rowCount()) {
+        if(i < m_pUi->m_tableWidget_results->rowCount()) {
             sGof = QString::number(vGoF[i]*100,'f',2)+QString(" %");
-            m_pUi->m_tableWidget_errors->item(i, 2)->setText(sGof);
+            m_pUi->m_tableWidget_results->item(i, 2)->setText(sGof);
         }
     }
 
@@ -397,24 +397,24 @@ void HpiSettingsView::onAddCoil()
     }
 
     // Add column 0 in error table widget (coil number)
-    m_pUi->m_tableWidget_errors->insertRow(m_pUi->m_tableWidget_errors->rowCount());
+    m_pUi->m_tableWidget_results->insertRow(m_pUi->m_tableWidget_results->rowCount());
     QTableWidgetItem* pTableItemB = new QTableWidgetItem(QString::number(m_pUi->m_tableWidget_Frequencies->rowCount()));
     pTableItemB->setFlags(Qt::ItemIsEnabled);
-    m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
+    m_pUi->m_tableWidget_results->setItem(m_pUi->m_tableWidget_results->rowCount()-1,
                                         0,
                                         pTableItemB);
 
     // Add column 1 in error table widget (error)
     QTableWidgetItem* pTableItemC = new QTableWidgetItem("0mm");
     pTableItemC->setFlags(Qt::ItemIsEnabled);
-    m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
+    m_pUi->m_tableWidget_results->setItem(m_pUi->m_tableWidget_results->rowCount()-1,
                                         1,
                                         pTableItemC);
 
     // Add column 2 in error table widget (gof)
     QTableWidgetItem* pTableItemD = new QTableWidgetItem("00.00");
     pTableItemD->setFlags(Qt::ItemIsEnabled);
-    m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
+    m_pUi->m_tableWidget_results->setItem(m_pUi->m_tableWidget_results->rowCount()-1,
                                          2,
                                          pTableItemD);
 
@@ -435,10 +435,10 @@ void HpiSettingsView::onRemoveCoil()
             m_pUi->m_tableWidget_Frequencies->item(i, 0)->setText(QString::number(i+1));
         }
 
-        m_pUi->m_tableWidget_errors->removeRow(row);
+        m_pUi->m_tableWidget_results->removeRow(row);
 
-        for (int i = 0; i < m_pUi->m_tableWidget_errors->rowCount(); ++i) {
-            m_pUi->m_tableWidget_errors->item(i, 0)->setText(QString::number(i+1));
+        for (int i = 0; i < m_pUi->m_tableWidget_results->rowCount(); ++i) {
+            m_pUi->m_tableWidget_results->item(i, 0)->setText(QString::number(i+1));
         }
 
         emit coilFrequenciesChanged(m_vCoilFreqs);
@@ -545,24 +545,24 @@ void HpiSettingsView::addCoilFreqToGUI(int iCoilFreq)
 void HpiSettingsView::addCoilErrorToGUI()
 {
     // Add column 0 in error table widget
-    m_pUi->m_tableWidget_errors->insertRow(m_pUi->m_tableWidget_errors->rowCount());
+    m_pUi->m_tableWidget_results->insertRow(m_pUi->m_tableWidget_results->rowCount());
     QTableWidgetItem* pTableItemB = new QTableWidgetItem(QString::number(m_pUi->m_tableWidget_Frequencies->rowCount()));
     pTableItemB->setFlags(Qt::ItemIsEnabled);
-    m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
+    m_pUi->m_tableWidget_results->setItem(m_pUi->m_tableWidget_results->rowCount()-1,
                                         0,
                                         pTableItemB);
 
     // Add column 1 in error table widget
     QTableWidgetItem* pTableItemC = new QTableWidgetItem("0mm");
     pTableItemC->setFlags(Qt::ItemIsEnabled);
-    m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
+    m_pUi->m_tableWidget_results->setItem(m_pUi->m_tableWidget_results->rowCount()-1,
                                         1,
                                         pTableItemC);
 
     // Add column 2 in error table widget
     QTableWidgetItem* pTableItemD = new QTableWidgetItem("00.00%");
     pTableItemD->setFlags(Qt::ItemIsEnabled);
-    m_pUi->m_tableWidget_errors->setItem(m_pUi->m_tableWidget_errors->rowCount()-1,
+    m_pUi->m_tableWidget_results->setItem(m_pUi->m_tableWidget_results->rowCount()-1,
                                          2,
                                          pTableItemD);
 }
@@ -576,11 +576,11 @@ void HpiSettingsView::clearCoilGUI()
     m_pUi->m_tableWidget_Frequencies->setHorizontalHeaderItem(0, new QTableWidgetItem("#Coil"));
     m_pUi->m_tableWidget_Frequencies->setHorizontalHeaderItem(1, new QTableWidgetItem("Frequency (Hz)"));
 
-    m_pUi->m_tableWidget_errors->clear();
-    m_pUi->m_tableWidget_errors->setRowCount(0);
-    m_pUi->m_tableWidget_errors->setHorizontalHeaderItem(0, new QTableWidgetItem("#Coil"));
-    m_pUi->m_tableWidget_errors->setHorizontalHeaderItem(1, new QTableWidgetItem("Error"));
-    m_pUi->m_tableWidget_errors->setHorizontalHeaderItem(2, new QTableWidgetItem("GoF"));
+    m_pUi->m_tableWidget_results->clear();
+    m_pUi->m_tableWidget_results->setRowCount(0);
+    m_pUi->m_tableWidget_results->setHorizontalHeaderItem(0, new QTableWidgetItem("#Coil"));
+    m_pUi->m_tableWidget_results->setHorizontalHeaderItem(1, new QTableWidgetItem("Error"));
+    m_pUi->m_tableWidget_results->setHorizontalHeaderItem(2, new QTableWidgetItem("GoF"));
 
 }
 

--- a/libraries/disp/viewers/hpisettingsview.h
+++ b/libraries/disp/viewers/hpisettingsview.h
@@ -53,6 +53,8 @@
 // EIGEN INCLUDES
 //=============================================================================================================
 
+#include <Eigen/Core>
+
 //=============================================================================================================
 // FORWARD DECLARATIONS
 //=============================================================================================================
@@ -105,7 +107,18 @@ public:
      * @param[in] dMeanErrorDist    the mean error value.
      */
     void setErrorLabels(const QVector<double>& vError,
-                        double dMeanErrorDist);
+                        const double dMeanErrorDist);
+
+    //=========================================================================================================
+    /**
+     * Updates the gof related labels.
+     *
+     * @param[in] vGoF            the new gof values.
+     * @param[in] dMeanGof    the mean gof value.
+     */
+
+    void setGoFLabels(const Eigen::VectorXd & vGoF,
+                      const double dMeanGof);
 
     //=========================================================================================================
     /**


### PR DESCRIPTION
<img width="322" src=https://user-images.githubusercontent.com/40984141/168338733-2916c8bc-fcae-4f71-b903-e045f7adaa06.png>

For a better understanding of whether fitting goes well and if the issue might be a particular coil, I added the Goodness of Fit (GoF ) next to the error in the `Quick Control` widget. 

In general, the error gives information about the transformation and the gof about the fit itself. So both should be presented next to each other