### PR TITLE
[FIX] build script return val

### DIFF
--- a/tools/building/build_project.bat
+++ b/tools/building/build_project.bat
@@ -340,7 +340,7 @@ for (( j=0; j<argc; j++)); do
   elif [ "${argv[j]}" == "help" ]; then
     PrintHelp="true"
   elif [ "${argv[j]}" == "static" ]; then
-    CMakeConfigFlags="${CMakeConfigFlags} --DBUILD_SHARED_LIBS=OFF"
+    CMakeConfigFlags="${CMakeConfigFlags} -DBUILD_SHARED_LIBS=OFF"
   fi
   case ${argv[j]} in
     *"Debug"*)

--- a/tools/building/build_project.bat
+++ b/tools/building/build_project.bat
@@ -8,12 +8,15 @@
     SET ScriptPath=%~dp0
     SET BaseFolder=%ScriptPath%..\..
 
-    SET SourceFolder=
-    SET BuildFolder=
-    SET OutFolder=
+    SET "EXIT_FAIL=1"
+    SET "EXIT_SUCCESS=0"
+
+    SET "SourceFolder="
+    SET "BuildFolder="
+    SET "OutFolder="
 
     SET "MockBuild=False"
-    SET MockText=
+    SET "MockText="
 
     SET "CleanBuild=False"
 
@@ -25,7 +28,6 @@
     SET "NumProcesses=1"
 
     SET "Rebuild=False"
-
 
     SET "CMakeConfigFlags="
     
@@ -105,11 +107,11 @@
 
     :buildSuccessful
       call:showBuildSuccessful
-    exit /B 0
+    exit /B %EXIT_SUCCESS%
 
     :buildFailed
       call:showBuildFailed
-    exit /B 1
+    exit /B %EXIT_FAIL%
 
     :doPrintConfiguration
       ECHO.

--- a/tools/building/build_project.bat
+++ b/tools/building/build_project.bat
@@ -224,6 +224,10 @@ function cleanAbsPath()
     echo "$cleanAbsPathStr"
 }
 
+
+EXIT_FAIL=1
+EXIT_SUCCESS=0
+
 ScriptPath="$(cleanAbsPath "$(dirname "$0")")"
 BaseFolder="$(cleanAbsPath "$ScriptPath/../..")"
 SourceFolder=""
@@ -378,7 +382,7 @@ doShowLogo
 
 if [ "${PrintHelp}" == "true" ]; then
   doPrintHelp
-  exit 0
+  exit ${EXIT_SUCCESS}
 fi
 
 if [ "${MockBuild}" == "true" ]; then
@@ -399,7 +403,7 @@ if [ "${CleanBuild}" == "true" ]; then
   echo " "
   ${MockText}rm -fr ${BuildFolder}
   ${MockText}rm -fr ${OutFolder}
-  exit 0
+  exit ${EXIT_SUCCESS}
 fi
 
 if [ "${Rebuild}" == "false" ]; then
@@ -427,11 +431,11 @@ echo " "
 
 if [ "${BuildSuccessful}" == "true" ]; then
   doShowLogoFlames
-  exit 0
+  exit ${EXIT_SUCCESS}
 else
   doShowBuildFailed
-  exit 1
+  exit ${EXIT_FAIL}
 fi
 
-exit 0
+exit ${EXIT_FAIL}
 

--- a/tools/building/build_project.bat
+++ b/tools/building/build_project.bat
@@ -198,7 +198,7 @@
       ECHO.
       ECHO   Here we go...                                       
       ECHO.
-    exit /B 0
+    exit /B 1
 
     :; # ########## WINDOWS SECTION ENDS ####################
     :; # ####################################################
@@ -425,8 +425,10 @@ echo " "
 
 if [ "${BuildSuccessful}" == "true" ]; then
   doShowLogoFlames
+  exit 0
 else
   doShowBuildFailed
+  exit 1
 fi
 
 exit 0


### PR DESCRIPTION
Fix build flag passed with --D. Should be -D.
Have build script return exit with error if build fails.

Currently our script returns success (0), regardless of the success of the build. This leads to the unfortunate circumstance of ant GH Action step running this script to pass, regardless of whether the build itself was successful. Typically this did not make itself apparent, since there are subsequent steps that would fail in the absence of a build. PR #935 had failing static builds on mac and linux, but since there are no subsequent steps, the build passed. PR #936 addresses the static flag issue.