### PR TITLE
Bug fix for array comparison

### DIFF
--- a/src/libraries/fiff/fiff_id.h
+++ b/src/libraries/fiff/fiff_id.h
@@ -189,7 +189,8 @@ inline qint32 FiffId::storageSize()
 inline bool operator== (const FiffId &a, const FiffId &b)
 {
     return (a.version == b.version &&
-            a.machid == b.machid &&
+            a.machid[0] == b.machid[0] &&
+            a.machid[1] == b.machid[1] &&
             a.time.secs == b.time.secs &&
             a.time.usecs == b.time.usecs);
 }


### PR DESCRIPTION
error: comparison between two arrays is deprecated in C++20 [-Werror=array-compare]