### PR TITLE
init.sh fails due to incorrect index

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -368,17 +368,18 @@ if [[ ${DEPS_ONLY} -eq 1 ]]; then
     exit 0
 fi
 
+CMAKE_PREFIX_VALUE="${QT_DIR}"
+if [[ -f "${EIGEN_CONFIG_PATH}" ]]; then
+    CMAKE_PREFIX_VALUE="${QT_DIR};${EIGEN_DIR}"
+fi
+
 cmake_args=(
     -B "${BUILD_DIR}"
     -S "${REPO_ROOT}"
     -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
     -DNO_OPENGL="${NO_OPENGL_VALUE}"
-    "-DCMAKE_PREFIX_PATH=${QT_DIR}"
+    "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_VALUE}"
 )
-
-if [[ -f "${EIGEN_CONFIG_PATH}" ]]; then
-    cmake_args[4]="-DCMAKE_PREFIX_PATH=${QT_DIR};${EIGEN_DIR}"
-fi
 
 if [[ "${LINKAGE}" == "static" ]]; then
     cmake_args+=(-DBUILD_SHARED_LIBS=OFF)

--- a/src/libraries/decoding/decoding_csp.cpp
+++ b/src/libraries/decoding/decoding_csp.cpp
@@ -172,7 +172,7 @@ void DecodingCsp::fit(const std::vector<MatrixXd>& epochs,
     }
 
     // Patterns = pinv(filters) — shape (n_ch × n_comp)
-    auto svd = m_filters.bdcSvd(ComputeThinU | ComputeThinV);
+    auto svd = m_filters.bdcSvd<ComputeThinU | ComputeThinV>();
     m_patterns = svd.solve(MatrixXd::Identity(n_total, n_total));
 
     // Compute mean band power for z-score normalisation


### PR DESCRIPTION
init.sh fails to run properly due to cmake_args index being incorrect. The CMAKE_PREFIX_PATH is actually index 6. Fixing it to not require an index at all.