### PR TITLE
[MAINT] Update Github Actions Runners

### DIFF
--- a/.github/workflows/buildqtbinaries.yml
+++ b/.github/workflows/buildqtbinaries.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   GenerateLinuxStaticBinaries:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     
     steps:
     - name: Clone repository

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ScanLinux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -193,7 +193,7 @@ jobs:
       if: matrix.os == 'ubuntu-20.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/o0aw8p8kqqnmwcp/qt5_5152_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/tje7jp6tsn2dxdd/qt5_5152_static_binaries_linux.tar.gz?dl=0 
         mkdir ../Qt5_binaries
         tar xvzf qt5_5152_static_binaries_linux.tar.gz -C ../ -P
     - name: Install Qt (MacOS)

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 3
       matrix:
         qt: [5.10.1]
-        os: [ubuntu-18.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
 
     steps:
     - name: Clone repository
@@ -29,7 +29,7 @@ jobs:
         git submodule update --init src/applications/mne_scan/plugins/brainflowboard/brainflow
         git submodule update --init src/applications/mne_scan/plugins/lsladapter/liblsl
     - name: Install Qt (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-11')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-11')
       uses: jurplel/install-qt-action@v2
       with:
         version: ${{ matrix.qt }}
@@ -56,7 +56,7 @@ jobs:
         cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile BrainFlow submodule (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-11')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-11')
       run: |
         cd src/applications/mne_scan/plugins/brainflowboard/brainflow
         mkdir build
@@ -72,7 +72,7 @@ jobs:
         cmake .. -G "Visual Studio 16 2019" -A x64
         cmake --build . --config Release --target install
     - name: Compile LSL submodule (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-11')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-11')
       run: |
         cd src/applications/mne_scan/plugins/lsladapter/liblsl
         mkdir build
@@ -94,7 +94,7 @@ jobs:
       max-parallel: 3
       matrix:
         qt: [5.15.2]
-        os: [ubuntu-18.04, macos-11, windows-2019]
+        os: [ubuntu-latest, macos-11, windows-2019]
 
     steps:
     - name: Clone repository
@@ -109,7 +109,7 @@ jobs:
         git submodule update --init src/applications/mne_scan/plugins/brainflowboard/brainflow
         git submodule update --init src/applications/mne_scan/plugins/lsladapter/liblsl
     - name: Install Qt (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-11')
+      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-11')
       uses: jurplel/install-qt-action@v2
       with:
         version: ${{ matrix.qt }}
@@ -136,7 +136,7 @@ jobs:
         cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile BrainFlow submodule (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-11')
+      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-11')
       run: |
         cd src/applications/mne_scan/plugins/brainflowboard/brainflow
         mkdir build
@@ -152,7 +152,7 @@ jobs:
         cmake .. -G "Visual Studio 16 2019" -A x64
         cmake --build . --config Release --target install
     - name: Compile LSL submodule (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-11')
+      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-11')
       run: |
         cd src/applications/mne_scan/plugins/lsladapter/liblsl
         mkdir build
@@ -173,7 +173,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-18.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
 
     steps:
     - name: Clone repository
@@ -184,13 +184,13 @@ jobs:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install OpenGL (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo add-apt-repository "deb http://security.ubuntu.com/ubuntu xenial-security main"
         sudo apt-get update -q
         sudo apt-get install build-essential libgl1-mesa-dev libicu55
     - name: Install Qt (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
         wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/o0aw8p8kqqnmwcp/qt5_5152_static_binaries_linux.tar.gz?dl=1
@@ -215,7 +215,7 @@ jobs:
         expand-archive -path "jom.zip"
         echo "D:\a\mne-cpp\mne-cpp\jom" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Configure and compile MNE-CPP (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-11')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-11')
       run: |
         export QT_DIR="$(pwd)/../Qt5_binaries/lib/cmake/Qt5"
         export Qt5_DIR="$(pwd)/../Qt5_binaries/lib/cmake/Qt5"
@@ -241,7 +241,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-18.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
 
     steps:
     - name: Clone repository
@@ -254,13 +254,13 @@ jobs:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install Codecov
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         curl -Os https://uploader.codecov.io/latest/linux/codecov
         chmod +x codecov
         echo "${pwd}" >> $GITHUB_PATH
     - name: Install Qt (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-11')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-11')
       uses: jurplel/install-qt-action@v2
       with:
         version: 5.15.2
@@ -283,12 +283,12 @@ jobs:
       run: |
         ./tools/building/build_project.bat  
     - name: Configure and compile MNE-CPP
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         cmake -DCMAKE_BUILD_TYPE="Release" -DWITH_CODE_COV=ON -B build -S src 
         cmake --build build --parallel $(expr $(nproc --all) / 2)
     - name: Run tests (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         QTEST_FUNCTION_TIMEOUT: 900000
@@ -308,7 +308,7 @@ jobs:
         ./tools/testing/test_all.bat verbose
 
   Doxygen:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Clone repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Install Qt
       run: |
         # Download the pre-built static version of Qt, which was created with the buildqtbinaries.yml workflow
-        wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/o0aw8p8kqqnmwcp/qt5_5152_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/tje7jp6tsn2dxdd/qt5_5152_static_binaries_linux.tar.gz?dl=0
         mkdir ../Qt5_binaries
         tar xvzf qt5_5152_static_binaries_linux.tar.gz -C ../ -P
     # Uncomment this if you want to build Qt statically in this workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   CreateRelease:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Clone repository
@@ -55,7 +55,7 @@ jobs:
         hub release create -m "Development Builds" dev_build --prerelease
 
   LinuxStatic:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: CreateRelease
 
     steps:
@@ -243,7 +243,7 @@ jobs:
         overwrite: true
 
   LinuxDynamic:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Clone repository
@@ -430,7 +430,7 @@ jobs:
   Tests:
     # Only run for dev releases
     if: endsWith(github.ref, 'main') == true
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: CreateRelease
 
     steps:
@@ -462,7 +462,7 @@ jobs:
         ./tools/testing/test_all.bat verbose withCoverage
 
   Doxygen:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: CreateRelease
 
     steps:

--- a/.github/workflows/testci.yml
+++ b/.github/workflows/testci.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 3
       matrix:
         qt: [5.10.1]
-        os: [ubuntu-18.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -29,7 +29,7 @@ jobs:
         git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
         git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
     - name: Install Qt (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       uses: jurplel/install-qt-action@v2
       with:
         version: ${{ matrix.qt }}
@@ -56,7 +56,7 @@ jobs:
         cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile BrainFlow submodule (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       run: |
         cd applications/mne_scan/plugins/brainflowboard/brainflow
         mkdir build
@@ -73,7 +73,7 @@ jobs:
         cmake .. -G "Visual Studio 16 2019" -A x64
         cmake --build . --config Release --target install
     - name: Compile LSL submodule (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       run: |
         cd applications/mne_scan/plugins/lsladapter/liblsl
         mkdir build
@@ -82,7 +82,7 @@ jobs:
         make
         cmake --build build
     - name: Configure and compile MNE-CPP (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       run: |
         cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
         cmake --build build
@@ -106,7 +106,7 @@ jobs:
       max-parallel: 3
       matrix:
         qt: [5.15.2]
-        os: [ubuntu-18.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -121,7 +121,7 @@ jobs:
         git submodule update --init applications/mne_scan/plugins/brainflowboard/brainflow
         git submodule update --init applications/mne_scan/plugins/lsladapter/liblsl
     - name: Install Qt (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       uses: jurplel/install-qt-action@v2
       with:
         version: ${{ matrix.qt }}
@@ -148,7 +148,7 @@ jobs:
         cmake -G "Visual Studio 16 2019" -A x64 -DMSVC_RUNTIME=dynamic -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE\applications\mne_scan\plugins\brainflowboard\brainflow\installed" ..
         cmake --build . --target install --config Release
     - name: Compile BrainFlow submodule (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       run: |
         cd applications/mne_scan/plugins/brainflowboard/brainflow
         mkdir build
@@ -165,7 +165,7 @@ jobs:
         cmake .. -G "Visual Studio 16 2019" -A x64
         cmake --build . --config Release --target install
     - name: Compile LSL submodule (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       run: |
         cd applications/mne_scan/plugins/lsladapter/liblsl
         mkdir build
@@ -174,7 +174,7 @@ jobs:
         make
         cmake --build build
     - name: Configure and compile MNE-CPP (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       run: |
         cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
         cmake --build build
@@ -197,7 +197,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -208,12 +208,12 @@ jobs:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install OpenGL (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo apt-get update -q
         sudo apt-get install build-essential libgl1-mesa-dev
     - name: Install Qt (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
         wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/ilwo7mu9muk48mf/qt5_5152_static_binaries_linux.tar.gz?dl=1
@@ -238,7 +238,7 @@ jobs:
         expand-archive -path "jom.zip"
         echo "D:\a\mne-cpp\mne-cpp\jom" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Configure and compile MNE-CPP (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       run: |
         ../Qt5_binaries/bin/cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
         cmake --build build
@@ -261,7 +261,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
     - name: Clone repository
@@ -274,11 +274,11 @@ jobs:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install Codecov
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo pip install codecov
     - name: Install Qt (Linux|MacOS)
-      if: (matrix.os == 'ubuntu-18.04') || (matrix.os == 'macos-latest')
+      if: (matrix.os == 'ubuntu-20.04') || (matrix.os == 'macos-latest')
       uses: jurplel/install-qt-action@v2
       with:
         version: 5.15.0
@@ -297,7 +297,7 @@ jobs:
         expand-archive -path "jom.zip"
         echo "D:\a\mne-cpp\mne-cpp\jom" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Configure and compile MNE-CPP (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
         cmake --build build
@@ -315,7 +315,7 @@ jobs:
         cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
         cmake --build build
     - name: Run tests (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         QTEST_FUNCTION_TIMEOUT: 900000
@@ -334,7 +334,7 @@ jobs:
       run: |
         ./tools/testing/test_all.bat verbose
   Doxygen:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Clone repository

--- a/.github/workflows/testci.yml
+++ b/.github/workflows/testci.yml
@@ -216,7 +216,7 @@ jobs:
       if: matrix.os == 'ubuntu-20.04'
       run: |
         # Download the pre-built static version of Qt, which was created with the generateBinaries.yml workflow
-        wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/ilwo7mu9muk48mf/qt5_5152_static_binaries_linux.tar.gz?dl=1
+        wget -O qt5_5152_static_binaries_linux.tar.gz https://www.dropbox.com/s/tje7jp6tsn2dxdd/qt5_5152_static_binaries_linux.tar.gz?dl=0
         mkdir ../Qt5_binaries
         tar xvzf qt5_5152_static_binaries_linux.tar.gz -C ../ -P
     - name: Install Qt (MacOS)


### PR DESCRIPTION
Ubunutu 18.04 is currently [deprecated and will soon be axed completely](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

This PR changes actions to use `ubuntu-20.04` wherever a "minimum" version is appropriate, or `ubuntu-latest` elsewhere.