### PR TITLE
[MAINT] Add rule for ignoring qt-creator generated build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,6 @@ mne-cpp.pro.user*
 /_site
 
 build/*
-
+build-*/
 .cache/*
+


### PR DESCRIPTION
Add entry to .gitignore so that QtCreator created build folders are ignored by git.