### PR TITLE
[MAINT] Fix some issues found by coverity scan

### DIFF
--- a/src/applications/mne_analyze/libs/anShared/Model/eventmodel.cpp
+++ b/src/applications/mne_analyze/libs/anShared/Model/eventmodel.cpp
@@ -450,7 +450,7 @@ bool EventModel::saveToFile(const QString& sPath)
 
     QTextStream out(bufferOut, QIODevice::ReadWrite);
     auto events = m_EventManager.getEventsInGroups(m_selectedEventGroups);
-    for (auto event : *events){
+    for (const auto& event : *events){
         out << "  " << event.sample << "   " << QString::number(static_cast<float>(event.sample - m_pFiffModel->absoluteFirstSample()) / this->getFreq(), 'f', 4) << "          0         1" << endl;
     }
 
@@ -471,7 +471,7 @@ bool EventModel::saveToFile(const QString& sPath)
 
     QTextStream out(&file);
     auto events = m_EventManager.getEventsInGroups(m_selectedEventGroups);
-    for (auto event : *events){
+    for (const auto& event : *events){
         out << "  " << event.sample << "   " << QString::number(static_cast<float>(event.sample - m_pFiffModel->absoluteFirstSample()) / this->getFreq(), 'f', 4) << "          0         1" << "\n";
 //        out << "  " << iEvent << "   " << QString::number(static_cast<float>(iEvent - m_pFiffModel->absoluteFirstSample()) / this->getFreq(), 'f', 4) << "          1         0" << endl;
     }
@@ -711,7 +711,7 @@ void EventModel::updateSelectedGroups(const QList<QModelIndex> &indexList)
 {
     clearGroupSelection();
 
-    for(auto row : indexList){
+    for(const auto& row : indexList){
         addToSelectedGroups(row.data(Qt::UserRole).toInt());
     }
 

--- a/src/applications/mne_analyze/plugins/events/eventview.cpp
+++ b/src/applications/mne_analyze/plugins/events/eventview.cpp
@@ -268,7 +268,7 @@ void EventView::removeEvent()
 
     std::set<int> set;
 
-    for (auto index : indexList){
+    for (const auto& index : indexList){
         set.insert(index.row());
     }
 

--- a/src/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
+++ b/src/applications/mne_analyze/plugins/rawdataviewer/fiffrawviewdelegate.cpp
@@ -322,7 +322,7 @@ void FiffRawViewDelegate::createEventsPath(const QModelIndex &index,
     auto events = t_pEventModel->getEventsToDisplay(iStart, iStart + data.size());
     if (!t_pEventModel->getShowSelected()){
         // Paint all events
-        for(auto event : *events){
+        for(const auto& event : *events){
             painter->setPen(QPen(t_pEventModel->getGroupColor(event.groupId), 1, Qt::SolidLine));
             int eventSample = event.sample;
             painter->drawLine(fInitX + static_cast<float>(eventSample - iStart) * dDx,
@@ -333,7 +333,7 @@ void FiffRawViewDelegate::createEventsPath(const QModelIndex &index,
     } else {
         // Paint selected events
         auto selection = t_pEventModel->getEventSelection();
-        for(auto item : selection){
+        for(const auto& item : selection){
             if (item < events->size()){
                 painter->setPen(QPen(t_pEventModel->getGroupColor(events->at(item).groupId), 1, Qt::SolidLine));
                 int eventSample = events->at(item).sample;

--- a/src/libraries/disp/viewers/helpers/rtfiffrawviewmodel.cpp
+++ b/src/libraries/disp/viewers/helpers/rtfiffrawviewmodel.cpp
@@ -1383,18 +1383,7 @@ double RtFiffRawViewModel::getMaxValueFromRawViewModel(int row) const
 
 void RtFiffRawViewModel::addEvent(int iSample)
 {
-    auto pGroups = m_EventManager.getAllGroups();
-    for(auto g : *pGroups){
-        qDebug() << "Group: " << g.name.c_str() << "- Id: " << g.id;
-    }
-
     m_EventManager.addEvent(iSample);
-
-    auto pEvents = m_EventManager.getAllEvents();
-
-    for(auto e : *pEvents){
-        qDebug() << "Event> Sample: " << e.sample << "- Id: " << e.id;
-    }
 }
 
 //=============================================================================================================

--- a/src/libraries/disp/viewers/scalingview.cpp
+++ b/src/libraries/disp/viewers/scalingview.cpp
@@ -185,7 +185,7 @@ ScalingView::~ScalingView()
 
     delete m_pUi;
 
-    for(auto control : m_qMapScaleControls)
+    for(auto& control : m_qMapScaleControls)
     {
         delete control;
     }

--- a/src/libraries/events/eventmanager.cpp
+++ b/src/libraries/events/eventmanager.cpp
@@ -349,7 +349,7 @@ bool EventManager::deleteEvents(const std::vector<idNum>& eventIds)
 bool EventManager::deleteEvents(std::unique_ptr<std::vector<Event> > eventIds)
 {
     bool status(eventIds->size());
-    for(auto e: *eventIds){
+    for(auto& e: *eventIds){
         status = status && deleteEvent(e.id);
     }
     return status;

--- a/src/libraries/events/eventsharedmemmanager.cpp
+++ b/src/libraries/events/eventsharedmemmanager.cpp
@@ -426,7 +426,7 @@ void EVENTSINTERNAL::EventSharedMemManager::processNewEvent(const EventUpdate& n
 void EVENTSINTERNAL::EventSharedMemManager::processDeleteEvent(const EventUpdate& ne)
 {
     auto eventsInSample = m_pEventManager->getEventsInSample(ne.getSample());
-    for(auto e: *eventsInSample)
+    for(auto& e: *eventsInSample)
     {
         if(e.groupId == m_GroupId)
         {

--- a/src/libraries/fiff/fiff_ch_info.cpp
+++ b/src/libraries/fiff/fiff_ch_info.cpp
@@ -59,6 +59,8 @@ FiffChInfo::FiffChInfo()
 , unit(0)
 , unit_mul(0)
 , ch_name(QString(""))
+, coil_trans()
+, eeg_loc()
 , coord_frame(FIFFV_COORD_UNKNOWN)
 {
     coil_trans.setIdentity();

--- a/src/libraries/utils/selectionio.cpp
+++ b/src/libraries/utils/selectionio.cpp
@@ -138,13 +138,13 @@ bool SelectionIO::readMNESelFile(const std::string& path, std::multimap<std::str
             std::stringstream stream{line};
             std::vector<std::string> firstSplit;
             for (std::string element; std::getline(stream, line, ':');){
-                firstSplit.push_back(std::move(element));
+                firstSplit.push_back(element);
             }
             std::string key = firstSplit.at(0);
 
             std::vector<std::string> secondSplit;
             for (std::string element; std::getline(stream, line, '|');){
-                secondSplit.push_back(std::move(element));
+                secondSplit.push_back(element);
             }
             if(secondSplit.back() == ""){
                 secondSplit.pop_back();

--- a/src/testframes/test_coregistration/test_coregistration.cpp
+++ b/src/testframes/test_coregistration/test_coregistration.cpp
@@ -173,7 +173,7 @@ void TestCoregistration::initTestCase()
     fiff_int_t iFrom = digSetSrc[0].coord_frame;
     fiff_int_t iTo = bemSurface.data()->coord_frame;
     transFitMatched = FiffCoordTrans::make(iFrom, iTo, matTrans);
-    transPerformICP = *new FiffCoordTrans(transFitMatched);
+    transPerformICP = FiffCoordTrans(transFitMatched);
 
     // Prepare Icp:
     VectorXf vecWeightsICP(digSetHsp.size()); // Weigths vector


### PR DESCRIPTION
 - iterate over references or const references when possible in range based or loops.
 - remove memory leak in test
 - remove potential UB uses of std::move.
 - explicitly call default constructor of previously uninitialized members in default FiffChInfo constructor.