### PR TITLE
[FIX] Match dynamic pack output path

### DIFF
--- a/tools/deploy.bat
+++ b/tools/deploy.bat
@@ -498,7 +498,7 @@ if [[ ${LinkOption} == "dynamic" ]]; then
         ${MockText}rm -r mne-cpp/resources/data
 
         # Creating archive of everything in current directory
-        ${MockText}tar cfvz ../mne-cpp-linux-dynamic-x86_64.tar.gz mne-cpp   
+        ${MockText}tar cfvz ${BasePath}/mne-cpp-linux-dynamic-x86_64.tar.gz mne-cpp   
     fi
 
 elif [[ ${LinkOption} == "static" ]]; then


### PR DESCRIPTION
In the deploy script, set pack dynamic output path to match static pack output path. This is currently different, causing release action not finding the resulting dynamic zipped pack.