### PR TITLE
WIP [MAINT] enable/disable ipc/shmem when building

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,13 @@ if(WITH_CODE_COV)
   add_link_options("--coverage")
 endif()
 
+option(NO_IPC "Build project with no interprocess communication features (shared memory)" OFF)
+
+if(NO_IPC)
+    add_compile_definitions(NO_IPC)
+endif()
+
+
 ##==============================================================================
 ## FFTW Options
 

--- a/src/libraries/events/eventmanager.cpp
+++ b/src/libraries/events/eventmanager.cpp
@@ -61,13 +61,14 @@ static std::string defaultGroupName("Default"); /**< A name to be used as the na
 //=============================================================================================================
 
 EventManager::EventManager()
-: m_pSharedMemManager(std::make_unique<EVENTSINTERNAL::EventSharedMemManager>(this))
-, m_iEventIdCounter(invalidID)
+: m_iEventIdCounter(invalidID)
 , m_iGroupIdCounter(invalidID)
 , m_bDefaultGroupNotCreated(true)
 , m_DefaultGroupId(invalidID)
 {
-
+#ifndef NO_IPC
+    m_pSharedMemManager = std::make_unique<EVENTSINTERNAL::EventSharedMemManager>(this);
+#endif
 }
 
 //=============================================================================================================
@@ -578,28 +579,37 @@ bool EventManager::addEventsToGroup(const std::vector<idNum>& eventIds, const id
 
 void EventManager::initSharedMemory()
 {
+#ifndef NO_IPC
     initSharedMemory(SharedMemoryMode::READ);
+#endif
 }
 
 //=============================================================================================================
 
 void EventManager::initSharedMemory(SharedMemoryMode mode)
 {
+#ifndef NO_IPC
     m_pSharedMemManager->init(mode);
+#endif
 }
 
 //=============================================================================================================
 
 void EventManager::stopSharedMemory()
 {
+#ifndef NO_IPC
     m_pSharedMemManager->stop();
+#endif
 }
 
 //=============================================================================================================
 
 bool EventManager::isSharedMemoryInit()
 {
+    #ifndef NO_IPC
     return m_pSharedMemManager->isInit();
+    #endif
+    return 0;
 }
 
 void EventManager::createDefaultGroupIfNeeded()

--- a/src/libraries/events/eventmanager.cpp
+++ b/src/libraries/events/eventmanager.cpp
@@ -606,9 +606,9 @@ void EventManager::stopSharedMemory()
 
 bool EventManager::isSharedMemoryInit()
 {
-    #ifndef NO_IPC
+#ifndef NO_IPC
     return m_pSharedMemManager->isInit();
-    #endif
+#endif
     return 0;
 }
 

--- a/src/libraries/events/eventmanager.h
+++ b/src/libraries/events/eventmanager.h
@@ -43,8 +43,10 @@
 #include "events_global.h"
 #include "event.h"
 #include "eventgroup.h"
-#include "eventsharedmemmanager.h"
 
+#ifndef NO_IPC
+#include "eventsharedmemmanager.h"
+#endif
 //=============================================================================================================
 // STD INCLUDES
 //=============================================================================================================
@@ -418,14 +420,16 @@ private:
     std::unordered_map<idNum, int>                  m_MapIdToSample;                /**< EventId to sample relationship table.*/
     std::map<idNum, EVENTSINTERNAL::EventGroupINT>  m_GroupsList;                   /**< Storage of eventgroups.*/
 
+#ifndef NO_IPC
     std::unique_ptr<EVENTSINTERNAL::EventSharedMemManager>  m_pSharedMemManager;    /**< Pointer to a shared manager object.*/
+    friend class EVENTSINTERNAL::EventSharedMemManager;
+#endif
 
     idNum   m_iEventIdCounter;          /**< This counter will serve as an eventId until this get error-prone. However it can be easily updated.*/
     idNum   m_iGroupIdCounter;          /**< This counter will serve as a groupId counter, and id generator.*/
     bool    m_bDefaultGroupNotCreated;  /**< State variable to know if the default group has been created, and thus decide to create it again or not. */
     idNum   m_DefaultGroupId;           /**< The id of the default group.*/
 
-    friend class EVENTSINTERNAL::EventSharedMemManager;
 };
 
 //=============================================================================================================


### PR DESCRIPTION
- Add CMake flag to build without ipc / shared memory features. (sets a macro)
- Quarantine shared memory usage in events lib.

To do:
 - [ ] Check for other uses of shared memory (mostly those related to the CMake WASM PR #938)