### PR TITLE
Remove codeql for staging

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "staging" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "staging" ]
+    branches: [ "main" ]
   schedule:
     - cron: '28 15 * * 1'
 
@@ -67,7 +67,7 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 


### PR DESCRIPTION
Looking at https://github.com/mne-tools/mne-cpp/actions/workflows/codeql.yml I see 9 runners in the last 2h that will each be tied up for about an hour

<img width="1198" height="713" alt="Screenshot 2026-05-01 at 10 21 02 AM" src="https://github.com/user-attachments/assets/ba60bd9b-36a9-48a6-9245-dde2395b9cfe" />

This PR aims to reduce this usage by just running CodeQL on `main`. I am not sure what the dev workflow is here exactly, but assuming you merge stuff from `staging` to `main` occassionally then this would help with the concurrency issues.

Feel free to close and fix a different way, but it would be good to get something like this in ASAP so that other repo workflows can continue!