### PR TITLE
[FIX] Segfault in forward computation

### DIFF
--- a/src/libraries/fwd/computeFwd/compute_fwd.cpp
+++ b/src/libraries/fwd/computeFwd/compute_fwd.cpp
@@ -1867,11 +1867,6 @@ void ComputeFwd::initFwd()
     m_listEegChs = QList<FiffChInfo>();
     m_listCompChs = QList<FiffChInfo>();
 
-    if(!m_pSettings->compute_grad) {
-        m_meg_forward_grad = Q_NULLPTR;
-        m_eeg_forward_grad = Q_NULLPTR;
-    }
-
     int iNMeg               = 0;
     int iNEeg               = 0;
     int iNComp              = 0;


### PR DESCRIPTION
Deleting the QSharedDataPointer causes a segfault when later dereferencing *m_eeg_forward_grad.data()/*m_meg_forward_grad.data() in the call of compute_forward_eeg/compute_forward_meg.

There might be a way to fix this while still deleting the (basically empty) object behind the shared pointer. However, as far as I can see we do not have a guarantee that the value of m_pSettings->compute_grad does not change, so if it would switch to true later on and for some reason calculatedFwd() gets called we would have a problem with the current code anyway.