### PR TITLE
[ENH] Flexible choice of cluster size

### DIFF
--- a/src/applications/mne_scan/plugins/rtfwd/rtfwd.cpp
+++ b/src/applications/mne_scan/plugins/rtfwd/rtfwd.cpp
@@ -105,6 +105,7 @@ RtFwd::RtFwd()
     m_pFwdSettings->include_eeg = true;
     m_pFwdSettings->accurate = true;
     m_pFwdSettings->mindist = 5.0f/1000.0f;
+    m_pFwdSettings->ncluster = 200;
 
     m_sAtlasDir = QCoreApplication::applicationDirPath() + "/../resources/data/MNE-sample-data/subjects/sample/label";
 }
@@ -345,6 +346,7 @@ void RtFwd::onDoForwardComputation()
 {
     m_mutex.lock();
     m_bDoFwdComputation = true;
+    // get value for number in cluster and set m_pFwdSettings->ncluster here
     m_mutex.unlock();
 }
 
@@ -513,7 +515,7 @@ void RtFwd::run()
 
         if(bDoClustering && bFwdReady) {
             emit statusInformationChanged(3);               // clustering
-            pClusteredFwd = MNEForwardSolution::SPtr(new MNEForwardSolution(pFwdSolution->cluster_forward_solution(*m_pAnnotationSet.data(), 200)));
+            pClusteredFwd = MNEForwardSolution::SPtr(new MNEForwardSolution(pFwdSolution->cluster_forward_solution(*m_pAnnotationSet.data(), m_pFwdSettings->ncluster)));
             emit clusteringAvailable(pClusteredFwd->nsource);
 
             m_pRTFSOutput->measurementData()->setValue(pClusteredFwd);

--- a/src/applications/mne_scan/plugins/rtfwd/rtfwd.cpp
+++ b/src/applications/mne_scan/plugins/rtfwd/rtfwd.cpp
@@ -321,6 +321,8 @@ void RtFwd::initPluginControlWidgets()
                 this, &RtFwd::onClusteringStatusChanged);
         connect(pFwdSettingsView, &FwdSettingsView::atlasDirChanged,
                 this, &RtFwd::onAtlasDirChanged);
+        connect(pFwdSettingsView, &FwdSettingsView::clusterNumberChanged,
+                this, &RtFwd::onClusterNumberChanged);
         connect(pFwdSettingsView, &FwdSettingsView::doForwardComputation,
                 this, &RtFwd::onDoForwardComputation);
 
@@ -387,6 +389,15 @@ void RtFwd::onAtlasDirChanged(const QString& sDirPath, const AnnotationSet::SPtr
     m_mutex.lock();
     m_sAtlasDir = sDirPath;
     m_pAnnotationSet = pAnnotationSet;
+    m_mutex.unlock();
+}
+
+//=============================================================================================================
+
+void RtFwd::onClusterNumberChanged(int iNClusterNumber)
+{
+    m_mutex.lock();
+    m_pFwdSettings->ncluster = iNClusterNumber;
     m_mutex.unlock();
 }
 

--- a/src/applications/mne_scan/plugins/rtfwd/rtfwd.h
+++ b/src/applications/mne_scan/plugins/rtfwd/rtfwd.h
@@ -216,6 +216,8 @@ private:
     bool                                        m_bBusy;                    /**< Indicates if we have to update headposition.**/
     bool                                        m_bDoRecomputation;         /**< If recomputation is activated.**/
     bool                                        m_bDoClustering;            /**< If clustering is activated.**/
+    bool                                        m_bNClusterChanged;         /**< Perform new clustering when cluster size changed**/
+
     bool                                        m_bDoFwdComputation;        /**< Do a forward computation. **/
 
     QString                                     m_sAtlasDir;                /**< File to Atlas. */

--- a/src/applications/mne_scan/plugins/rtfwd/rtfwd.h
+++ b/src/applications/mne_scan/plugins/rtfwd/rtfwd.h
@@ -192,6 +192,14 @@ private:
 
     //=========================================================================================================
     /**
+     * Call this function whenever the number of dipoles per cluster changed.
+     *
+     * @param[in] iNClusterNumber   Number of dipoles per cluster.
+     */
+    void onClusterNumberChanged(int iNClusterNumber);
+
+    //=========================================================================================================
+    /**
      * Call this function whenever the atlas directory is set.
      *
      * @param[in] sDirPath              The path to the atlas directory.

--- a/src/libraries/disp/viewers/formfiles/fwdsettingsview.ui
+++ b/src/libraries/disp/viewers/formfiles/fwdsettingsview.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>333</width>
+    <width>362</width>
     <height>939</height>
    </rect>
   </property>
@@ -226,7 +226,7 @@
         <item>
          <widget class="QLabel" name="label_5">
           <property name="text">
-           <string>Desired number of clustered Sources</string>
+           <string>Number of sources per cluster</string>
           </property>
          </widget>
         </item>
@@ -239,10 +239,10 @@
            </size>
           </property>
           <property name="minimum">
-           <number>20</number>
+           <number>5</number>
           </property>
           <property name="maximum">
-           <number>1000</number>
+           <number>999</number>
           </property>
          </widget>
         </item>

--- a/src/libraries/disp/viewers/formfiles/fwdsettingsview.ui
+++ b/src/libraries/disp/viewers/formfiles/fwdsettingsview.ui
@@ -222,6 +222,33 @@
        </widget>
       </item>
       <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Desired number of clustered Sources</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="m_spinBox_iNDipoleClustered">
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="minimum">
+           <number>20</number>
+          </property>
+          <property name="maximum">
+           <number>1000</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label">

--- a/src/libraries/disp/viewers/fwdsettingsview.cpp
+++ b/src/libraries/disp/viewers/fwdsettingsview.cpp
@@ -82,7 +82,7 @@ FwdSettingsView::FwdSettingsView(const QString& sSettingsPath,
 
     // init
     m_pUi->m_checkBox_bDoRecomputation->setChecked(false);
-    m_pUi->m_checkBox_bDoClustering->setChecked(false);
+    m_pUi->m_checkBox_bDoClustering->setChecked(true);
     m_pUi->m_lineEdit_iNChan->setText(QString::number(0));
     m_pUi->m_lineEdit_iNSourceSpace->setText(QString::number(0));
     m_pUi->m_lineEdit_iNDipole->setText(QString::number(0));
@@ -90,6 +90,7 @@ FwdSettingsView::FwdSettingsView(const QString& sSettingsPath,
     m_pUi->m_lineEdit_sCoordFrame->setText("Head Space");
     m_pUi->m_lineEdit_iNDipoleClustered->setText("Not Clustered");
     m_pUi->m_spinBox_iNDipoleClustered->setValue(200);
+    m_pUi->m_spinBox_iNDipoleClustered->setKeyboardTracking(false);
 
     // load init annotation set
     QString t_sAtlasDir = QCoreApplication::applicationDirPath() + "/../resources/data/MNE-sample-data/subjects/sample/label";
@@ -117,7 +118,7 @@ FwdSettingsView::FwdSettingsView(const QString& sSettingsPath,
             this, &FwdSettingsView::onClusteringStatusChanged);
     connect(m_pUi->m_qPushButton_ComputeForward, &QPushButton::clicked,
             this, &FwdSettingsView::doForwardComputation);
-    connect(m_pUi->m_spinBox_iNDipoleClustered, &QSpinBox::valueChanged,
+    connect(m_pUi->m_spinBox_iNDipoleClustered, QOverload<int>::of(&QSpinBox::valueChanged),
             this, &FwdSettingsView::clusterNumberChanged);
 
     // load settings
@@ -207,6 +208,9 @@ void FwdSettingsView::setRecomputationStatus(int iStatus)
     } else if (iStatus == 4) {
         m_pUi->m_label_recomputationFeedback->setText("Not Computed");
         m_pUi->m_label_recomputationFeedback->setStyleSheet("QLabel { background-color : red;}");
+    } else if (iStatus == 5) {
+        m_pUi->m_label_recomputationFeedback->setText("Not Clustered");
+        m_pUi->m_label_recomputationFeedback->setStyleSheet("QLabel { background-color : yellow;}");
     } else {
         m_pUi->m_label_recomputationFeedback->setText("Finished");
         m_pUi->m_label_recomputationFeedback->setStyleSheet("QLabel { background-color : green;}");

--- a/src/libraries/disp/viewers/fwdsettingsview.cpp
+++ b/src/libraries/disp/viewers/fwdsettingsview.cpp
@@ -37,6 +37,7 @@
 //=============================================================================================================
 
 #include "fwdsettingsview.h"
+#include "QtWidgets/qspinbox.h"
 #include "ui_fwdsettingsview.h"
 
 #include <fs/annotationset.h>
@@ -115,6 +116,8 @@ FwdSettingsView::FwdSettingsView(const QString& sSettingsPath,
             this, &FwdSettingsView::onClusteringStatusChanged);
     connect(m_pUi->m_qPushButton_ComputeForward, &QPushButton::clicked,
             this, &FwdSettingsView::doForwardComputation);
+    connect(m_pUi->m_spinBox_iNDipoleClustered, &QSpinBox::valueChanged,
+            this, &FwdSettingsView::clusterNumberChanged);
 
     // load settings
     loadSettings();

--- a/src/libraries/disp/viewers/fwdsettingsview.cpp
+++ b/src/libraries/disp/viewers/fwdsettingsview.cpp
@@ -89,6 +89,7 @@ FwdSettingsView::FwdSettingsView(const QString& sSettingsPath,
     m_pUi->m_lineEdit_sSourceOri->setText("fixed");
     m_pUi->m_lineEdit_sCoordFrame->setText("Head Space");
     m_pUi->m_lineEdit_iNDipoleClustered->setText("Not Clustered");
+    m_pUi->m_spinBox_iNDipoleClustered->setValue(200);
 
     // load init annotation set
     QString t_sAtlasDir = QCoreApplication::applicationDirPath() + "/../resources/data/MNE-sample-data/subjects/sample/label";
@@ -254,6 +255,13 @@ void FwdSettingsView::setSolutionInformation(FIFFLIB::fiff_int_t iSourceOri,
 bool FwdSettingsView::getClusteringStatusChanged()
 {
     return m_pUi->m_checkBox_bDoClustering->isChecked();
+}
+
+//=============================================================================================================
+
+int FwdSettingsView::getClusterNumber()
+{
+    return m_pUi->m_spinBox_iNDipoleClustered->value();
 }
 
 //=============================================================================================================

--- a/src/libraries/disp/viewers/fwdsettingsview.h
+++ b/src/libraries/disp/viewers/fwdsettingsview.h
@@ -122,6 +122,14 @@ public:
 
     //=========================================================================================================
     /**
+     * Get status of cluster size spin box.
+     *
+     * @return  Desired number of sources in clustered source space.
+     */
+    int getClusterNumber();
+
+    //=========================================================================================================
+    /**
      * Shows atlas selection dialog
      */
     void showAtlasDirDialog();
@@ -234,6 +242,14 @@ signals:
      * Emit this signal whenever a forward computation is supposed to be triggered.
      */
     void doForwardComputation();
+
+    //=========================================================================================================
+    /**
+     * Emit this signal whenever a forward computation is supposed to be triggered.
+     *
+     * @param[in] iNCluster    Number of desired sources in the clustered source space.
+     */
+    void clusterNumberChanged(int iNCluster);
 
 };
 

--- a/src/libraries/fwd/computeFwd/compute_fwd.cpp
+++ b/src/libraries/fwd/computeFwd/compute_fwd.cpp
@@ -1867,11 +1867,6 @@ void ComputeFwd::initFwd()
     m_listEegChs = QList<FiffChInfo>();
     m_listCompChs = QList<FiffChInfo>();
 
-    if(!m_pSettings->compute_grad) {
-        m_meg_forward_grad = Q_NULLPTR;
-        m_eeg_forward_grad = Q_NULLPTR;
-    }
-
     int iNMeg               = 0;
     int iNEeg               = 0;
     int iNComp              = 0;

--- a/src/libraries/fwd/computeFwd/compute_fwd_settings.h
+++ b/src/libraries/fwd/computeFwd/compute_fwd_settings.h
@@ -131,6 +131,7 @@ public:
     bool do_all;
     QStringList labels;         /**< Compute the solution only for these labels. */
     int nlabel;
+    int ncluster;               /**< Number of sources desired in clustered solution. */
 
     QString eeg_model_file;     /**< File of EEG sphere model specifications. */
     QString eeg_model_name;     /**< Name of the EEG model to use. */


### PR DESCRIPTION
Added functionality to allow for a flexible choice of the cluster size of the clustered forward solution. Before the cluster size was hard-coded.

Furthermore fixed a small bug which would lead to crashes due to a segfault:

Deleting the QSharedDataPointer in compute_fwd.cpp causes a segfault when later dereferencing *m_eeg_forward_grad.data()/*m_meg_forward_grad.data() in the call of compute_forward_eeg/compute_forward_meg.

There might be a way to fix this while still deleting the (basically empty) object behind the shared pointer. However, as far as I can see we do not have a guarantee that the value of m_pSettings->compute_grad does not change, so if it would switch to true later on and for some reason calculatedFwd() gets called we would have a problem with the current code anyway.