### PR TITLE
feat(polhemus): add resetRegistration() to PolhemusCoregistration

### DIFF
--- a/src/libraries/utils/polhemus/polhemus_coregistration.cpp
+++ b/src/libraries/utils/polhemus/polhemus_coregistration.cpp
@@ -125,6 +125,16 @@ bool PolhemusCoregistration::captureCurrentPenPositionAsHeadShape()
 
 //=============================================================================================================
 
+void PolhemusCoregistration::resetRegistration()
+{
+    m_registrationValid = false;
+    m_headToWorld.setToIdentity();
+    m_headToDevice.setToIdentity();
+    emit registrationChanged();
+}
+
+//=============================================================================================================
+
 bool PolhemusCoregistration::computeRegistration()
 {
     if (!m_pPoints->hasAllFiducials()) {

--- a/src/libraries/utils/polhemus/polhemus_coregistration.h
+++ b/src/libraries/utils/polhemus/polhemus_coregistration.h
@@ -164,6 +164,12 @@ public:
      */
     bool computeRegistration();
 
+    /**
+     * @brief Reset the registration state (headToWorld, headToDevice) to identity.
+     *        Call this when the user clears all fiducials.
+     */
+    void resetRegistration();
+
     bool registrationValid() const { return m_registrationValid; }
 
     //=========================================================================================================


### PR DESCRIPTION
Clears headToWorld, headToDevice and sets registrationValid=false, then emits registrationChanged. Called when the user clears all acquired points so no stale transform remains active.