### PR TITLE
[MAINT] Add GH Actions workflows for Qt6 

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -197,7 +197,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        qt: [6.2.4]
+        qt: [6.2.0]
         os: [ubuntu-latest, macos-latest, windows-2019]
 
     steps:
@@ -458,13 +458,13 @@ jobs:
       if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
       uses: jurplel/install-qt-action@v3
       with:
-        version: 6.2.4
+        version: 6.2.0
         modules: qtcharts
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
       uses: jurplel/install-qt-action@v3
       with:
-        version: 6.2.4
+        version: 6.2.0
         arch: win64_msvc2019_64
         modules: qtcharts
     - name: Install jom (Windows)

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,7 +6,7 @@ on:
     - main
 
 jobs:
-  MinQtDynamic:
+  MinQt5Dynamic:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -98,7 +98,7 @@ jobs:
       run: |
         ./tools/deployment/deploy.bat dynamic pack
 
-  MaxQtDynamic:
+  MaxQt5Dynamic:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -190,6 +190,98 @@ jobs:
       run: |
         ./tools/deployment/deploy.bat dynamic pack
 
+  MaxQt6Dynamic:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        qt: [6.2.4]
+        os: [ubuntu-latest, macos-latest, windows-2019]
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install BrainFlow and LSL submodules
+      run: |
+        git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
+        git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
+    - name: Install Qt (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: ${{ matrix.qt }}
+        modules: qtcharts
+    - name: Install Qt (Windows)
+      if: matrix.os == 'windows-2019'
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: ${{ matrix.qt }}
+        arch: win64_msvc2019_64
+        modules: qtcharts
+    - name: Install jom (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        Invoke-WebRequest https://www.dropbox.com/s/gbf8sdx8wqxcrnd/jom.zip?dl=1 -OutFile .\jom.zip
+        expand-archive -path "jom.zip"
+        echo "D:\a\mne-cpp\mne-cpp\jom" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Compile BrainFlow submodule (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        cd applications\mne_scan\plugins\brainflowboard\brainflow
+        mkdir build
+        cd build
+        cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
+        cmake --build . --target install --config Release
+    - name: Compile BrainFlow submodule (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
+      run: |
+        cd applications/mne_scan/plugins/brainflowboard/brainflow
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=../installed -DCMAKE_BUILD_TYPE=Release ..
+        make
+        make install
+    - name: Compile LSL submodule (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        cd applications\mne_scan\plugins\lsladapter\liblsl
+        mkdir build
+        cd build
+        cmake .. -G "Visual Studio 16 2019" -A x64
+        cmake --build . --config Release --target install
+    - name: Compile LSL submodule (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
+      run: |
+        cd applications/mne_scan/plugins/lsladapter/liblsl
+        mkdir build
+        cd build
+        cmake ..
+        make
+        make install
+    - name: Configure and compile MNE-CPP (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
+      run: |
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl MNECPP_CONFIG+=withAppBundles
+        make -j4
+    - name: Configure and compile MNE-CPP (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        # Setup VS compiler
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+        qmake -r MNECPP_CONFIG+=noTests MNECPP_CONFIG+=withBrainFlow MNECPP_CONFIG+=withLsl
+        jom -j4
+    - name: Deploy binaries
+      run: |
+        ./tools/deployment/deploy.bat dynamic pack
+
   QtStatic:
     runs-on: ${{ matrix.os }}
 
@@ -255,7 +347,7 @@ jobs:
       run: |
         ./tools/deployment/deploy.bat static pack
 
-  Tests:
+  TestsQt5:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -319,6 +411,88 @@ jobs:
         jom -j4
     - name: Run tests (Linux)
       if: matrix.os == 'ubuntu-18.04'
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        QTEST_FUNCTION_TIMEOUT: 900000
+      run: |
+        ./tools/testing/test_all.bat verbose withCoverage
+    - name: Run tests (MacOS)
+      if: matrix.os == 'macos-latest'
+      env:
+        QTEST_FUNCTION_TIMEOUT: 900000
+      run: |
+        ./tools/testing/test_all.bat verbose
+    - name: Run tests (Windows)
+      if: matrix.os == 'windows-2019'
+      env:
+        QTEST_FUNCTION_TIMEOUT: 900000
+      run: |
+        ./tools/testing/test_all.bat verbose
+
+  TestsQt6:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-2019]
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+    - name: Clone mne-cpp test data
+      run: git clone https://github.com/mne-tools/mne-cpp-test-data.git ./bin/mne-cpp-test-data
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install Codecov
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        echo "${pwd}" >> $GITHUB_PATH
+    - name: Install Qt (Linux|MacOS)
+      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: 6.2.4
+        modules: qtcharts
+    - name: Install Qt (Windows)
+      if: matrix.os == 'windows-2019'
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: 6.2.4
+        arch: win64_msvc2019_64
+        modules: qtcharts
+    - name: Install jom (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        Invoke-WebRequest https://www.dropbox.com/s/gbf8sdx8wqxcrnd/jom.zip?dl=1 -OutFile .\jom.zip
+        expand-archive -path "jom.zip"
+        echo "D:\a\mne-cpp\mne-cpp\jom" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Configure and compile MNE-CPP (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        qmake -r MNECPP_CONFIG+=withCodeCov MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
+        make -j4
+    - name: Configure and compile MNE-CPP (MacOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
+        make -j4
+    - name: Configure and compile MNE-CPP (Windows)
+      if: matrix.os == 'windows-2019'
+      run: |
+        # Setup VS compiler
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+        Get-Content "$env:temp\vcvars.txt" | Foreach-Object { if ($_ -match "^(.*?)=(.*)$") { Set-Content "env:\$($matches[1])" $matches[2] } }
+        qmake -r MNECPP_CONFIG+=noApplications MNECPP_CONFIG+=noExamples
+        jom -j4
+    - name: Run tests (Linux)
+      if: matrix.os == 'ubuntu-latest'
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         QTEST_FUNCTION_TIMEOUT: 900000

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -30,13 +30,13 @@ jobs:
         git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
     - name: Install Qt (Linux|MacOS)
       if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: ${{ matrix.qt }}
         modules: qtcharts
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2016'
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: ${{ matrix.qt }}
         arch: win64_msvc2017_64
@@ -122,13 +122,13 @@ jobs:
         git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
     - name: Install Qt (Linux|MacOS)
       if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: ${{ matrix.qt }}
         modules: qtcharts
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: ${{ matrix.qt }}
         arch: win64_msvc2019_64
@@ -214,13 +214,13 @@ jobs:
         git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
     - name: Install Qt (Linux|MacOS)
       if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: ${{ matrix.qt }}
         modules: qtcharts
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: ${{ matrix.qt }}
         arch: win64_msvc2019_64
@@ -374,13 +374,13 @@ jobs:
         echo "${pwd}" >> $GITHUB_PATH
     - name: Install Qt (Linux|MacOS)
       if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: 5.15.2
         modules: qtcharts
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: 5.15.2
         arch: win64_msvc2019_64
@@ -456,13 +456,13 @@ jobs:
         echo "${pwd}" >> $GITHUB_PATH
     - name: Install Qt (Linux|MacOS)
       if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: 6.2.4
         modules: qtcharts
     - name: Install Qt (Windows)
       if: matrix.os == 'windows-2019'
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         version: 6.2.4
         arch: win64_msvc2019_64

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,7 +6,7 @@ on:
     - main
 
 jobs:
-  MinQt5Dynamic:
+  MinQtDynamic:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -98,7 +98,7 @@ jobs:
       run: |
         ./tools/deployment/deploy.bat dynamic pack
 
-  MaxQt5Dynamic:
+  MaxQtDynamic:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -347,7 +347,7 @@ jobs:
       run: |
         ./tools/deployment/deploy.bat static pack
 
-  TestsQt5:
+  Tests:
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
Add workflows for building and testing in Qt6. For an upcoming PR to add Qt6 support.


The qt 6 workflows will not succeed yet. I'm just looking to see if they will successfully install Qt and QtCharts. They are not yet set to be a requirement to merge changes. 

Once the Qt6 merge does happen, it might be the case that some features will not be buildable on the old Qt5.10 min version. If so, a discussion on new min versions might be in order.