### PR TITLE
[FIX] Fix packing linux builds

### DIFF
--- a/tools/deploy.bat
+++ b/tools/deploy.bat
@@ -423,7 +423,7 @@ for (( j=0; j<argc; j++ )); do
     elif [ "${argv[j]}" == "static" ]; then
         LinkOption="static"
     elif [ "${argv[j]}" == "pack" ]; then
-        PackOption="pack"
+        PackOption="true"
     elif [ "${argv[j]}" == "help" ]; then
         PrintHelp="true"
     elif [ "${argv[j]}" == "mock" ]; then


### PR DESCRIPTION
Currently our deploy script sets `PackOption` to `pack` instead of `true` in the Linux section of the script. When this is later checked in the script, it causes the packing code not to run, since we check for `"pack" == "true"`. This has resulted our Linux binaries not being generated whenever a release is triggered.

This PR makes a change to the linux section of the script, where command line arguments are parsed, fixing the setting of the pack variable to `true` in case the appropriate flag is passed. This makes the functionality mirror that of the macOS section, which is behaving correctly.